### PR TITLE
Jinja2 template config can lead to XSS attacks

### DIFF
--- a/app/routes/public.py
+++ b/app/routes/public.py
@@ -17,8 +17,7 @@ from app.routes.settings import _get_all as get_settings
 router = APIRouter(tags=["public"])
 
 TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
-_jinja_env = Environment(loader=FileSystemLoader(str(TEMPLATE_DIR)))
-
+_jinja_env = Environment(autoescape=True, loader=FileSystemLoader(str(TEMPLATE_DIR)))
 
 @router.get("/pay/{token}")
 def public_payment_page(token: str, status: str = None, db: Session = Depends(get_db)):

--- a/app/services/pdf_service.py
+++ b/app/services/pdf_service.py
@@ -13,8 +13,7 @@ from jinja2 import Environment, FileSystemLoader
 from weasyprint import HTML
 
 TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
-_jinja_env = Environment(loader=FileSystemLoader(str(TEMPLATE_DIR)))
-
+_jinja_env = Environment(autoescape=True, loader=FileSystemLoader(str(TEMPLATE_DIR)))
 
 def _format_currency(value):
     try:


### PR DESCRIPTION
These patches mitigate 2 cross-site scripting vulnerabilities in the Python scripts by enabling the autoescape feature in the Jinja2 template engine, which previously allowed unescaped HTML content to be rendered