### PR TITLE
Fix backup list rendering and download behavior

### DIFF
--- a/app/routes/backups.py
+++ b/app/routes/backups.py
@@ -28,13 +28,14 @@ class RestoreRequest(BaseModel):
 
 @router.get("")
 def list_backups(db: Session = Depends(get_db)):
-    """List all backups from DB records + filesystem."""
+    """List only backups whose files still exist on disk."""
     db_backups = db.query(Backup).order_by(Backup.created_at.desc()).all()
     return [
         {"id": b.id, "filename": b.filename, "file_size": b.file_size,
          "backup_type": b.backup_type, "notes": b.notes,
          "created_at": b.created_at.isoformat() if b.created_at else None}
         for b in db_backups
+        if (BACKUP_DIR / b.filename).exists()
     ]
 
 

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -8,6 +8,7 @@
 const SettingsPage = {
     async render() {
         const s = await API.get('/settings');
+        setTimeout(() => SettingsPage.loadBackups(), 0);
         return `
             <div class="page-header">
                 <h2>Company Settings</h2>
@@ -191,7 +192,7 @@ const SettingsPage = {
                     <td>${(b.file_size / 1024).toFixed(1)} KB</td>
                     <td>${formatDate(b.created_at)}</td>
                     <td class="actions">
-                        <a href="/api/backups/${b.id}/download" class="btn btn-sm btn-secondary" download>Download</a>
+                        <a href="/api/backups/download/${encodeURIComponent(b.filename)}" class="btn btn-sm btn-secondary" download>Download</a>
                     </td>
                 </tr>`).join('')}</tbody>
             </table></div>`;

--- a/app/static/js/utils.js
+++ b/app/static/js/utils.js
@@ -15,7 +15,10 @@ function formatCurrency(amount) {
 
 function formatDate(dateStr) {
     if (!dateStr) return '';
-    const d = new Date(dateStr + 'T00:00:00');
+    const d = dateStr.includes('T')
+        ? new Date(dateStr)
+        : new Date(dateStr + 'T00:00:00');
+    if (Number.isNaN(d.getTime())) return 'Invalid date';
     return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 }
 


### PR DESCRIPTION
Hi, I found a few issues with the backup functionality while running on Windows.

Backups listed in Settings would not appear until another backup was created, at which point the existing backups would suddenly show up. The created dates were also rendering incorrectly, and the download links pointed to the wrong endpoint.

This PR fixes the backup UI in Settings so existing backups display immediately, backup dates render correctly instead of showing “Invalid Date,” and downloads use the correct backup file path instead of returning a download.json error.