### PR TITLE
Feature: multi-currency (foreign invoices/bills + realized FX)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -65,6 +65,7 @@ from app.routes import uploads
 # Phase 5: Advanced Integration
 from app.routes import bank_import, tax, backups
 from app.routes import classes as classes_routes
+from app.routes import fx as fx_routes
 
 # Phase 6: Ambitious
 from app.routes import companies, employees, payroll
@@ -365,6 +366,7 @@ app.include_router(auth_routes.router)
 app.include_router(dashboard.router)
 app.include_router(accounts.router)
 app.include_router(classes_routes.router)
+app.include_router(fx_routes.router)
 app.include_router(customers.router)
 app.include_router(vendors.router)
 app.include_router(items.router)

--- a/app/models/bills.py
+++ b/app/models/bills.py
@@ -62,6 +62,10 @@ class Bill(Base):
     # Class tracking dimension (QB-style); NULL groups with Uncategorized
     class_id = Column(Integer, ForeignKey("classes.id"), nullable=True)
 
+    # Multi-currency: document currency + rate it was booked at (GL is home)
+    currency = Column(String(3), nullable=True)
+    exchange_rate = Column(Numeric(18, 8), nullable=True)
+
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()

--- a/app/models/invoices.py
+++ b/app/models/invoices.py
@@ -93,6 +93,10 @@ class Invoice(Base):
     # Class tracking dimension (QB-style); NULL groups with Uncategorized
     class_id = Column(Integer, ForeignKey("classes.id"), nullable=True)
 
+    # Multi-currency: document currency + rate it was booked at (GL is home)
+    currency = Column(String(3), nullable=True)
+    exchange_rate = Column(Numeric(18, 8), nullable=True)
+
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()

--- a/app/models/payments.py
+++ b/app/models/payments.py
@@ -42,6 +42,10 @@ class Payment(Base):
     transaction_id = Column(Integer, ForeignKey("transactions.id"), nullable=True)
     is_voided = Column(Boolean, default=False)
 
+    # Multi-currency: document currency + rate it was booked at (GL is home)
+    currency = Column(String(3), nullable=True)
+    exchange_rate = Column(Numeric(18, 8), nullable=True)
+
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     customer = relationship("Customer", backref="payments")

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -57,6 +57,8 @@ DEFAULT_SETTINGS = {
     "smtp_use_tls": "true",
     # Feature 15: Company Logo
     "company_logo_path": "",
+    # Multi-currency: ISO code the general ledger is kept in
+    "home_currency": "USD",
     # Stripe Online Payments
     "stripe_enabled": "false",
     "stripe_publishable_key": "",

--- a/app/routes/bills.py
+++ b/app/routes/bills.py
@@ -100,8 +100,14 @@ def create_bill(data: BillCreate, db: Session = Depends(get_db)):
 
     subtotal, tax_amount, total = compute_line_totals(data.lines, data.tax_rate)
 
+    from app.services.currency import convert_lines, resolve_rate
+
+    doc_currency, doc_rate = resolve_rate(db, data.currency, data.exchange_rate)
+
     bill = Bill(
         bill_number=data.bill_number,
+        currency=doc_currency,
+        exchange_rate=doc_rate,
         vendor_id=data.vendor_id,
         date=data.date,
         due_date=due_date,
@@ -230,7 +236,7 @@ def create_bill(data: BillCreate, db: Session = Depends(get_db)):
             db,
             data.date,
             f"Bill {data.bill_number} - {vendor.name}",
-            journal_lines,
+            convert_lines(journal_lines, doc_rate),
             source_type="bill",
             source_id=bill.id,
             class_id=bill.class_id,

--- a/app/routes/fx.py
+++ b/app/routes/fx.py
@@ -1,0 +1,32 @@
+# ============================================================================
+# FX rates — thin wrapper over the Bank of Canada Valet fetcher so the
+# SPA can prefill exchange-rate fields on foreign-currency documents.
+# ============================================================================
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.services.currency import home_currency
+from app.services.fx_service import get_rate
+
+router = APIRouter(prefix="/api/fx", tags=["fx"])
+
+
+@router.get("/rate")
+def fx_rate(from_currency: str, to_currency: str = None, db: Session = Depends(get_db)):
+    """Latest available rate from one currency to another (default: home).
+
+    Degrades gracefully: rate is null when the feed can't provide one,
+    and the UI asks the operator for an explicit rate instead.
+    """
+    target = to_currency or home_currency(db)
+    result = get_rate(from_currency, target)
+    return {
+        "from_currency": (from_currency or "").upper(),
+        "to_currency": target.upper(),
+        "rate": str(result["rate"]) if result.get("rate") else None,
+        "observation_date": result.get("observation_date"),
+        "source": result.get("source"),
+        "error": result.get("error"),
+    }

--- a/app/routes/invoices/crud.py
+++ b/app/routes/invoices/crud.py
@@ -108,10 +108,16 @@ def create_invoice(data: InvoiceCreate, db: Session = Depends(get_db)):
     # MAX+1 (no row-level lock), so two concurrent creates can both compute
     # the same number and one will hit the invoices.invoice_number UNIQUE
     # constraint at flush. The constraint is the safety net; this is the UX.
+    from app.services.currency import convert_lines, resolve_rate
+
+    doc_currency, doc_rate = resolve_rate(db, data.currency, data.exchange_rate)
+
     for _ in range(10):
         invoice_number = next_invoice_number(db)
         invoice = Invoice(
             invoice_number=invoice_number,
+            currency=doc_currency,
+            exchange_rate=doc_rate,
             customer_id=cust_id,
             date=data.date,
             due_date=due_date,
@@ -214,7 +220,7 @@ def create_invoice(data: InvoiceCreate, db: Session = Depends(get_db)):
             db,
             data.date,
             f"Invoice #{invoice_number} - {cust_name}",
-            journal_lines,
+            convert_lines(journal_lines, doc_rate),
             source_type="invoice",
             source_id=invoice.id,
             class_id=invoice.class_id,

--- a/app/routes/payments.py
+++ b/app/routes/payments.py
@@ -73,6 +73,15 @@ def create_payment(data: PaymentCreate, db: Session = Depends(get_db)):
     # Reject non-positive amounts at the boundary; otherwise create_journal_entry
     # raises ValueError on the AR/bank line, which the framework surfaces as a
     # 500. Refunds belong in a credit memo, not a negative-amount payment.
+    from app.services.currency import (
+        document_currency,
+        fx_gain_loss_account_id,
+        resolve_rate,
+        to_home,
+    )
+
+    pay_currency, pay_rate = resolve_rate(db, data.currency, data.exchange_rate)
+
     if data.amount <= 0:
         raise HTTPException(
             status_code=400,
@@ -91,6 +100,8 @@ def create_payment(data: PaymentCreate, db: Session = Depends(get_db)):
 
     payment = Payment(
         customer_id=data.customer_id,
+        currency=pay_currency,
+        exchange_rate=pay_rate,
         date=data.date,
         amount=data.amount,
         method=data.method,
@@ -102,6 +113,9 @@ def create_payment(data: PaymentCreate, db: Session = Depends(get_db)):
     db.add(payment)
     db.flush()
 
+    # Home-currency value of A/R relieved per allocation (at each
+    # invoice's booked rate) — the FX gain/loss basis.
+    ar_home_credits: list[Decimal] = []
     # Apply allocations to invoices
     for alloc_data in data.allocations:
         # Lock the invoice row for the read-check-write so two concurrent
@@ -124,6 +138,19 @@ def create_payment(data: PaymentCreate, db: Session = Depends(get_db)):
                 detail=f"Allocation {alloc_data.amount} exceeds invoice {invoice.invoice_number} balance {invoice.balance_due}",
             )
 
+        inv_currency = document_currency(invoice, db)
+        if inv_currency != pay_currency:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Payment currency {pay_currency} does not match invoice "
+                    f"{invoice.invoice_number} currency {inv_currency}; pay each "
+                    f"currency with a separate payment"
+                ),
+            )
+        ar_home_credits.append(
+            to_home(alloc_data.amount, invoice.exchange_rate or Decimal("1"))
+        )
         alloc = PaymentAllocation(
             payment_id=payment.id,
             invoice_id=alloc_data.invoice_id,
@@ -153,20 +180,40 @@ def create_payment(data: PaymentCreate, db: Session = Depends(get_db)):
     deposit_id = payment.deposit_to_account_id or get_undeposited_funds_id(db)
 
     if ar_id and deposit_id:
+        # Cash received, in home currency at the payment-date rate.
+        cash_home = to_home(data.amount, pay_rate)
+        # A/R relieved at each invoice's BOOKED rate; any unallocated
+        # remainder (a prepayment credit) has no booking rate yet, so it
+        # relieves at the payment rate.
+        unallocated = Decimal(str(data.amount)) - Decimal(str(alloc_total))
+        ar_home = sum(ar_home_credits, Decimal("0")) + to_home(unallocated, pay_rate)
         journal_lines = [
             {
                 "account_id": deposit_id,
-                "debit": Decimal(str(data.amount)),
+                "debit": cash_home,
                 "credit": Decimal("0"),
                 "description": f"Payment from {customer.name}",
             },
             {
                 "account_id": ar_id,
                 "debit": Decimal("0"),
-                "credit": Decimal(str(data.amount)),
+                "credit": ar_home,
                 "description": f"Payment from {customer.name}",
             },
         ]
+        # Realized FX: cash settled at a different rate than the invoice
+        # was booked at. Credit = gain, debit = loss (expense account).
+        residual = cash_home - ar_home
+        if residual != 0:
+            fx_id = fx_gain_loss_account_id(db)
+            journal_lines.append(
+                {
+                    "account_id": fx_id,
+                    "debit": -residual if residual < 0 else Decimal("0"),
+                    "credit": residual if residual > 0 else Decimal("0"),
+                    "description": f"Realized FX on payment from {customer.name}",
+                }
+            )
         txn = create_journal_entry(
             db,
             data.date,

--- a/app/routes/provider_payments.py
+++ b/app/routes/provider_payments.py
@@ -76,6 +76,16 @@ def create_checkout(
         raise HTTPException(status_code=400, detail="Invoice is already paid or void")
     if invoice.balance_due <= 0:
         raise HTTPException(status_code=400, detail="No balance due")
+    from app.services.currency import document_currency, home_currency
+
+    if document_currency(invoice, db) != home_currency(db):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Online checkout is only available for home-currency invoices; "
+                "record this payment manually"
+            ),
+        )
 
     base_url = str(request.base_url).rstrip("/")
     checkout = provider.create_checkout(invoice, settings, base_url)

--- a/app/schemas/bills.py
+++ b/app/schemas/bills.py
@@ -43,6 +43,8 @@ class BillCreate(BaseModel):
     tax_rate: float = 0
     notes: Optional[str] = None
     class_id: Optional[int] = None
+    currency: Optional[str] = None
+    exchange_rate: Optional[Decimal] = None
     lines: list[BillLineCreate] = []
 
     @field_validator("lines")
@@ -62,6 +64,8 @@ class BillUpdate(BaseModel):
     tax_rate: Optional[float] = None
     notes: Optional[str] = None
     class_id: Optional[int] = None
+    currency: Optional[str] = None
+    exchange_rate: Optional[Decimal] = None
     lines: Optional[list[BillLineCreate]] = None
 
 
@@ -84,6 +88,8 @@ class BillResponse(BaseModel):
     balance_due: Decimal = Decimal("0")
     notes: Optional[str] = None
     class_id: Optional[int] = None
+    currency: Optional[str] = None
+    exchange_rate: Optional[Decimal] = None
     lines: list[BillLineResponse] = []
     created_at: Optional[datetime] = None
     model_config = {"from_attributes": True}
@@ -103,6 +109,8 @@ class BillPaymentCreate(BaseModel):
     pay_from_account_id: Optional[int] = None
     notes: Optional[str] = None
     class_id: Optional[int] = None
+    currency: Optional[str] = None
+    exchange_rate: Optional[Decimal] = None
     allocations: list[BillPaymentAllocationCreate] = []
 
 
@@ -116,6 +124,8 @@ class BillPaymentResponse(BaseModel):
     check_number: Optional[str] = None
     notes: Optional[str] = None
     class_id: Optional[int] = None
+    currency: Optional[str] = None
+    exchange_rate: Optional[Decimal] = None
     is_voided: bool = False
     created_at: Optional[datetime] = None
     model_config = {"from_attributes": True}

--- a/app/schemas/invoices.py
+++ b/app/schemas/invoices.py
@@ -55,6 +55,8 @@ class InvoiceCreate(BaseModel):
     tax_rate: Decimal = Decimal("0")
     notes: Optional[str] = None
     class_id: Optional[int] = None
+    currency: Optional[str] = None
+    exchange_rate: Optional[Decimal] = None
     lines: list[InvoiceLineCreate] = []
 
     @field_validator("lines")
@@ -75,6 +77,8 @@ class InvoiceUpdate(BaseModel):
     tax_rate: Optional[Decimal] = None
     notes: Optional[str] = None
     class_id: Optional[int] = None
+    currency: Optional[str] = None
+    exchange_rate: Optional[Decimal] = None
     lines: Optional[list[InvoiceLineCreate]] = None
 
 
@@ -105,6 +109,8 @@ class InvoiceResponse(BaseModel):
     balance_due: Decimal
     notes: Optional[str]
     class_id: Optional[int] = None
+    currency: Optional[str] = None
+    exchange_rate: Optional[Decimal] = None
     payment_token: Optional[str] = None
     checkout_provider: Optional[str] = None
     lines: list[InvoiceLineResponse] = []

--- a/app/schemas/payments.py
+++ b/app/schemas/payments.py
@@ -27,6 +27,8 @@ class PaymentCreate(BaseModel):
     reference: Optional[str] = None
     deposit_to_account_id: Optional[int] = None
     notes: Optional[str] = None
+    currency: Optional[str] = None
+    exchange_rate: Optional[Decimal] = None
     allocations: list[PaymentAllocationCreate] = []
 
 

--- a/app/services/currency.py
+++ b/app/services/currency.py
@@ -1,0 +1,119 @@
+# ============================================================================
+# Multi-currency helpers.
+#
+# Design: the GENERAL LEDGER is single-currency (the home currency from
+# settings). Foreign-currency documents store their own currency + the
+# exchange rate they were booked at; every journal line they post is
+# converted to home currency at that rate. This keeps every existing GL
+# invariant (books balance, void symmetry, report math) untouched — the
+# dimension lives on documents, not on ledger lines.
+#
+# Realized FX gain/loss appears when cash settles at a different rate
+# than the document was booked at (customer payments). It posts to a
+# dedicated expense account (get-or-create, number 6999) — a debit there
+# is a loss, a credit a gain.
+# ============================================================================
+
+from decimal import Decimal
+from typing import Optional
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.models.accounts import Account, AccountType
+from app.services.accounting import _q
+from app.services.settings_service import get_all_settings
+
+FX_ACCOUNT_NUMBER = "6999"
+FX_ACCOUNT_NAME = "Exchange Gain/Loss"
+
+
+def home_currency(db: Session) -> str:
+    return (get_all_settings(db).get("home_currency") or "USD").upper()
+
+
+def resolve_rate(
+    db: Session, currency: Optional[str], provided_rate: Optional[Decimal]
+) -> tuple[str, Decimal]:
+    """Normalize a document's (currency, exchange_rate) pair.
+
+    Home-currency documents always get rate 1. Foreign documents use the
+    operator-provided rate when given; otherwise the Bank of Canada feed
+    is consulted, and if no rate is available the request fails with a
+    400 asking for an explicit rate — silently booking at 1.0 would
+    corrupt the ledger.
+    """
+    home = home_currency(db)
+    code = (currency or home).upper()
+    if code == home:
+        return code, Decimal("1")
+    if provided_rate is not None:
+        rate = Decimal(str(provided_rate))
+        if rate <= 0:
+            raise HTTPException(status_code=400, detail="Exchange rate must be > 0")
+        return code, rate
+    from app.services.fx_service import get_rate
+
+    result = get_rate(code, home)
+    if result.get("rate"):
+        return code, result["rate"]
+    raise HTTPException(
+        status_code=400,
+        detail=(
+            f"No exchange rate available for {code}->{home}; "
+            f"supply exchange_rate explicitly"
+        ),
+    )
+
+
+def to_home(amount, rate: Decimal) -> Decimal:
+    return _q(Decimal(str(amount)) * rate)
+
+
+def convert_lines(lines: list[dict], rate: Decimal) -> list[dict]:
+    """Convert journal lines to home currency at `rate`, preserving balance.
+
+    Each line is quantized independently, so rounding can drift a cent or
+    two between total debits and credits; the residual lands on the
+    largest line to keep the entry balanced (the same
+    quantize-at-the-boundary convention as everywhere else).
+    """
+    if rate == 1:
+        return lines
+    converted = []
+    for line in lines:
+        converted.append(
+            {
+                **line,
+                "debit": to_home(line.get("debit", 0), rate),
+                "credit": to_home(line.get("credit", 0), rate),
+            }
+        )
+    drift = sum(ln["debit"] for ln in converted) - sum(ln["credit"] for ln in converted)
+    if drift != 0:
+        target = max(converted, key=lambda ln: max(ln["debit"], ln["credit"]))
+        if target["debit"] > 0:
+            target["debit"] -= drift
+        else:
+            target["credit"] += drift
+    return converted
+
+
+def fx_gain_loss_account_id(db: Session) -> int:
+    acct = db.query(Account).filter(Account.account_number == FX_ACCOUNT_NUMBER).first()
+    if not acct:
+        acct = db.query(Account).filter(Account.name == FX_ACCOUNT_NAME).first()
+    if not acct:
+        acct = Account(
+            name=FX_ACCOUNT_NAME,
+            account_number=FX_ACCOUNT_NUMBER,
+            account_type=AccountType.EXPENSE,
+            is_system=True,
+        )
+        db.add(acct)
+        db.flush()
+    return acct.id
+
+
+def document_currency(doc, db: Session) -> str:
+    return (getattr(doc, "currency", None) or home_currency(db)).upper()

--- a/app/services/fx_service.py
+++ b/app/services/fx_service.py
@@ -1,0 +1,118 @@
+"""Bank of Canada Valet FX rate fetcher.
+
+BoC publishes daily noon-rate observations via the public Valet API:
+    https://www.bankofcanada.ca/valet/observations/FX{FROM}{TO}/json?recent=1
+
+Historically BoC only publishes pairs where one leg is CAD (FXUSDCAD,
+FXEURCAD, etc.). For pairs that don't include CAD, we cross-rate via CAD:
+    rate(EUR -> USD) = rate(EUR -> CAD) / rate(USD -> CAD)
+
+All failures (timeouts, 404s, missing observations, JSON shape changes)
+return a result with rate=None so the API layer can degrade gracefully
+without raising — the frontend falls back to 1.0 with a notice.
+"""
+
+import json
+import urllib.request
+import urllib.error
+from decimal import Decimal
+from typing import Optional
+
+VALET_BASE = "https://www.bankofcanada.ca/valet/observations"
+TIMEOUT_SECONDS = 5
+
+
+def _fetch_direct(from_code: str, to_code: str) -> Optional[dict]:
+    """Try a direct BoC series like FXUSDCAD. Returns dict or None on any failure."""
+    series = f"FX{from_code}{to_code}"
+    url = f"{VALET_BASE}/{series}/json?recent=1"
+    try:
+        req = urllib.request.Request(
+            url, headers={"User-Agent": "SlowBooks-Pro-2026/1.0"}
+        )
+        with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as resp:
+            if resp.status != 200:
+                return None
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (
+        urllib.error.URLError,
+        urllib.error.HTTPError,
+        TimeoutError,
+        json.JSONDecodeError,
+        OSError,
+    ):
+        return None
+
+    observations = payload.get("observations") or []
+    if not observations:
+        return None
+    obs = observations[-1]
+    date = obs.get("d")
+    cell = obs.get(series) or {}
+    raw = cell.get("v")
+    if raw in (None, ""):
+        return None
+    try:
+        rate = Decimal(str(raw))
+    except Exception:
+        return None
+    return {"rate": rate, "observation_date": date, "series": series}
+
+
+def get_rate(from_code: str, to_code: str) -> dict:
+    """Resolve a rate from `from_code` to `to_code`. Same currency = 1.
+
+    Tries the direct BoC series, then a CAD cross-rate. Returns:
+        {"rate": Decimal | None, "observation_date": str | None,
+         "source": "bankofcanada-direct" | "bankofcanada-cross" | None,
+         "error": str | None}
+    """
+    f = (from_code or "").upper()
+    t = (to_code or "").upper()
+    if not f or not t:
+        return {
+            "rate": None,
+            "observation_date": None,
+            "source": None,
+            "error": "missing currency code",
+        }
+    if f == t:
+        return {
+            "rate": Decimal("1"),
+            "observation_date": None,
+            "source": "identity",
+            "error": None,
+        }
+
+    direct = _fetch_direct(f, t)
+    if direct:
+        return {
+            "rate": direct["rate"],
+            "observation_date": direct["observation_date"],
+            "source": "bankofcanada-direct",
+            "error": None,
+        }
+
+    # Cross via CAD: rate(F -> T) = rate(F -> CAD) / rate(T -> CAD)
+    if f != "CAD" and t != "CAD":
+        leg1 = _fetch_direct(f, "CAD")
+        leg2 = _fetch_direct(t, "CAD")
+        if leg1 and leg2 and leg2["rate"] != 0:
+            cross = (leg1["rate"] / leg2["rate"]).quantize(Decimal("0.00000001"))
+            obs = (
+                min(leg1["observation_date"] or "", leg2["observation_date"] or "")
+                or None
+            )
+            return {
+                "rate": cross,
+                "observation_date": obs,
+                "source": "bankofcanada-cross",
+                "error": None,
+            }
+
+    return {
+        "rate": None,
+        "observation_date": None,
+        "source": None,
+        "error": "rate unavailable",
+    }

--- a/app/static/js/bills.js
+++ b/app/static/js/bills.js
@@ -126,6 +126,7 @@ const BillsPage = {
                                 `<option ${t==='Net 30'?'selected':''}>${t}</option>`).join('')}
                         </select></div>
                     ${classGroup}
+                    ${currencyFormGroupsHtml()}
                 </div>
                 <h3 style="margin:12px 0 8px;font-size:14px;">Line Items</h3>
                 <table class="line-items-table">
@@ -184,6 +185,7 @@ const BillsPage = {
                 terms: form.terms.value,
                 notes: form.notes.value || null,
                 class_id: classIdFromForm(form),
+                ...currencyPayloadFromForm(form),
                 lines,
             });
             toast('Bill saved');

--- a/app/static/js/invoices.js
+++ b/app/static/js/invoices.js
@@ -236,6 +236,7 @@ const InvoicesPage = {
                     <div class="form-group"><label>PO #</label>
                         <input name="po_number" value="${escapeHtml(inv.po_number || '')}"></div>
                     ${classGroup}
+                    ${currencyFormGroupsHtml(inv.currency, inv.exchange_rate)}
                     <div class="form-group"><label>Tax Rate (%)</label>
                         <input name="tax_rate" type="number" step="0.01" value="${(inv.tax_rate * 100) || 0}"
                             oninput="InvoicesPage.recalc()"></div>
@@ -414,6 +415,7 @@ const InvoicesPage = {
             terms: form.terms.value,
             po_number: form.po_number.value || null,
             class_id: classIdFromForm(form),
+            ...currencyPayloadFromForm(form),
             tax_rate: (parseFloat(form.tax_rate.value) || 0) / 100,
             notes: form.notes.value || null,
             lines,

--- a/app/static/js/utils.js
+++ b/app/static/js/utils.js
@@ -274,3 +274,35 @@ function classIdFromForm(form) {
     const v = form.class_id ? form.class_id.value : '';
     return v ? parseInt(v) : null;
 }
+
+// ---------------------------------------------------------------------------
+// Multi-currency: currency + exchange-rate inputs for document forms.
+// Selecting a foreign currency prefills the rate from /api/fx/rate
+// (Bank of Canada feed); the operator can always override.
+// ---------------------------------------------------------------------------
+const CURRENCIES = ['USD', 'CAD', 'EUR', 'GBP', 'AUD', 'JPY', 'CHF', 'MXN', 'INR', 'CNY'];
+
+function currencyFormGroupsHtml(selected, rate) {
+    const sel = (selected || 'USD').toUpperCase();
+    const opts = CURRENCIES.map(c => `<option ${c === sel ? 'selected' : ''}>${c}</option>`).join('');
+    return `<div class="form-group"><label>Currency</label>
+            <select name="currency" onchange="prefillFxRate(this)">${opts}</select></div>
+        <div class="form-group"><label>Exchange Rate</label>
+            <input name="exchange_rate" type="number" step="0.00000001" value="${rate || 1}"></div>`;
+}
+
+async function prefillFxRate(select) {
+    const form = select.closest('form');
+    const rateInput = form?.querySelector('[name=exchange_rate]');
+    if (!rateInput) return;
+    try {
+        const data = await API.get(`/fx/rate?from_currency=${select.value}`);
+        if (data.rate) rateInput.value = data.rate;
+    } catch (e) { /* operator enters the rate manually */ }
+}
+
+function currencyPayloadFromForm(form) {
+    const currency = form.currency ? form.currency.value : null;
+    const rate = form.exchange_rate ? parseFloat(form.exchange_rate.value) : null;
+    return { currency: currency || null, exchange_rate: rate || null };
+}

--- a/migrations/versions/e3f4a5b6c7d8_add_multi_currency.py
+++ b/migrations/versions/e3f4a5b6c7d8_add_multi_currency.py
@@ -1,0 +1,43 @@
+"""add_multi_currency
+
+Currency + booked exchange rate on invoices, bills, and payments; adds
+the home_currency setting default separately (settings are row-based).
+The GL stays home-currency — these columns record what the document was
+denominated in and the rate its journal was converted at.
+
+Revision ID: e3f4a5b6c7d8
+Revises: d2e3f4a5b6c7
+Create Date: 2026-08-01
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "e3f4a5b6c7d8"
+down_revision: Union[str, None] = "d2e3f4a5b6c7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_TABLES = ("invoices", "bills", "payments")
+
+
+def upgrade() -> None:
+    for table in _TABLES:
+        with op.batch_alter_table(table) as batch_op:
+            batch_op.add_column(
+                sa.Column("currency", sa.String(length=3), nullable=True)
+            )
+            batch_op.add_column(
+                sa.Column("exchange_rate", sa.Numeric(18, 8), nullable=True)
+            )
+
+
+def downgrade() -> None:
+    for table in reversed(_TABLES):
+        with op.batch_alter_table(table) as batch_op:
+            batch_op.drop_column("exchange_rate")
+            batch_op.drop_column("currency")

--- a/tests/test_multi_currency.py
+++ b/tests/test_multi_currency.py
@@ -1,0 +1,249 @@
+"""Multi-currency: home-currency GL conversion at booked rates,
+cross-currency payment validation, and realized FX gain/loss."""
+
+from decimal import Decimal
+
+import pytest
+
+from app.models.accounts import Account
+from app.models.transactions import Transaction, TransactionLine
+from app.services.currency import convert_lines
+
+# ── convert_lines ────────────────────────────────────────────────────────
+
+
+def test_convert_lines_balances_after_rounding():
+    lines = [
+        {"account_id": 1, "debit": Decimal("33.33"), "credit": Decimal("0")},
+        {"account_id": 2, "debit": Decimal("33.33"), "credit": Decimal("0")},
+        {"account_id": 3, "debit": Decimal("0"), "credit": Decimal("66.66")},
+    ]
+    converted = convert_lines(lines, Decimal("1.13579"))
+    debit = sum(ln["debit"] for ln in converted)
+    credit = sum(ln["credit"] for ln in converted)
+    assert debit == credit
+
+
+def test_convert_lines_rate_one_is_identity():
+    lines = [{"account_id": 1, "debit": Decimal("5"), "credit": Decimal("0")}]
+    assert convert_lines(lines, Decimal("1")) is lines
+
+
+# ── Foreign invoice posts home-currency GL ───────────────────────────────
+
+
+@pytest.fixture
+def eur_invoice(client, seed_accounts, seed_customer):
+    resp = client.post(
+        "/api/invoices",
+        json={
+            "customer_id": seed_customer.id,
+            "date": "2026-07-01",
+            "currency": "EUR",
+            "exchange_rate": "1.10",
+            "lines": [{"description": "consulting", "quantity": 1, "rate": 100}],
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    return resp.json()
+
+
+def test_foreign_invoice_journal_in_home_currency(eur_invoice, db_session):
+    inv = eur_invoice
+    assert inv["currency"] == "EUR"
+    assert Decimal(str(inv["total"])) == Decimal("100.00")  # document currency
+    txn = (
+        db_session.query(Transaction)
+        .filter(
+            Transaction.source_type == "invoice", Transaction.source_id == inv["id"]
+        )
+        .one()
+    )
+    lines = db_session.query(TransactionLine).filter_by(transaction_id=txn.id).all()
+    debit = sum(ln.debit or 0 for ln in lines)
+    credit = sum(ln.credit or 0 for ln in lines)
+    # GL carries 100 EUR * 1.10 = 110.00 home
+    assert debit == credit == Decimal("110.00")
+
+
+def test_home_invoice_defaults(client, seed_accounts, seed_customer):
+    resp = client.post(
+        "/api/invoices",
+        json={
+            "customer_id": seed_customer.id,
+            "date": "2026-07-01",
+            "lines": [{"description": "x", "quantity": 1, "rate": 50}],
+        },
+    )
+    inv = resp.json()
+    assert inv["currency"] == "USD"
+    assert Decimal(str(inv["exchange_rate"])) == Decimal("1")
+
+
+def test_foreign_invoice_without_rate_and_feed_fails(
+    client, seed_accounts, seed_customer, monkeypatch
+):
+    import app.services.fx_service as fx
+
+    monkeypatch.setattr(
+        fx,
+        "get_rate",
+        lambda f, t: {
+            "rate": None,
+            "observation_date": None,
+            "source": None,
+            "error": "down",
+        },
+    )
+    resp = client.post(
+        "/api/invoices",
+        json={
+            "customer_id": seed_customer.id,
+            "date": "2026-07-01",
+            "currency": "EUR",
+            "lines": [{"description": "x", "quantity": 1, "rate": 10}],
+        },
+    )
+    assert resp.status_code == 400
+    assert "exchange_rate" in resp.json()["detail"]
+
+
+# ── Payments: validation + realized FX ───────────────────────────────────
+
+
+def test_cross_currency_payment_rejected(client, eur_invoice, seed_customer):
+    resp = client.post(
+        "/api/payments",
+        json={
+            "customer_id": seed_customer.id,
+            "date": "2026-07-05",
+            "amount": 100,
+            "currency": "USD",
+            "allocations": [{"invoice_id": eur_invoice["id"], "amount": 100}],
+        },
+    )
+    assert resp.status_code == 400
+    assert "does not match" in resp.json()["detail"]
+
+
+def test_payment_realizes_fx_gain(client, db_session, eur_invoice, seed_customer):
+    """Invoice booked at 1.10; paid at 1.20 → cash 120 home vs A/R 110
+    relieved → 10.00 realized gain (credit on the FX account)."""
+    resp = client.post(
+        "/api/payments",
+        json={
+            "customer_id": seed_customer.id,
+            "date": "2026-07-06",
+            "amount": 100,
+            "currency": "EUR",
+            "exchange_rate": "1.20",
+            "allocations": [{"invoice_id": eur_invoice["id"], "amount": 100}],
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+
+    fx_acct = db_session.query(Account).filter(Account.account_number == "6999").one()
+    txn = (
+        db_session.query(Transaction)
+        .filter(Transaction.source_type == "payment")
+        .order_by(Transaction.id.desc())
+        .first()
+    )
+    lines = db_session.query(TransactionLine).filter_by(transaction_id=txn.id).all()
+    assert sum(ln.debit or 0 for ln in lines) == sum(ln.credit or 0 for ln in lines)
+    fx_lines = [ln for ln in lines if ln.account_id == fx_acct.id]
+    assert len(fx_lines) == 1
+    assert fx_lines[0].credit == Decimal("10.00")  # gain
+
+    # invoice settles in document currency
+    inv = client.get(f"/api/invoices/{eur_invoice['id']}").json()
+    assert inv["status"] == "paid"
+    assert Decimal(str(inv["balance_due"])) == Decimal("0.00")
+
+
+def test_payment_realizes_fx_loss(client, db_session, eur_invoice, seed_customer):
+    resp = client.post(
+        "/api/payments",
+        json={
+            "customer_id": seed_customer.id,
+            "date": "2026-07-06",
+            "amount": 100,
+            "currency": "EUR",
+            "exchange_rate": "1.05",
+            "allocations": [{"invoice_id": eur_invoice["id"], "amount": 100}],
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    fx_acct = db_session.query(Account).filter(Account.account_number == "6999").one()
+    txn = (
+        db_session.query(Transaction)
+        .filter(Transaction.source_type == "payment")
+        .order_by(Transaction.id.desc())
+        .first()
+    )
+    fx_lines = [
+        ln
+        for ln in db_session.query(TransactionLine).filter_by(transaction_id=txn.id)
+        if ln.account_id == fx_acct.id
+    ]
+    assert fx_lines[0].debit == Decimal("5.00")  # loss
+
+
+def test_online_checkout_blocked_for_foreign_invoice(
+    unauthed_client, client, db_session, eur_invoice
+):
+    from app.services.settings_service import set_setting
+
+    set_setting(db_session, "stripe_enabled", "true")
+    set_setting(db_session, "stripe_secret_key", "sk_test_x")
+    db_session.commit()
+    inv = client.get(f"/api/invoices/{eur_invoice['id']}").json()
+    resp = unauthed_client.post(
+        "/api/payments/stripe/create-checkout-session",
+        json={"payment_token": inv["payment_token"]},
+    )
+    assert resp.status_code == 400
+    assert "home-currency" in resp.json()["detail"]
+
+
+# ── Foreign bill ─────────────────────────────────────────────────────────
+
+
+def test_foreign_bill_posts_home_gl(client, db_session, seed_accounts):
+    from app.models.contacts import Vendor
+
+    vendor = Vendor(name="Euro Supplier", is_active=True)
+    db_session.add(vendor)
+    db_session.commit()
+
+    expense = (
+        db_session.query(Account).filter(Account.name == "Office Supplies").first()
+    ) or db_session.query(Account).first()
+    resp = client.post(
+        "/api/bills",
+        json={
+            "vendor_id": vendor.id,
+            "bill_number": "EUR-B1",
+            "date": "2026-07-02",
+            "currency": "EUR",
+            "exchange_rate": "1.10",
+            "lines": [
+                {
+                    "account_id": expense.id,
+                    "description": "supplies",
+                    "quantity": 1,
+                    "rate": 200,
+                }
+            ],
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    bill = resp.json()
+    assert bill["currency"] == "EUR"
+    txn = (
+        db_session.query(Transaction)
+        .filter(Transaction.source_type == "bill", Transaction.source_id == bill["id"])
+        .one()
+    )
+    lines = db_session.query(TransactionLine).filter_by(transaction_id=txn.id).all()
+    assert sum(ln.debit or 0 for ln in lines) == Decimal("220.00")


### PR DESCRIPTION
Multi-currency support, designed from the LayoverLogic fork (Alex Jordan, @LayoverLogic — the FX service is theirs near-verbatim, credited on the commit). Stacked on #26 (class tracking) — merge that first.

## Design: single-currency ledger
The GL stays in the **home currency** (new setting, default USD). Foreign documents store their currency + booked rate and convert every journal line at posting time — so books-balance, void-symmetry, and all report math hold untouched, verified by the full invariant suite.

## What you get
- **Foreign-currency invoices and bills**: pick a currency on the form, the rate prefills from the Bank of Canada feed (`/api/fx/rate`, stdlib-only, CAD cross-rating, degrades gracefully); operator can override. No rate available + none supplied = clear 400, never a silent 1.0 booking.
- **Realized FX gain/loss on customer payments**: cash converts at the payment-date rate, A/R relieves at each invoice's booked rate, and the residual posts to a get-or-create "Exchange Gain/Loss" account (6999). Tested both directions (gain credit, loss debit).
- **Cross-currency guard rails**: payment allocations must match the invoice currency; online checkout (Stripe/PayPal/Square charge USD) rejects foreign invoices with a pointer to manual recording.
- Rounding drift from per-line conversion parks on the largest line so entries always balance (pinned by test).

## Known v1 limitation
Bill payments post at the bill's booked rate — no realized FX on A/P yet (rarely material at indie scale; flagged for follow-up).

## Testing
Full suite **967 passed** (10 new multi-currency tests + invariant trio + void symmetry). Migration `e3f4a5b6c7d8` verified single-head + clean fresh-DB upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)