### PR TITLE
Fork sync: CSV bank import (Chase + PayPal) from amazon1148

### DIFF
--- a/app/routes/bank_import.py
+++ b/app/routes/bank_import.py
@@ -108,7 +108,8 @@ async def import_csv(
     """Import CSV bank transactions into a bank account.
 
     Auto-detects format (Chase checking, Chase credit, PayPal).
-    Deduplicates by (date, amount) to prevent re-import.
+    Deduplicates by content-derived import_id (re-imports and overlapping
+    exports skip; legitimate same-day duplicates still import).
     Auto-applies bank rules after import.
     """
     ba = db.query(BankAccount).filter(BankAccount.id == bank_account_id).first()

--- a/app/routes/bank_import.py
+++ b/app/routes/bank_import.py
@@ -1,5 +1,5 @@
 # ============================================================================
-# Bank Feed Import — OFX/QFX file upload and import
+# Bank Feed Import — OFX/QFX + CSV file upload and import
 # Feature 18: Upload → preview → confirm → auto-match by amount/date
 # ============================================================================
 
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 from app.database import get_db
 from app.models.banking import BankAccount
 from app.services.ofx_import import parse_ofx, import_transactions
+from app.services.bank_csv_import import parse_csv, import_csv_transactions
 
 router = APIRouter(prefix="/api/bank-import", tags=["bank_import"])
 
@@ -56,4 +57,69 @@ async def import_ofx(
 
     transactions = parse_ofx(text)
     result = import_transactions(db, bank_account_id, transactions)
+    return result
+
+
+@router.post("/preview-csv")
+async def preview_csv(file: UploadFile = File(...)):
+    """Parse CSV bank statement and return preview of transactions."""
+    content = await file.read()
+    try:
+        text = content.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        text = content.decode("latin-1")
+
+    result = parse_csv(text)
+    if result["error"]:
+        return {
+            "format": result["format"],
+            "error": result["error"],
+            "count": 0,
+            "transactions": [],
+        }
+
+    return {
+        "format": result["format"],
+        "count": len(result["transactions"]),
+        "transactions": [
+            {
+                "date": (
+                    t["date"].isoformat()
+                    if hasattr(t["date"], "isoformat")
+                    else str(t["date"])
+                ),
+                "amount": float(t["amount"]),
+                "payee": t.get("payee", ""),
+                "description": t.get("description", ""),
+                "check_number": t.get("check_number"),
+                "fee": float(t["fee"]) if t.get("fee") else None,
+            }
+            for t in result["transactions"]
+        ],
+    }
+
+
+@router.post("/import-csv/{bank_account_id}")
+async def import_csv(
+    bank_account_id: int,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+):
+    """Import CSV bank transactions into a bank account.
+
+    Auto-detects format (Chase checking, Chase credit, PayPal).
+    Deduplicates by (date, amount) to prevent re-import.
+    Auto-applies bank rules after import.
+    """
+    ba = db.query(BankAccount).filter(BankAccount.id == bank_account_id).first()
+    if not ba:
+        raise HTTPException(status_code=404, detail="Bank account not found")
+
+    content = await file.read()
+    try:
+        text = content.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        text = content.decode("latin-1")
+
+    result = import_csv_transactions(db, bank_account_id, text)
     return result

--- a/app/services/bank_csv_import.py
+++ b/app/services/bank_csv_import.py
@@ -10,15 +10,17 @@
 # ============================================================================
 
 import csv
+import hashlib
 import io
 import logging
 from datetime import date, datetime
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Optional
 
 from sqlalchemy.orm import Session
 
 from app.models.banking import BankTransaction
+from app.services.bank_rules_engine import apply_bank_rules
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +107,7 @@ def parse_chase_checking(reader: csv.DictReader) -> list[dict]:
         try:
             txn_date = parse_date(date_str)
             amount = Decimal(amount_str)
-        except (ValueError, Exception) as e:
+        except (ValueError, InvalidOperation) as e:
             logger.warning("Skipping chase checking row: %s", e)
             continue
 
@@ -142,7 +144,7 @@ def parse_chase_credit(reader: csv.DictReader) -> list[dict]:
         try:
             txn_date = parse_date(date_str)
             amount = Decimal(amount_str)
-        except (ValueError, Exception) as e:
+        except (ValueError, InvalidOperation) as e:
             logger.warning("Skipping chase credit row: %s", e)
             continue
 
@@ -151,9 +153,9 @@ def parse_chase_credit(reader: csv.DictReader) -> list[dict]:
                 "date": txn_date,
                 "amount": amount,  # already signed: negative=charge, positive=payment/return
                 "payee": description,
-                "description": f"{category} - {description}"
-                if category
-                else description,
+                "description": (
+                    f"{category} - {description}" if category else description
+                ),
                 "check_number": None,
                 "import_id": f"cc_{txn_date.isoformat()}_{amount}",
                 "category": category,
@@ -193,7 +195,7 @@ def parse_paypal(reader: csv.DictReader) -> list[dict]:
             txn_date = parse_date(date_str)
             gross = Decimal(gross_str)
             fee = Decimal(fee_str) if fee_str else Decimal("0.00")
-        except (ValueError, Exception) as e:
+        except (ValueError, InvalidOperation) as e:
             logger.warning("Skipping PayPal row: %s", e)
             continue
 
@@ -238,7 +240,6 @@ def parse_paypal_new(reader: csv.DictReader) -> list[dict]:
         description = (row.get("Description") or "").strip()
         gross_str = (row.get("Gross") or "").strip()
         fee_str = (row.get("Fee") or "").strip()
-        from_email = (row.get("From Email Address") or "").strip()
 
         if not date_str or not gross_str:
             continue
@@ -247,7 +248,7 @@ def parse_paypal_new(reader: csv.DictReader) -> list[dict]:
             txn_date = parse_date(date_str)
             gross = Decimal(gross_str)
             fee = Decimal(fee_str) if fee_str else Decimal("0.00")
-        except (ValueError, Exception) as e:
+        except (ValueError, InvalidOperation) as e:
             logger.warning("Skipping PayPal row: %s", e)
             continue
 
@@ -326,6 +327,42 @@ def parse_csv(csv_text: str) -> dict:
 # ── Import into DB ───────────────────────────────────────────────────────
 
 
+_IMPORT_ID_PREFIX = {
+    "chase_checking": "chk",
+    "chase_credit": "cc",
+    "paypal": "pp",
+    "paypal_new": "pp",
+}
+
+
+def assign_import_ids(fmt: str, transactions: list[dict]) -> None:
+    """Assign a deterministic, collision-safe import_id to each parsed row.
+
+    CSVs have no FITID, so the id is derived from the row's content:
+    (date, amount, payee|description digest) plus an occurrence counter for
+    rows that are otherwise identical within the same file. This makes
+    re-importing the same file (or an overlapping date-range export) skip
+    every row it already imported, WITHOUT dropping legitimate duplicates —
+    two identical same-day charges get occurrence 0 and 1, so both import,
+    and both are recognized on a re-import.
+
+    Overwrites any import_id the parser attached (the parser-level ids
+    were (date, amount) only — the very collision this exists to fix).
+    """
+    prefix = _IMPORT_ID_PREFIX.get(fmt, "csv")
+    occurrences: dict[tuple, int] = {}
+    for txn in transactions:
+        digest = hashlib.sha256(
+            f"{txn.get('payee', '')}|{txn.get('description', '')}".encode()
+        ).hexdigest()[:12]
+        key = (txn["date"], txn["amount"], digest)
+        n = occurrences.get(key, 0)
+        occurrences[key] = n + 1
+        txn["import_id"] = (
+            f"{prefix}_{txn['date'].isoformat()}_{txn['amount']}_{digest}_{n}"
+        )
+
+
 def import_csv_transactions(
     db: Session,
     bank_account_id: int,
@@ -334,26 +371,24 @@ def import_csv_transactions(
 ) -> dict:
     """Parse CSV and import into BankTransaction records.
 
-    Dedup strategy (CSVs have no FITID): match on (date, amount) within the
-    same bank account. This prevents re-import of the same file.
+    Dedup strategy: content-derived import_id (see assign_import_ids),
+    mirroring the FITID dedup in ofx_import.import_transactions.
     """
     result = parse_csv(csv_text)
     if result["error"]:
         return {"imported": 0, "skipped": 0, "errors": [result["error"]], "total": 0}
 
     transactions = result["transactions"]
+    assign_import_ids(result["format"], transactions)
     imported = 0
     skipped = 0
-    errors = []
 
     for txn in transactions:
-        # Dedup by (date, amount) for this account
         existing = (
             db.query(BankTransaction)
             .filter(
                 BankTransaction.bank_account_id == bank_account_id,
-                BankTransaction.date == txn["date"],
-                BankTransaction.amount == txn["amount"],
+                BankTransaction.import_id == txn["import_id"],
             )
             .first()
         )
@@ -361,82 +396,37 @@ def import_csv_transactions(
             skipped += 1
             continue
 
-        try:
-            bt = BankTransaction(
-                bank_account_id=bank_account_id,
-                date=txn["date"],
-                amount=txn["amount"],
-                payee=(txn.get("payee", "") or "")[:200],
-                description=(txn.get("description", "") or "")[:500],
-                check_number=txn.get("check_number"),
-                import_id=txn.get("import_id"),
-                import_source=f"csv_{result['format']}",
-                match_status="unmatched",
-            )
-            db.add(bt)
-            imported += 1
-        except Exception as e:
-            logger.exception("Failed to import bank CSV transaction")
-            errors.append(str(e))
+        description = (txn.get("description", "") or "")[:500]
+        fee = txn.get("fee")
+        if fee:
+            # Surface the PayPal fee so the bookkeeper sees it when
+            # categorizing (amount is Gross; the fee nets against it).
+            description = f"{description} (fee {fee})"[:500]
+
+        bt = BankTransaction(
+            bank_account_id=bank_account_id,
+            date=txn["date"],
+            amount=txn["amount"],
+            payee=(txn.get("payee", "") or "")[:200],
+            description=description,
+            check_number=txn.get("check_number"),
+            import_id=txn["import_id"],
+            import_source=f"csv_{result['format']}",
+            match_status="unmatched",
+        )
+        db.add(bt)
+        imported += 1
 
     db.commit()
 
-    # Auto-apply bank rules (same logic as ofx_import.import_transactions)
+    # Auto-apply bank rules (shared engine with the OFX importer)
     if imported > 0:
-        _apply_bank_rules(db, bank_account_id)
+        apply_bank_rules(db, bank_account_id)
 
     return {
         "imported": imported,
         "skipped": skipped,
-        "errors": errors,
+        "errors": [],
         "total": len(transactions),
         "format": result["format"],
     }
-
-
-def _apply_bank_rules(db: Session, bank_account_id: int) -> None:
-    """Auto-categorize unmatched transactions by bank rules."""
-    try:
-        from app.models.bank_rules import BankRule
-
-        rules = (
-            db.query(BankRule)
-            .filter(BankRule.is_active)
-            .order_by(BankRule.priority.desc())
-            .all()
-        )
-        if not rules:
-            return
-
-        unmatched = (
-            db.query(BankTransaction)
-            .filter(
-                BankTransaction.bank_account_id == bank_account_id,
-                BankTransaction.match_status == "unmatched",
-            )
-            .all()
-        )
-
-        auto_matched = 0
-        for txn in unmatched:
-            payee = (txn.payee or "").lower()
-            for rule in rules:
-                pattern = rule.pattern.lower()
-                hit = False
-                if rule.rule_type == "contains" and pattern in payee:
-                    hit = True
-                elif rule.rule_type == "starts_with" and payee.startswith(pattern):
-                    hit = True
-                elif rule.rule_type == "exact" and payee == pattern:
-                    hit = True
-                if hit:
-                    if rule.account_id:
-                        txn.category_account_id = rule.account_id
-                    txn.match_status = "auto"
-                    auto_matched += 1
-                    break
-
-        if auto_matched > 0:
-            db.commit()
-    except ImportError:
-        pass  # bank_rules model not available

--- a/app/services/bank_csv_import.py
+++ b/app/services/bank_csv_import.py
@@ -1,0 +1,442 @@
+# ============================================================================
+# CSV Bank Transaction Import — Chase checking, Chase credit card, PayPal
+# Extends Feature 18 (bank feed import) to support CSV bank statement exports.
+#
+# Column mapping & pitfalls documented in the skill. Key rules:
+#   - Chase checking: Amount column already signed (neg=debit, pos=credit)
+#   - Chase credit:   Amount column already signed (neg=charge, pos=payment)
+#   - PayPal:         Gross (NOT Net) = transaction amount;
+#                     Fee column goes to Merchant Fee expense (6120)
+# ============================================================================
+
+import csv
+import io
+import logging
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.banking import BankTransaction
+
+logger = logging.getLogger(__name__)
+
+# ── Column signatures for format auto-detection ──────────────────────────
+
+CHASE_CHECKING_SIG = {"Details", "Posting Date", "Description", "Amount", "Type"}
+CHASE_CREDIT_SIG = {
+    "Transaction Date",
+    "Post Date",
+    "Description",
+    "Category",
+    "Type",
+    "Amount",
+}
+PAYPAL_SIG = {
+    "Date",
+    "Time",
+    "Name",
+    "Type",
+    "Status",
+}
+PAYPAL_NEW_SIG = {
+    "Date",
+    "Time",
+    "Description",
+    "Gross",
+    "Fee",
+    "Net",
+    "Transaction ID",
+    "From Email Address",
+    "Name",
+}
+
+
+def detect_format(headers: set[str]) -> str:
+    """Detect CSV format by header column signature (not filename)."""
+    if CHASE_CHECKING_SIG.issubset(headers):
+        return "chase_checking"
+    if CHASE_CREDIT_SIG.issubset(headers):
+        return "chase_credit"
+    if PAYPAL_SIG.issubset(headers):
+        return "paypal"
+    if PAYPAL_NEW_SIG.issubset(headers):
+        return "paypal_new"
+    return "unknown"
+
+
+def parse_date(val: str) -> date:
+    """Parse a date string with broad format tolerance."""
+    val = val.strip()
+    for fmt in ("%m/%d/%Y", "%Y-%m-%d", "%m-%d-%Y", "%d/%m/%Y"):
+        try:
+            return datetime.strptime(val, fmt).date()
+        except ValueError:
+            continue
+    try:
+        from dateutil import parser as dateparser
+
+        return dateparser.parse(val).date()
+    except ImportError:
+        pass
+    raise ValueError(f"Cannot parse date: {val}")
+
+
+# ── Format-specific parsers ──────────────────────────────────────────────
+
+
+def parse_chase_checking(reader: csv.DictReader) -> list[dict]:
+    """Parse Chase personal checking CSV.
+
+    Columns: Details, Posting Date, Description, Amount, Type, Balance, Check or Slip #
+    """
+    transactions = []
+    for row in reader:
+        txn_type = (row.get("Details") or "").strip()
+        date_str = (row.get("Posting Date") or "").strip()
+        description = (row.get("Description") or "").strip()
+        amount_str = (row.get("Amount") or "").strip()
+        check_slip = (row.get("Check or Slip #") or "").strip()
+
+        if not date_str or not amount_str:
+            continue
+
+        try:
+            txn_date = parse_date(date_str)
+            amount = Decimal(amount_str)
+        except (ValueError, Exception) as e:
+            logger.warning("Skipping chase checking row: %s", e)
+            continue
+
+        transactions.append(
+            {
+                "date": txn_date,
+                "amount": amount,  # already signed: negative=debit, positive=credit
+                "payee": description,
+                "description": description,
+                "check_number": check_slip if check_slip else None,
+                "import_id": f"chk_{txn_date.isoformat()}_{amount}",
+                "txn_type": txn_type,
+            }
+        )
+    return transactions
+
+
+def parse_chase_credit(reader: csv.DictReader) -> list[dict]:
+    """Parse Chase credit card CSV.
+
+    Columns: Transaction Date, Post Date, Description, Category, Type, Amount, Memo
+    """
+    transactions = []
+    for row in reader:
+        date_str = (row.get("Transaction Date") or "").strip()
+        description = (row.get("Description") or "").strip()
+        category = (row.get("Category") or "").strip()
+        amount_str = (row.get("Amount") or "").strip()
+        memo = (row.get("Memo") or "").strip()
+
+        if not date_str or not amount_str:
+            continue
+
+        try:
+            txn_date = parse_date(date_str)
+            amount = Decimal(amount_str)
+        except (ValueError, Exception) as e:
+            logger.warning("Skipping chase credit row: %s", e)
+            continue
+
+        transactions.append(
+            {
+                "date": txn_date,
+                "amount": amount,  # already signed: negative=charge, positive=payment/return
+                "payee": description,
+                "description": f"{category} - {description}"
+                if category
+                else description,
+                "check_number": None,
+                "import_id": f"cc_{txn_date.isoformat()}_{amount}",
+                "category": category,
+                "memo": memo,
+            }
+        )
+    return transactions
+
+
+def parse_paypal(reader: csv.DictReader) -> list[dict]:
+    """Parse PayPal CSV.
+
+    CRITICAL DIFFERENCE from raw intuition: map *Gross* (not Net) as the
+    transaction amount. Net understates revenue because PayPal already
+    subtracted the fee. Route the Fee column to Merchant Fee expense (6120)
+    in a separate split. See imports/csv-import.md for worked example.
+
+    Additionally, skip paired "Bank Deposit to PP Account" rows — they are
+    the mirror-image of Express Checkout payments and net to zero. The real
+    cash movement shows up in the Chase checking CSV as an IAT (PAYPAL)
+    transfer.
+    """
+    transactions = []
+    for row in reader:
+        date_str = (row.get("Date") or "").strip()
+        name = (row.get("Name") or "").strip()
+        txn_type = (row.get("Type") or "").strip()
+        status = (row.get("Status") or "").strip()
+        gross_str = (row.get("Gross") or "").strip()
+        fee_str = (row.get("Fee") or "").strip()
+        item_title = (row.get("Item Title") or "").strip()
+
+        if not date_str or not gross_str:
+            continue
+
+        try:
+            txn_date = parse_date(date_str)
+            gross = Decimal(gross_str)
+            fee = Decimal(fee_str) if fee_str else Decimal("0.00")
+        except (ValueError, Exception) as e:
+            logger.warning("Skipping PayPal row: %s", e)
+            continue
+
+        # Skip paired Bank Deposit rows — they're the mirror of payments
+        if txn_type == "Bank Deposit to PP Account":
+            continue
+
+        # Build description from available fields
+        desc_parts = [p for p in [name, item_title, txn_type] if p]
+        description = " | ".join(desc_parts)
+
+        transactions.append(
+            {
+                "date": txn_date,
+                "amount": gross,  # Gross, NOT Net
+                "payee": name or item_title or "PayPal Transfer",
+                "description": description,
+                "check_number": None,
+                "import_id": f"pp_{txn_date.isoformat()}_{gross}",
+                "fee": fee,
+                "status": status,
+            }
+        )
+    return transactions
+
+
+def parse_paypal_new(reader: csv.DictReader) -> list[dict]:
+    """Parse new-style PayPal CSV (2026 format — simpler columns).
+
+    Columns: Date, Time, Time Zone, Description, Currency, Gross, Fee, Net,
+             Balance, Transaction ID, From Email Address, Name, Bank Name,
+             Bank Account, Shipping and Handling Amount, Sales Tax, Invoice ID,
+             Reference Txn ID
+
+    Key difference from old format: no 'Type' or 'Status' columns.
+    Uses Description + Name as payee, Gross as amount.
+    """
+    transactions = []
+    for row in reader:
+        date_str = (row.get("Date") or "").strip()
+        name = (row.get("Name") or "").strip()
+        description = (row.get("Description") or "").strip()
+        gross_str = (row.get("Gross") or "").strip()
+        fee_str = (row.get("Fee") or "").strip()
+        from_email = (row.get("From Email Address") or "").strip()
+
+        if not date_str or not gross_str:
+            continue
+
+        try:
+            txn_date = parse_date(date_str)
+            gross = Decimal(gross_str)
+            fee = Decimal(fee_str) if fee_str else Decimal("0.00")
+        except (ValueError, Exception) as e:
+            logger.warning("Skipping PayPal row: %s", e)
+            continue
+
+        # Skip Bank Deposit to PP Account rows (mirror entries)
+        if description.startswith("Bank Deposit to PP Account"):
+            continue
+
+        payee = name or description or "PayPal Transfer"
+        desc = (
+            f"{description} | {name}"
+            if name and description
+            else (description or name or "")
+        )
+
+        transactions.append(
+            {
+                "date": txn_date,
+                "amount": gross,
+                "payee": payee,
+                "description": desc,
+                "check_number": None,
+                "import_id": f"pp_{txn_date.isoformat()}_{gross}",
+                "fee": fee,
+            }
+        )
+    return transactions
+
+
+# ── Dispatch ─────────────────────────────────────────────────────────────
+
+
+def parse_csv(csv_text: str) -> dict:
+    """Parse CSV text, auto-detect format, return parsed transactions.
+
+    Strips BOM and surrounding quotes from headers for reliable detection.
+    Handles PayPal's '\ufeff"Date"' header format.
+
+    Returns:
+        {"format": str, "transactions": list[dict], "error": str | None}
+    """
+    # Strip BOM before handing to csv reader
+    if csv_text.startswith("\ufeff"):
+        csv_text = csv_text[1:]
+
+    reader = csv.DictReader(io.StringIO(csv_text))
+    if not reader.fieldnames:
+        return {
+            "format": "unknown",
+            "transactions": [],
+            "error": "Empty CSV or no headers",
+        }
+
+    # Normalize headers: strip whitespace, quotes, and BOM residue
+    headers = {h.strip().strip('"').strip("'") for h in reader.fieldnames if h}
+    fmt = detect_format(headers)
+
+    parsers = {
+        "chase_checking": parse_chase_checking,
+        "chase_credit": parse_chase_credit,
+        "paypal": parse_paypal,
+        "paypal_new": parse_paypal_new,
+    }
+
+    parser = parsers.get(fmt)
+    if not parser:
+        return {
+            "format": "unknown",
+            "transactions": [],
+            "error": f"Unknown CSV format. Headers found: {sorted(headers)}",
+        }
+
+    transactions = parser(reader)
+    return {"format": fmt, "transactions": transactions, "error": None}
+
+
+# ── Import into DB ───────────────────────────────────────────────────────
+
+
+def import_csv_transactions(
+    db: Session,
+    bank_account_id: int,
+    csv_text: str,
+    format_hint: Optional[str] = None,
+) -> dict:
+    """Parse CSV and import into BankTransaction records.
+
+    Dedup strategy (CSVs have no FITID): match on (date, amount) within the
+    same bank account. This prevents re-import of the same file.
+    """
+    result = parse_csv(csv_text)
+    if result["error"]:
+        return {"imported": 0, "skipped": 0, "errors": [result["error"]], "total": 0}
+
+    transactions = result["transactions"]
+    imported = 0
+    skipped = 0
+    errors = []
+
+    for txn in transactions:
+        # Dedup by (date, amount) for this account
+        existing = (
+            db.query(BankTransaction)
+            .filter(
+                BankTransaction.bank_account_id == bank_account_id,
+                BankTransaction.date == txn["date"],
+                BankTransaction.amount == txn["amount"],
+            )
+            .first()
+        )
+        if existing:
+            skipped += 1
+            continue
+
+        try:
+            bt = BankTransaction(
+                bank_account_id=bank_account_id,
+                date=txn["date"],
+                amount=txn["amount"],
+                payee=(txn.get("payee", "") or "")[:200],
+                description=(txn.get("description", "") or "")[:500],
+                check_number=txn.get("check_number"),
+                import_id=txn.get("import_id"),
+                import_source=f"csv_{result['format']}",
+                match_status="unmatched",
+            )
+            db.add(bt)
+            imported += 1
+        except Exception as e:
+            logger.exception("Failed to import bank CSV transaction")
+            errors.append(str(e))
+
+    db.commit()
+
+    # Auto-apply bank rules (same logic as ofx_import.import_transactions)
+    if imported > 0:
+        _apply_bank_rules(db, bank_account_id)
+
+    return {
+        "imported": imported,
+        "skipped": skipped,
+        "errors": errors,
+        "total": len(transactions),
+        "format": result["format"],
+    }
+
+
+def _apply_bank_rules(db: Session, bank_account_id: int) -> None:
+    """Auto-categorize unmatched transactions by bank rules."""
+    try:
+        from app.models.bank_rules import BankRule
+
+        rules = (
+            db.query(BankRule)
+            .filter(BankRule.is_active)
+            .order_by(BankRule.priority.desc())
+            .all()
+        )
+        if not rules:
+            return
+
+        unmatched = (
+            db.query(BankTransaction)
+            .filter(
+                BankTransaction.bank_account_id == bank_account_id,
+                BankTransaction.match_status == "unmatched",
+            )
+            .all()
+        )
+
+        auto_matched = 0
+        for txn in unmatched:
+            payee = (txn.payee or "").lower()
+            for rule in rules:
+                pattern = rule.pattern.lower()
+                hit = False
+                if rule.rule_type == "contains" and pattern in payee:
+                    hit = True
+                elif rule.rule_type == "starts_with" and payee.startswith(pattern):
+                    hit = True
+                elif rule.rule_type == "exact" and payee == pattern:
+                    hit = True
+                if hit:
+                    if rule.account_id:
+                        txn.category_account_id = rule.account_id
+                    txn.match_status = "auto"
+                    auto_matched += 1
+                    break
+
+        if auto_matched > 0:
+            db.commit()
+    except ImportError:
+        pass  # bank_rules model not available

--- a/app/services/bank_rules_engine.py
+++ b/app/services/bank_rules_engine.py
@@ -1,0 +1,68 @@
+# ============================================================================
+# Bank rule application — shared by every bank-feed importer (OFX, CSV).
+#
+# Extracted from ofx_import.import_transactions so the CSV importer doesn't
+# carry a drifting copy of the matching logic. Rules are ordered by priority
+# (highest first); the first hit wins and marks the transaction "auto".
+# ============================================================================
+
+import logging
+
+from sqlalchemy.orm import Session
+
+from app.models.banking import BankTransaction
+
+logger = logging.getLogger(__name__)
+
+
+def apply_bank_rules(db: Session, bank_account_id: int) -> int:
+    """Auto-categorize this account's unmatched transactions by bank rules.
+
+    Returns the number of transactions auto-matched. Commits only when at
+    least one transaction matched.
+    """
+    try:
+        from app.models.bank_rules import BankRule
+    except ImportError:
+        return 0  # bank_rules model not available
+
+    rules = (
+        db.query(BankRule)
+        .filter(BankRule.is_active)
+        .order_by(BankRule.priority.desc())
+        .all()
+    )
+    if not rules:
+        return 0
+
+    unmatched = (
+        db.query(BankTransaction)
+        .filter(
+            BankTransaction.bank_account_id == bank_account_id,
+            BankTransaction.match_status == "unmatched",
+        )
+        .all()
+    )
+
+    auto_matched = 0
+    for txn in unmatched:
+        payee = (txn.payee or "").lower()
+        for rule in rules:
+            pattern = rule.pattern.lower()
+            hit = False
+            if rule.rule_type == "contains" and pattern in payee:
+                hit = True
+            elif rule.rule_type == "starts_with" and payee.startswith(pattern):
+                hit = True
+            elif rule.rule_type == "exact" and payee == pattern:
+                hit = True
+            if hit:
+                if rule.account_id:
+                    txn.category_account_id = rule.account_id
+                txn.match_status = "auto"
+                auto_matched += 1
+                break
+
+    if auto_matched > 0:
+        db.commit()
+    return auto_matched

--- a/app/services/ofx_import.py
+++ b/app/services/ofx_import.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 from sqlalchemy.orm import Session
 
 from app.models.banking import BankTransaction
+from app.services.bank_rules_engine import apply_bank_rules
 
 
 def parse_ofx(content: str) -> list[dict]:
@@ -118,47 +119,6 @@ def import_transactions(
 
     # Auto-apply bank rules to newly imported transactions
     if imported > 0:
-        try:
-            from app.models.bank_rules import BankRule
-
-            rules = (
-                db.query(BankRule)
-                .filter(BankRule.is_active)
-                .order_by(BankRule.priority.desc())
-                .all()
-            )
-            if rules:
-                unmatched = (
-                    db.query(BankTransaction)
-                    .filter(
-                        BankTransaction.bank_account_id == bank_account_id,
-                        BankTransaction.match_status == "unmatched",
-                    )
-                    .all()
-                )
-                auto_matched = 0
-                for txn in unmatched:
-                    payee = (txn.payee or "").lower()
-                    for rule in rules:
-                        pattern = rule.pattern.lower()
-                        hit = False
-                        if rule.rule_type == "contains" and pattern in payee:
-                            hit = True
-                        elif rule.rule_type == "starts_with" and payee.startswith(
-                            pattern
-                        ):
-                            hit = True
-                        elif rule.rule_type == "exact" and payee == pattern:
-                            hit = True
-                        if hit:
-                            if rule.account_id:
-                                txn.category_account_id = rule.account_id
-                            txn.match_status = "auto"
-                            auto_matched += 1
-                            break
-                if auto_matched > 0:
-                    db.commit()
-        except ImportError:
-            pass  # bank_rules model not available yet
+        apply_bank_rules(db, bank_account_id)
 
     return {"imported": imported, "skipped": skipped, "total": len(transactions)}

--- a/app/static/js/banking.js
+++ b/app/static/js/banking.js
@@ -46,7 +46,7 @@ const BankingPage = {
                 <div class="btn-group">
                     <button class="btn btn-secondary" onclick="App.navigate('#/banking')">Back</button>
                     <button class="btn btn-primary" onclick="BankingPage.showTxnForm(${bankAccountId})">+ Transaction</button>
-                    <button class="btn btn-secondary" onclick="BankingPage.showOFXImport(${bankAccountId})">Import OFX/QFX</button>
+                    <button class="btn btn-secondary" onclick="BankingPage.showOFXImport(${bankAccountId})">Import OFX/QFX/CSV</button>
                     <button class="btn btn-secondary" onclick="BankingPage.startReconcile(${bankAccountId})">Reconcile</button>
                 </div>
             </div>
@@ -266,13 +266,13 @@ const BankingPage = {
         } catch (err) { toast(err.message, 'error'); }
     },
 
-    // Feature 18: OFX/QFX Import
+    // Feature 18: OFX/QFX Import (+ CSV: Chase checking/credit, PayPal)
     async showOFXImport(bankAccountId) {
-        openModal('Import OFX/QFX File', `
+        openModal('Import Bank File', `
             <form onsubmit="BankingPage.previewOFX(event, ${bankAccountId})">
                 <div class="form-group">
-                    <label>Select OFX or QFX file from your bank</label>
-                    <input type="file" name="file" accept=".ofx,.qfx" required id="ofx-file">
+                    <label>Select an OFX/QFX file, or a CSV export (Chase checking, Chase credit, PayPal)</label>
+                    <input type="file" name="file" accept=".ofx,.qfx,.csv" required id="ofx-file">
                 </div>
                 <div class="form-actions">
                     <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
@@ -282,30 +282,38 @@ const BankingPage = {
             <div id="ofx-preview" style="margin-top:12px;"></div>`);
     },
 
+    _isCsvFile(file) {
+        return /\.csv$/i.test(file.name || '');
+    },
+
     async previewOFX(e, bankAccountId) {
         e.preventDefault();
         const file = $('#ofx-file').files[0];
         if (!file) return;
+        const isCsv = BankingPage._isCsvFile(file);
         const formData = new FormData();
         formData.append('file', file);
         try {
-            const resp = await fetch('/api/bank-import/preview', { method: 'POST', body: formData });
+            const endpoint = isCsv ? '/api/bank-import/preview-csv' : '/api/bank-import/preview';
+            const resp = await fetch(endpoint, { method: 'POST', body: formData });
             const data = await resp.json();
             if (!resp.ok) throw new Error(data.detail || 'Parse failed');
+            if (isCsv && data.error) throw new Error(data.error);
             BankingPage._ofxData = data;
             let rows = data.transactions.map((t, i) => `<tr>
                 <td>${escapeHtml(t.date || '')}</td>
                 <td>${escapeHtml(t.payee || '')}</td>
                 <td class="amount" style="${t.amount >= 0 ? 'color:var(--success)' : 'color:var(--danger)'}">${formatCurrency(t.amount)}</td>
-                <td>${escapeHtml(t.fitid || '')}</td>
+                <td>${escapeHtml(isCsv ? (t.description || '') : (t.fitid || ''))}</td>
             </tr>`).join('');
             $('#ofx-preview').innerHTML = `
                 <div style="margin-bottom:8px; font-size:11px;">
                     <strong>${data.transactions.length}</strong> transactions found.
+                    ${isCsv && data.format ? `Format: ${escapeHtml(data.format)}` : ''}
                     ${data.account_id ? `Account: ${escapeHtml(data.account_id)}` : ''}
                 </div>
                 <div class="table-container" style="max-height:300px; overflow-y:auto;"><table>
-                    <thead><tr><th>Date</th><th>Payee</th><th class="amount">Amount</th><th>FITID</th></tr></thead>
+                    <thead><tr><th>Date</th><th>Payee</th><th class="amount">Amount</th><th>${isCsv ? 'Description' : 'FITID'}</th></tr></thead>
                     <tbody>${rows}</tbody>
                 </table></div>
                 <div class="form-actions" style="margin-top:12px;">
@@ -318,12 +326,17 @@ const BankingPage = {
 
     async confirmOFXImport(bankAccountId) {
         try {
+            const file = $('#ofx-file').files[0];
+            const isCsv = BankingPage._isCsvFile(file);
             const formData = new FormData();
-            formData.append('file', $('#ofx-file').files[0]);
-            const resp = await fetch(`/api/bank-import/import/${bankAccountId}`, { method: 'POST', body: formData });
+            formData.append('file', file);
+            const endpoint = isCsv
+                ? `/api/bank-import/import-csv/${bankAccountId}`
+                : `/api/bank-import/import/${bankAccountId}`;
+            const resp = await fetch(endpoint, { method: 'POST', body: formData });
             const data = await resp.json();
             if (!resp.ok) throw new Error(data.detail || 'Import failed');
-            toast(`Imported ${data.imported} transactions (${data.skipped_duplicates} duplicates skipped)`);
+            toast(`Imported ${data.imported} transactions (${data.skipped} duplicates skipped)`);
             closeModal();
             BankingPage.viewRegister(bankAccountId);
         } catch (err) { toast(err.message, 'error'); }

--- a/tests/test_bank_csv_import.py
+++ b/tests/test_bank_csv_import.py
@@ -1,0 +1,207 @@
+"""CSV bank import: format auto-detection, PayPal Gross/Fee handling,
+content-derived import_id dedup, and bank-rule parity with OFX import."""
+
+from decimal import Decimal
+
+from app.models.accounts import Account, AccountType
+from app.models.bank_rules import BankRule
+from app.models.banking import BankAccount, BankTransaction
+from app.services.bank_csv_import import (
+    detect_format,
+    import_csv_transactions,
+    parse_csv,
+)
+
+CHASE_CHECKING_CSV = (
+    "Details,Posting Date,Description,Amount,Type,Balance,Check or Slip #\n"
+    "DEBIT,07/01/2026,COFFEE SHOP,-4.50,DEBIT_CARD,995.50,\n"
+    "DEBIT,07/01/2026,COFFEE SHOP,-4.50,DEBIT_CARD,991.00,\n"
+    "CREDIT,07/02/2026,PAYROLL DEPOSIT,2500.00,ACH_CREDIT,3491.00,\n"
+    "DEBIT,07/03/2026,CHECK 1041,-125.00,CHECK_PAID,3366.00,1041\n"
+)
+
+CHASE_CREDIT_CSV = (
+    "Transaction Date,Post Date,Description,Category,Type,Amount,Memo\n"
+    "07/05/2026,07/06/2026,HARDWARE STORE,Home,Sale,-89.99,\n"
+    "07/07/2026,07/08/2026,PAYMENT THANK YOU,,Payment,500.00,\n"
+)
+
+PAYPAL_OLD_CSV = (
+    '﻿"Date","Time","Time Zone","Name","Type","Status","Currency","Gross","Fee","Net",'
+    '"From Email Address","To Email Address","Transaction ID","Item Title"\n'
+    '"07/10/2026","10:00:00","PDT","Ada Lovelace","Express Checkout Payment","Completed",'
+    '"USD","100.00","-3.20","96.80","ada@example.com","me@example.com","TX123","Widget"\n'
+    '"07/10/2026","10:00:05","PDT","","Bank Deposit to PP Account","Completed",'
+    '"USD","-96.80","0.00","-96.80","","","TX124",""\n'
+)
+
+PAYPAL_NEW_CSV = (
+    "Date,Time,Time Zone,Description,Currency,Gross,Fee,Net,Balance,Transaction ID,"
+    "From Email Address,Name,Bank Name,Bank Account,Shipping and Handling Amount,"
+    "Sales Tax,Invoice ID,Reference Txn ID\n"
+    "07/12/2026,09:00:00,PDT,General Payment,USD,250.00,-7.55,242.45,242.45,TX200,"
+    "grace@example.com,Grace Hopper,,,0.00,0.00,INV-9,\n"
+)
+
+
+def _mk_bank_account(db_session):
+    ba = BankAccount(name="Test Checking", bank_name="Chase")
+    db_session.add(ba)
+    db_session.commit()
+    return ba
+
+
+# ── Format detection ─────────────────────────────────────────────────────
+
+
+def test_detect_formats():
+    assert (
+        detect_format(
+            {"Details", "Posting Date", "Description", "Amount", "Type", "Balance"}
+        )
+        == "chase_checking"
+    )
+    assert (
+        detect_format(
+            {
+                "Transaction Date",
+                "Post Date",
+                "Description",
+                "Category",
+                "Type",
+                "Amount",
+            }
+        )
+        == "chase_credit"
+    )
+    assert detect_format({"Date", "Time", "Name", "Type", "Status"}) == "paypal"
+    assert detect_format({"Nothing", "Useful"}) == "unknown"
+
+
+def test_parse_chase_checking_rows():
+    result = parse_csv(CHASE_CHECKING_CSV)
+    assert result["format"] == "chase_checking"
+    assert result["error"] is None
+    txns = result["transactions"]
+    assert len(txns) == 4
+    assert txns[0]["amount"] == Decimal("-4.50")
+    assert txns[3]["check_number"] == "1041"
+
+
+def test_parse_paypal_gross_fee_and_mirror_skip():
+    result = parse_csv(PAYPAL_OLD_CSV)
+    assert result["format"] == "paypal"
+    txns = result["transactions"]
+    # The "Bank Deposit to PP Account" mirror row is skipped
+    assert len(txns) == 1
+    # Gross, NOT Net
+    assert txns[0]["amount"] == Decimal("100.00")
+    assert txns[0]["fee"] == Decimal("-3.20")
+
+
+def test_parse_paypal_new_format():
+    result = parse_csv(PAYPAL_NEW_CSV)
+    assert result["format"] == "paypal_new"
+    txns = result["transactions"]
+    assert len(txns) == 1
+    assert txns[0]["amount"] == Decimal("250.00")
+    assert txns[0]["payee"] == "Grace Hopper"
+
+
+# ── Import + dedup ───────────────────────────────────────────────────────
+
+
+def test_same_day_same_amount_duplicates_both_import(db_session):
+    """Two identical coffee charges on the same day are BOTH real
+    transactions — the (date, amount) dedup this replaces dropped one."""
+    ba = _mk_bank_account(db_session)
+    result = import_csv_transactions(db_session, ba.id, CHASE_CHECKING_CSV)
+    assert result["imported"] == 4
+    assert result["skipped"] == 0
+    coffee = (
+        db_session.query(BankTransaction)
+        .filter(BankTransaction.payee == "COFFEE SHOP")
+        .all()
+    )
+    assert len(coffee) == 2
+
+
+def test_reimport_same_file_skips_everything(db_session):
+    ba = _mk_bank_account(db_session)
+    first = import_csv_transactions(db_session, ba.id, CHASE_CHECKING_CSV)
+    assert first["imported"] == 4
+    second = import_csv_transactions(db_session, ba.id, CHASE_CHECKING_CSV)
+    assert second["imported"] == 0
+    assert second["skipped"] == 4
+
+
+def test_overlapping_export_skips_only_known_rows(db_session):
+    """A later export containing already-imported rows plus new ones
+    imports only the new ones."""
+    ba = _mk_bank_account(db_session)
+    import_csv_transactions(db_session, ba.id, CHASE_CHECKING_CSV)
+
+    overlapping = CHASE_CHECKING_CSV + (
+        "DEBIT,07/04/2026,GROCERY STORE,-62.10,DEBIT_CARD,3303.90,\n"
+    )
+    result = import_csv_transactions(db_session, ba.id, overlapping)
+    assert result["imported"] == 1
+    assert result["skipped"] == 4
+
+
+def test_import_source_tagged_with_format(db_session):
+    ba = _mk_bank_account(db_session)
+    import_csv_transactions(db_session, ba.id, CHASE_CREDIT_CSV)
+    sources = {
+        t.import_source
+        for t in db_session.query(BankTransaction)
+        .filter(BankTransaction.bank_account_id == ba.id)
+        .all()
+    }
+    assert sources == {"csv_chase_credit"}
+
+
+def test_paypal_fee_surfaces_in_description(db_session):
+    ba = _mk_bank_account(db_session)
+    import_csv_transactions(db_session, ba.id, PAYPAL_OLD_CSV)
+    txn = (
+        db_session.query(BankTransaction)
+        .filter(BankTransaction.bank_account_id == ba.id)
+        .one()
+    )
+    assert "fee -3.20" in txn.description
+
+
+# ── Bank-rule parity with OFX ────────────────────────────────────────────
+
+
+def test_bank_rules_auto_apply_on_csv_import(db_session):
+    ba = _mk_bank_account(db_session)
+    expense = Account(name="Meals", account_type=AccountType.EXPENSE)
+    db_session.add(expense)
+    db_session.commit()
+    db_session.add(
+        BankRule(
+            name="Coffee",
+            pattern="coffee",
+            rule_type="contains",
+            account_id=expense.id,
+        )
+    )
+    db_session.commit()
+
+    import_csv_transactions(db_session, ba.id, CHASE_CHECKING_CSV)
+    coffee = (
+        db_session.query(BankTransaction)
+        .filter(BankTransaction.payee == "COFFEE SHOP")
+        .all()
+    )
+    assert all(t.match_status == "auto" for t in coffee)
+    assert all(t.category_account_id == expense.id for t in coffee)
+
+
+def test_unknown_format_reports_error(db_session):
+    ba = _mk_bank_account(db_session)
+    result = import_csv_transactions(db_session, ba.id, "Foo,Bar\n1,2\n")
+    assert result["imported"] == 0
+    assert result["errors"]


### PR DESCRIPTION
Brings the CSV bank importer from the amazon1148 fork upstream — Chase checking, Chase credit, and both PayPal export formats, auto-detected by header signature. The first commit preserves @amazon1148's authorship (cherry-picked from their `6b3f3a7`, restricted to the bank-import feature; the original bundled unrelated macOS deployment tooling that was excluded). Fix-ups land on top.

## Feature
- `app/services/bank_csv_import.py` — header-signature auto-detect (no filename guessing), BOM/quoted-header handling, multi-format dates, Decimal amounts, PayPal **Gross-not-Net** with the fee split out and mirror "Bank Deposit to PP Account" rows skipped.
- `POST /api/bank-import/preview-csv` + `POST /api/bank-import/import-csv/{bank_account_id}`, mirroring the OFX pair.
- Banking UI import modal now accepts `.csv` and routes by extension; shows the detected format in the preview.

## Fixes applied on top
- **Dedup correctness**: the fork deduped by `(date, amount)`, which silently drops legitimate duplicates (two identical same-day charges). Now a content-derived `import_id` with an occurrence counter — re-imports and overlapping exports skip, real duplicates import.
- Extracted the bank-rule auto-categorization that was inlined in `ofx_import` (and copied in the fork) into a shared `bank_rules_engine.apply_bank_rules()` used by both importers.
- Narrowed `except (ValueError, Exception)` catch-alls; PayPal fee surfaced in the description; fixed the pre-existing import toast reading `skipped_duplicates` (API returns `skipped`).

## Testing
Full suite 523 passed; 11 new tests (format detection, Gross/Fee, mirror-row skip, same-day duplicate preservation, idempotent re-import, overlapping exports, bank-rule parity, unknown-format error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)