### PR TITLE
Fork sync: LayoverLogic security & correctness fixes

### DIFF
--- a/app/schemas/accounts.py
+++ b/app/schemas/accounts.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from app.models.accounts import AccountType
 
@@ -14,6 +14,12 @@ class AccountCreate(BaseModel):
     parent_id: Optional[int] = None
     description: Optional[str] = None
 
+    @field_validator("account_number")
+    @classmethod
+    def blank_account_number_to_none(cls, v):
+        # account_number is unique; storing "" would collide across accounts
+        return v.strip() or None if isinstance(v, str) else v
+
 
 class AccountUpdate(BaseModel):
     name: Optional[str] = None
@@ -22,6 +28,11 @@ class AccountUpdate(BaseModel):
     parent_id: Optional[int] = None
     description: Optional[str] = None
     is_active: Optional[bool] = None
+
+    @field_validator("account_number")
+    @classmethod
+    def blank_account_number_to_none(cls, v):
+        return v.strip() or None if isinstance(v, str) else v
 
 
 class AccountResponse(BaseModel):
@@ -35,6 +46,12 @@ class AccountResponse(BaseModel):
     is_system: bool
     balance: Decimal
     created_at: datetime
+
+    @field_validator("balance", mode="before")
+    @classmethod
+    def null_balance_to_zero(cls, v):
+        # legacy/imported rows can carry NULL balances; don't 500 on read
+        return Decimal("0") if v is None else v
     updated_at: datetime
 
     model_config = {"from_attributes": True}

--- a/app/schemas/accounts.py
+++ b/app/schemas/accounts.py
@@ -52,6 +52,7 @@ class AccountResponse(BaseModel):
     def null_balance_to_zero(cls, v):
         # legacy/imported rows can carry NULL balances; don't 500 on read
         return Decimal("0") if v is None else v
+
     updated_at: datetime
 
     model_config = {"from_attributes": True}

--- a/app/services/company_service.py
+++ b/app/services/company_service.py
@@ -25,7 +25,7 @@ import re
 import sys
 from pathlib import Path
 
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
 from app.config import DATABASE_URL
@@ -332,11 +332,14 @@ def create_company(
             base_url + "postgres", isolation_level="AUTOCOMMIT"
         )
         with system_engine.connect() as conn:
-            # database_name is validated above against strict alphanumeric pattern
-            conn.execute(text(f'CREATE DATABASE "{database_name}"'))
+            # database_name is validated above against strict alphanumeric pattern;
+            # dialect-level quoting is defence-in-depth for the DDL statement,
+            # which cannot use bound parameters.
+            quoted_db_name = conn.dialect.identifier_preparer.quote(database_name)
+            conn.exec_driver_sql(f"CREATE DATABASE {quoted_db_name}")
         system_engine.dispose()
 
-        # Run Alembic migrations on new database
+        # Create schema on the new database
         new_engine = create_engine(base_url + database_name)
         from app.database import Base
 

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -77,12 +77,19 @@ const App = {
             $('#page-content').innerHTML = html;
             App.setStatus(`${route.label} — Ready`);
         } catch (err) {
+            // Server-side detail (err.message and stack) goes to console
+            // for devs; the DOM gets a clean user-facing error with a
+            // recovery action. Avoid leaking framework / decompilation
+            // internals into the rendered page (S1 audit finding).
             console.error(err);
             $('#page-content').innerHTML = `<div class="empty-state">
-                <p><strong>Error 0x8004:</strong> ${escapeHtml(err.message)}</p>
-                <p style="font-size:10px; color:var(--text-muted);">CQBView::OnActivate() failed at offset 0x00042A10</p>
+                <h3>Couldn't load this page</h3>
+                <p>${escapeHtml(err.message || 'An unexpected error occurred.')}</p>
+                <p style="margin-top:12px;">
+                    <a href="#/" class="btn btn-secondary">Return to Dashboard</a>
+                </p>
             </div>`;
-            App.setStatus('Error — see console for details');
+            App.setStatus('Error loading page');
         }
     },
 

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -17,9 +17,6 @@ const SettingsPage = {
         return `
             <div class="page-header">
                 <h2>Company Settings</h2>
-                <div style="font-size:10px; color:var(--text-muted);">
-                    CPreferencesDialog — IDD_PREFERENCES @ 0x0023F800
-                </div>
             </div>
             <form id="settings-form" onsubmit="SettingsPage.save(event)">
                 <div class="settings-section">

--- a/tests/test_account_schema_hardening.py
+++ b/tests/test_account_schema_hardening.py
@@ -1,0 +1,64 @@
+"""Account schema hardening: NULL balances and blank account numbers.
+
+- accounts.balance is nullable in practice (legacy/imported rows); the
+  response schema must coalesce NULL to 0 instead of 500ing on read.
+- accounts.account_number is unique; a blank string must normalize to
+  NULL or the second no-number account collides with the first.
+"""
+
+from sqlalchemy import text
+
+from app.models.accounts import Account, AccountType
+
+
+def test_null_balance_account_reads_as_zero(client, db_session):
+    account = Account(name="Legacy NULL balance", account_type=AccountType.EXPENSE)
+    db_session.add(account)
+    db_session.commit()
+    db_session.execute(
+        text("UPDATE accounts SET balance = NULL WHERE id = :id"),
+        {"id": account.id},
+    )
+    db_session.commit()
+
+    resp = client.get(f"/api/accounts/{account.id}")
+    assert resp.status_code == 200
+    assert resp.json()["balance"] == "0"
+
+
+def test_blank_account_number_normalizes_to_null(client):
+    first = client.post(
+        "/api/accounts",
+        json={"name": "No number one", "account_type": "expense", "account_number": ""},
+    )
+    assert first.status_code == 201
+    assert first.json()["account_number"] is None
+
+    # A second blank-numbered account must not hit the unique constraint
+    second = client.post(
+        "/api/accounts",
+        json={
+            "name": "No number two",
+            "account_type": "expense",
+            "account_number": "   ",
+        },
+    )
+    assert second.status_code == 201
+    assert second.json()["account_number"] is None
+
+
+def test_blank_account_number_on_update_normalizes_to_null(client):
+    created = client.post(
+        "/api/accounts",
+        json={
+            "name": "Numbered",
+            "account_type": "expense",
+            "account_number": "9998",
+        },
+    )
+    assert created.status_code == 201
+    account_id = created.json()["id"]
+
+    updated = client.put(f"/api/accounts/{account_id}", json={"account_number": ""})
+    assert updated.status_code == 200
+    assert updated.json()["account_number"] is None

--- a/tests/test_company_service_dbname.py
+++ b/tests/test_company_service_dbname.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock, patch
 
 from app.services.company_service import _VALID_DB_NAME, create_company
 
-
 HOSTILE_NAMES = [
     'evil"; DROP DATABASE postgres; --',
     "evil'; DROP DATABASE postgres; --",

--- a/tests/test_company_service_dbname.py
+++ b/tests/test_company_service_dbname.py
@@ -1,0 +1,60 @@
+"""Company database creation: name validation and DDL quoting.
+
+The CREATE DATABASE statement cannot use bound parameters, so the service
+relies on two layers: a strict allowlist regex (primary defence) and
+dialect-level identifier quoting (defence-in-depth). These tests lock both.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.services.company_service import _VALID_DB_NAME, create_company
+
+
+HOSTILE_NAMES = [
+    'evil"; DROP DATABASE postgres; --',
+    "evil'; DROP DATABASE postgres; --",
+    "evil name",
+    "evil;name",
+    "1starts_with_digit",
+    "",
+    "a" * 64,  # one over the 63-char limit
+]
+
+
+def test_valid_db_name_rejects_hostile_input():
+    for name in HOSTILE_NAMES:
+        assert not _VALID_DB_NAME.match(name), name
+
+
+def test_valid_db_name_accepts_normal_names():
+    for name in ["acme", "acme_books", "Acme-2026", "a"]:
+        assert _VALID_DB_NAME.match(name), name
+
+
+def test_create_company_rejects_invalid_name_before_any_sql():
+    db = MagicMock()
+    with patch("app.services.company_service._is_sqlite", return_value=False), patch(
+        "app.services.company_service.create_engine"
+    ) as engine_factory:
+        result = create_company(db, "Evil", 'evil"; DROP DATABASE postgres; --')
+    assert result["success"] is False
+    engine_factory.assert_not_called()
+
+
+def test_create_company_quotes_db_name_via_dialect():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+
+    conn = MagicMock()
+    conn.dialect.identifier_preparer.quote.return_value = '"acme_books"'
+    engine = MagicMock()
+    engine.connect.return_value.__enter__.return_value = conn
+
+    with patch("app.services.company_service._is_sqlite", return_value=False), patch(
+        "app.services.company_service.create_engine", return_value=engine
+    ), patch("app.services.company_service._base_url", return_value="postgresql://x/"):
+        result = create_company(db, "Acme", "acme_books")
+
+    assert result["success"] is True
+    conn.dialect.identifier_preparer.quote.assert_called_once_with("acme_books")
+    conn.exec_driver_sql.assert_called_once_with('CREATE DATABASE "acme_books"')

--- a/tests/test_no_decomp_strings_in_dom.py
+++ b/tests/test_no_decomp_strings_in_dom.py
@@ -1,0 +1,120 @@
+"""S1 audit follow-up: pin that decompilation-heritage debug strings
+stay confined to comments and never reach the rendered DOM.
+
+The codebase deliberately carries QuickBooks-2003 decompilation flair in
+file-header /** ... */ blocks and inline // comments — that's a feature,
+not a bug. What's NOT okay is the same strings appearing inside template
+literals or other executable code, because they then ship to the browser
+and give an attacker a free fingerprinting surface (and look unprofessional
+to legitimate users).
+
+The May-2026 audit caught two such leaks:
+- app/static/js/settings.js — page-header subtitle exposing
+  "CPreferencesDialog — IDD_PREFERENCES @ 0x0023F800"
+- app/static/js/app.js — canned error block exposing
+  "Error 0x8004: ..." + "CQBView::OnActivate() failed at offset 0x00042A10"
+
+This test scans every JS file under app/static/js/, strips comments,
+and fails if any of the well-known decomp patterns survive. Future
+flair belongs in comments — keep this test green and the audit gap
+stays closed.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+# Patterns that look like decomp-heritage debug info. Tuned to be
+# specific enough that legitimate code (CSS hex colors, etc.) doesn't
+# false-positive — we don't match # colors, we don't match short
+# 0xNN constants, we don't match arbitrary capitalised words.
+_DECOMP_PATTERNS = [
+    # Hex memory offsets / Win32 constants: 0x followed by 4+ hex digits.
+    # 4+ filters out short hex literals like 0xFF or 0x100; real
+    # decomp offsets are always at least 4 nibbles.
+    (re.compile(r"\b0x[0-9A-Fa-f]{4,}\b"), "hex memory offset / Win32 constant"),
+    # MFC / decomp class names — CQB followed by capitalised name.
+    (re.compile(r"\bCQB[A-Z]\w*"), "decompiled MFC/QB class name"),
+    # Win32 dialog / control resource IDs.
+    (re.compile(r"\bID[DC]_[A-Z][A-Z0-9_]*"), "Win32 resource ID"),
+    # Specific decomp markers explicitly called out by the S1 audit.
+    (re.compile(r"\bCPreferences\w*"), "decompiled preferences class"),
+    (re.compile(r"\bqbw32\b", re.IGNORECASE), "QuickBooks binary name"),
+]
+
+
+_JS_DIR = Path(__file__).resolve().parent.parent / "app" / "static" / "js"
+
+
+def _strip_comments(src: str) -> str:
+    """Remove /* ... */ block comments AND // line comments.
+
+    Naive but adequate: the codebase doesn't have // sequences inside
+    string literals (URLs use `'/'` or backticks without `//`), and no
+    template literal contains `*/`. If those assumptions ever break,
+    upgrade this to a real tokenizer. Until then the simple regex
+    pair is good enough and keeps the test self-contained.
+    """
+    no_block = re.sub(r"/\*.*?\*/", "", src, flags=re.DOTALL)
+    no_line = re.sub(r"//[^\n]*", "", no_block)
+    return no_line
+
+
+@pytest.mark.parametrize(
+    "js_path",
+    sorted(_JS_DIR.glob("*.js")),
+    ids=lambda p: p.name,
+)
+def test_no_decomp_strings_outside_comments(js_path):
+    src = js_path.read_text(encoding="utf-8")
+    code_only = _strip_comments(src)
+
+    for pattern, label in _DECOMP_PATTERNS:
+        match = pattern.search(code_only)
+        if match is None:
+            continue
+        # Report with line number from the COMMENT-STRIPPED source so
+        # the developer can locate the offending template literal.
+        preceding = code_only[: match.start()]
+        line_no = preceding.count("\n") + 1
+        # Show ~80 chars of context around the match for quick triage.
+        ctx_start = max(0, match.start() - 40)
+        ctx_end = min(len(code_only), match.end() + 40)
+        snippet = code_only[ctx_start:ctx_end].replace("\n", " ")
+        pytest.fail(
+            f"\nS1 regression: {label} found in executable code of "
+            f"{js_path.name}\n"
+            f"  Pattern:    {pattern.pattern!r}\n"
+            f"  Match:      {match.group(0)!r}\n"
+            f"  Line (in comment-stripped source): {line_no}\n"
+            f"  Context:    ...{snippet}...\n"
+            f"  Fix:        if it's documentation, move it into a "
+            f"/* */ or // comment.\n"
+            f"              if it's debug info actually leaking to the "
+            f"DOM, strip it.\n"
+        )
+
+
+def test_decomp_flair_in_comments_is_preserved():
+    """Sanity check on the OPPOSITE direction: the comment-level
+    decomp flair (e.g. `/** Decompiled from QBW32.EXE!CMainFrame */` at
+    the top of app.js) is intentional and must NOT be stripped by an
+    overzealous future cleanup. If this assertion fails, someone
+    probably went too aggressive removing the heritage banners — they
+    don't reach the DOM, so they're fine to keep.
+    """
+    app_js = (_JS_DIR / "app.js").read_text(encoding="utf-8")
+    # The file-header banner is the canonical example of intentional
+    # in-comment flair.
+    assert "QBW32.EXE" in app_js, (
+        "app.js file-header banner missing — the decomp flair in /** */ "
+        "comments is deliberate and shouldn't be stripped."
+    )
+    # And it must be inside a comment, not in code.
+    code_only = _strip_comments(app_js)
+    assert "QBW32.EXE" not in code_only, (
+        "QBW32.EXE appears in app.js OUTSIDE a comment — that would leak "
+        "to the DOM. Either move it into /* */ or // or remove it."
+    )

--- a/tests/test_no_decomp_strings_in_dom.py
+++ b/tests/test_no_decomp_strings_in_dom.py
@@ -25,7 +25,6 @@ from pathlib import Path
 
 import pytest
 
-
 # Patterns that look like decomp-heritage debug info. Tuned to be
 # specific enough that legitimate code (CSS hex colors, etc.) doesn't
 # false-positive — we don't match # colors, we don't match short


### PR DESCRIPTION
Brings upstream-applicable fixes from the LayoverLogic fork (Alex Jordan, @LayoverLogic), with authorship preserved on each commit.

## What's included
- **CREATE DATABASE identifier quoting** in `create_company` — defence-in-depth behind the existing allowlist regex; clears CodeQL CWE-089. Re-applied by hand from fork commit `9159c63d` + new unit tests locking both layers.
- **Decomp debug strings stripped from the rendered DOM** (settings header subtitle, error-page block) + a 42-case regression scan that keeps heritage flair in comments only (cherry-picked from fork commit `0b2a730b`).
- **Account schema hardening**: NULL stored balances read as 0 instead of 500ing; blank `account_number` normalizes to NULL so the unique constraint can't collide on empty strings (adapted from fork commits `42139223`/`aadfa560`).

## Verified already-upstream (no port needed)
- Dashboard income chart reading GL credits; settings secret masking (upstream's is stronger — `ai_api_key` is Fernet-encrypted); Jinja autoescape; COA inactive-account filter (`app.js:277`); PG enum name-persistence; the fork's onclick-XSS fix targets code paths that don't exist upstream (zero interpolated onclick handlers today).

## Testing
- Full suite: 561 passed. New: `test_company_service_dbname.py` (4), `test_account_schema_hardening.py` (3), `test_no_decomp_strings_in_dom.py` (42).

🤖 Generated with [Claude Code](https://claude.com/claude-code)