### PR TITLE
Feature: fixed assets (register + depreciation + disposal)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -66,6 +66,7 @@ from app.routes import uploads
 from app.routes import bank_import, tax, backups
 from app.routes import classes as classes_routes
 from app.routes import fx as fx_routes
+from app.routes import fixed_assets as fixed_assets_routes
 
 # Phase 6: Ambitious
 from app.routes import companies, employees, payroll
@@ -367,6 +368,7 @@ app.include_router(dashboard.router)
 app.include_router(accounts.router)
 app.include_router(classes_routes.router)
 app.include_router(fx_routes.router)
+app.include_router(fixed_assets_routes.router)
 app.include_router(customers.router)
 app.include_router(vendors.router)
 app.include_router(items.router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -8,6 +8,7 @@ from app.models.payments import Payment, PaymentAllocation
 from app.models.banking import BankAccount, BankTransaction, Reconciliation
 from app.models.settings import Settings
 from app.models.classes import TxnClass  # noqa: F401 — registers the table
+from app.models.fixed_assets import FixedAsset, FixedAssetType  # noqa: F401
 
 # Phase 1: Foundation
 from app.models.audit import AuditLog

--- a/app/models/fixed_assets.py
+++ b/app/models/fixed_assets.py
@@ -1,0 +1,102 @@
+# ============================================================================
+# Fixed assets — register + depreciation, designed from the joelmacklow
+# fork's fixed-assets slice (docs/spec-fixed-assets-management.md).
+#
+# Asset types carry the three account mappings (asset, accumulated
+# depreciation, depreciation expense) so the register never hardcodes
+# account numbers. Book value is DERIVED (cost - accumulated), never
+# stored as an editable field. Depreciation history rows are deferred
+# per the spec — runs accumulate onto the asset and post journals.
+# ============================================================================
+
+import enum
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    Date,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class FixedAssetStatus(str, enum.Enum):
+    REGISTERED = "registered"
+    DISPOSED = "disposed"
+
+
+class DepreciationMethod(str, enum.Enum):
+    STRAIGHT_LINE = "straight_line"
+    DECLINING_BALANCE = "declining_balance"
+
+
+class FixedAssetType(Base):
+    __tablename__ = "fixed_asset_types"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(120), unique=True, nullable=False)
+    description = Column(Text, nullable=True)
+    asset_account_id = Column(Integer, ForeignKey("accounts.id"), nullable=True)
+    accumulated_depreciation_account_id = Column(
+        Integer, ForeignKey("accounts.id"), nullable=True
+    )
+    depreciation_expense_account_id = Column(
+        Integer, ForeignKey("accounts.id"), nullable=True
+    )
+    depreciation_method = Column(
+        Enum(DepreciationMethod),
+        nullable=False,
+        default=DepreciationMethod.STRAIGHT_LINE,
+    )
+    # STRAIGHT_LINE uses effective life; DECLINING_BALANCE uses annual rate
+    effective_life_years = Column(Numeric(8, 2), nullable=True)
+    annual_rate = Column(Numeric(8, 4), nullable=True)  # e.g. 0.2000 = 20%/yr
+    is_active = Column(Boolean, nullable=False, default=True)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    assets = relationship("FixedAsset", back_populates="asset_type")
+
+
+class FixedAsset(Base):
+    __tablename__ = "fixed_assets"
+
+    id = Column(Integer, primary_key=True, index=True)
+    asset_number = Column(String(40), unique=True, nullable=False)
+    name = Column(String(200), nullable=False)
+    asset_type_id = Column(
+        Integer, ForeignKey("fixed_asset_types.id"), nullable=False, index=True
+    )
+    status = Column(
+        Enum(FixedAssetStatus), nullable=False, default=FixedAssetStatus.REGISTERED
+    )
+    purchase_date = Column(Date, nullable=False)
+    purchase_price = Column(Numeric(12, 2), nullable=False, default=0)
+    salvage_value = Column(Numeric(12, 2), nullable=False, default=0)
+    description = Column(Text, nullable=True)
+
+    # Maintained by depreciation runs / disposal — never edited directly.
+    accumulated_depreciation = Column(Numeric(12, 2), nullable=False, default=0)
+    last_depreciation_date = Column(Date, nullable=True)
+
+    disposal_date = Column(Date, nullable=True)
+    disposal_proceeds = Column(Numeric(12, 2), nullable=True)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    asset_type = relationship("FixedAssetType", back_populates="assets")

--- a/app/routes/fixed_assets.py
+++ b/app/routes/fixed_assets.py
@@ -1,0 +1,251 @@
+# ============================================================================
+# Fixed assets — types, register, depreciation runs, disposal, CSV import,
+# and the reconciliation report.
+# ============================================================================
+
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.fixed_assets import (
+    DepreciationMethod,
+    FixedAsset,
+    FixedAssetStatus,
+    FixedAssetType,
+)
+from app.services.fixed_assets import (
+    book_value,
+    dispose_asset,
+    import_assets_csv,
+    next_asset_number,
+    run_depreciation,
+)
+from app.services.upload_limits import read_limited
+
+router = APIRouter(prefix="/api/fixed-assets", tags=["fixed_assets"])
+
+
+# ── Schemas ──────────────────────────────────────────────────────────────
+
+
+class AssetTypeCreate(BaseModel):
+    name: str
+    description: Optional[str] = None
+    asset_account_id: Optional[int] = None
+    accumulated_depreciation_account_id: Optional[int] = None
+    depreciation_expense_account_id: Optional[int] = None
+    depreciation_method: DepreciationMethod = DepreciationMethod.STRAIGHT_LINE
+    effective_life_years: Optional[Decimal] = None
+    annual_rate: Optional[Decimal] = None
+
+
+class AssetTypeUpdate(AssetTypeCreate):
+    name: Optional[str] = None
+    is_active: Optional[bool] = None
+    depreciation_method: Optional[DepreciationMethod] = None
+
+
+class AssetCreate(BaseModel):
+    name: str
+    asset_type_id: int
+    purchase_date: date
+    purchase_price: Decimal
+    salvage_value: Decimal = Decimal("0")
+    description: Optional[str] = None
+
+
+class AssetUpdate(BaseModel):
+    name: Optional[str] = None
+    asset_type_id: Optional[int] = None
+    purchase_date: Optional[date] = None
+    purchase_price: Optional[Decimal] = None
+    salvage_value: Optional[Decimal] = None
+    description: Optional[str] = None
+
+
+class DepreciationRunRequest(BaseModel):
+    run_date: date
+
+
+class DisposalRequest(BaseModel):
+    disposal_date: date
+    proceeds: Decimal = Decimal("0")
+    deposit_account_id: int
+
+
+def _type_payload(t: FixedAssetType) -> dict:
+    return {
+        "id": t.id,
+        "name": t.name,
+        "description": t.description,
+        "asset_account_id": t.asset_account_id,
+        "accumulated_depreciation_account_id": t.accumulated_depreciation_account_id,
+        "depreciation_expense_account_id": t.depreciation_expense_account_id,
+        "depreciation_method": t.depreciation_method.value,
+        "effective_life_years": (
+            float(t.effective_life_years) if t.effective_life_years else None
+        ),
+        "annual_rate": float(t.annual_rate) if t.annual_rate else None,
+        "is_active": t.is_active,
+    }
+
+
+def _asset_payload(a: FixedAsset) -> dict:
+    return {
+        "id": a.id,
+        "asset_number": a.asset_number,
+        "name": a.name,
+        "asset_type_id": a.asset_type_id,
+        "asset_type_name": a.asset_type.name if a.asset_type else None,
+        "status": a.status.value,
+        "purchase_date": a.purchase_date.isoformat(),
+        "purchase_price": float(a.purchase_price),
+        "salvage_value": float(a.salvage_value or 0),
+        "accumulated_depreciation": float(a.accumulated_depreciation or 0),
+        "book_value": float(book_value(a)),
+        "last_depreciation_date": (
+            a.last_depreciation_date.isoformat() if a.last_depreciation_date else None
+        ),
+        "disposal_date": a.disposal_date.isoformat() if a.disposal_date else None,
+        "disposal_proceeds": (
+            float(a.disposal_proceeds) if a.disposal_proceeds is not None else None
+        ),
+        "description": a.description,
+    }
+
+
+# ── Asset types ──────────────────────────────────────────────────────────
+
+
+@router.get("/types")
+def list_types(include_inactive: bool = False, db: Session = Depends(get_db)):
+    q = db.query(FixedAssetType)
+    if not include_inactive:
+        q = q.filter(FixedAssetType.is_active.is_(True))
+    return [_type_payload(t) for t in q.order_by(FixedAssetType.name).all()]
+
+
+@router.post("/types", status_code=201)
+def create_type(data: AssetTypeCreate, db: Session = Depends(get_db)):
+    if db.query(FixedAssetType).filter(FixedAssetType.name == data.name).first():
+        raise HTTPException(status_code=409, detail="Asset type already exists")
+    row = FixedAssetType(**data.model_dump())
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return _type_payload(row)
+
+
+@router.put("/types/{type_id}")
+def update_type(type_id: int, data: AssetTypeUpdate, db: Session = Depends(get_db)):
+    row = db.get(FixedAssetType, type_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Asset type not found")
+    for key, value in data.model_dump(exclude_unset=True).items():
+        setattr(row, key, value)
+    db.commit()
+    db.refresh(row)
+    return _type_payload(row)
+
+
+# ── Assets ───────────────────────────────────────────────────────────────
+
+
+@router.get("")
+def list_assets(include_disposed: bool = True, db: Session = Depends(get_db)):
+    q = db.query(FixedAsset)
+    if not include_disposed:
+        q = q.filter(FixedAsset.status == FixedAssetStatus.REGISTERED)
+    return [_asset_payload(a) for a in q.order_by(FixedAsset.asset_number).all()]
+
+
+@router.get("/{asset_id}")
+def get_asset(asset_id: int, db: Session = Depends(get_db)):
+    asset = db.get(FixedAsset, asset_id)
+    if not asset:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    return _asset_payload(asset)
+
+
+@router.post("", status_code=201)
+def create_asset(data: AssetCreate, db: Session = Depends(get_db)):
+    if not db.get(FixedAssetType, data.asset_type_id):
+        raise HTTPException(status_code=404, detail="Asset type not found")
+    asset = FixedAsset(asset_number=next_asset_number(db), **data.model_dump())
+    db.add(asset)
+    db.commit()
+    db.refresh(asset)
+    return _asset_payload(asset)
+
+
+@router.put("/{asset_id}")
+def update_asset(asset_id: int, data: AssetUpdate, db: Session = Depends(get_db)):
+    asset = db.get(FixedAsset, asset_id)
+    if not asset:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    if asset.status == FixedAssetStatus.DISPOSED:
+        raise HTTPException(status_code=400, detail="Disposed assets are read-only")
+    for key, value in data.model_dump(exclude_unset=True).items():
+        setattr(asset, key, value)
+    db.commit()
+    db.refresh(asset)
+    return _asset_payload(asset)
+
+
+# ── Operations ───────────────────────────────────────────────────────────
+
+
+@router.post("/run-depreciation")
+def depreciation_run(data: DepreciationRunRequest, db: Session = Depends(get_db)):
+    return run_depreciation(db, data.run_date)
+
+
+@router.post("/{asset_id}/dispose")
+def dispose(asset_id: int, data: DisposalRequest, db: Session = Depends(get_db)):
+    asset = db.get(FixedAsset, asset_id)
+    if not asset:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    return dispose_asset(
+        db, asset, data.disposal_date, data.proceeds, data.deposit_account_id
+    )
+
+
+@router.post("/import-csv")
+async def import_csv(file: UploadFile = File(...), db: Session = Depends(get_db)):
+    content = await read_limited(file, label="Asset CSV")
+    try:
+        text = content.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        text = content.decode("latin-1")
+    return import_assets_csv(db, text)
+
+
+@router.get("/reports/reconciliation")
+def reconciliation(db: Session = Depends(get_db)):
+    """Fixed Asset Reconciliation: register totals per type (cost,
+    accumulated, book value) — compare against the mapped GL accounts."""
+    rows = []
+    for t in db.query(FixedAssetType).order_by(FixedAssetType.name).all():
+        assets = [a for a in t.assets if a.status == FixedAssetStatus.REGISTERED]
+        cost = sum(Decimal(str(a.purchase_price)) for a in assets)
+        accum = sum(Decimal(str(a.accumulated_depreciation or 0)) for a in assets)
+        rows.append(
+            {
+                "asset_type": t.name,
+                "asset_count": len(assets),
+                "cost": float(cost),
+                "accumulated_depreciation": float(accum),
+                "book_value": float(cost - accum),
+            }
+        )
+    return {
+        "types": rows,
+        "total_cost": sum(r["cost"] for r in rows),
+        "total_accumulated": sum(r["accumulated_depreciation"] for r in rows),
+        "total_book_value": sum(r["book_value"] for r in rows),
+    }

--- a/app/services/fixed_assets.py
+++ b/app/services/fixed_assets.py
@@ -1,0 +1,317 @@
+# ============================================================================
+# Fixed assets service — depreciation math, disposal, CSV import.
+#
+# Depreciation runs are month-granular: a run covers the FULL months
+# between the asset's depreciation start (purchase date, or the day
+# after the last run) and the run date. Straight-line spreads
+# (cost - salvage) over the effective life; declining-balance applies
+# the annual rate to current book value. Both cap so book value never
+# drops below salvage.
+# ============================================================================
+
+import csv
+import io
+import logging
+from datetime import date
+from decimal import Decimal
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.models.accounts import Account, AccountType
+from app.models.fixed_assets import (
+    DepreciationMethod,
+    FixedAsset,
+    FixedAssetStatus,
+    FixedAssetType,
+)
+from app.services.accounting import _q, create_journal_entry
+
+logger = logging.getLogger(__name__)
+
+DISPOSAL_ACCOUNT_NUMBER = "7999"
+DISPOSAL_ACCOUNT_NAME = "Gain/Loss on Asset Disposal"
+
+
+def book_value(asset: FixedAsset) -> Decimal:
+    return _q(
+        Decimal(str(asset.purchase_price))
+        - Decimal(str(asset.accumulated_depreciation or 0))
+    )
+
+
+def next_asset_number(db: Session) -> str:
+    count = db.query(FixedAsset).count()
+    candidate = count + 1
+    while True:
+        number = f"FA-{candidate:04d}"
+        if not db.query(FixedAsset).filter(FixedAsset.asset_number == number).first():
+            return number
+        candidate += 1
+
+
+def _require_type_accounts(asset_type: FixedAssetType):
+    missing = [
+        label
+        for label, value in (
+            (
+                "accumulated depreciation",
+                asset_type.accumulated_depreciation_account_id,
+            ),
+            ("depreciation expense", asset_type.depreciation_expense_account_id),
+        )
+        if not value
+    ]
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Asset type '{asset_type.name}' is missing account mappings: "
+                f"{', '.join(missing)}"
+            ),
+        )
+
+
+def _full_months_between(start: date, end: date) -> int:
+    """Whole calendar months from `start` to `end` (0 when < 1 month)."""
+    if end <= start:
+        return 0
+    months = (end.year - start.year) * 12 + (end.month - start.month)
+    if end.day < start.day:
+        months -= 1
+    return max(0, months)
+
+
+def period_depreciation(asset: FixedAsset, run_date: date) -> Decimal:
+    """Depreciation to post for the period ending run_date."""
+    if asset.status != FixedAssetStatus.REGISTERED:
+        return Decimal("0")
+    start = asset.last_depreciation_date or asset.purchase_date
+    months = _full_months_between(start, run_date)
+    if months <= 0:
+        return Decimal("0")
+
+    cost = Decimal(str(asset.purchase_price))
+    salvage = Decimal(str(asset.salvage_value or 0))
+    depreciable_remaining = book_value(asset) - salvage
+    if depreciable_remaining <= 0:
+        return Decimal("0")
+
+    atype = asset.asset_type
+    if atype.depreciation_method == DepreciationMethod.STRAIGHT_LINE:
+        life = Decimal(str(atype.effective_life_years or 0))
+        if life <= 0:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Asset type '{atype.name}' has no effective life set",
+            )
+        monthly = (cost - salvage) / (life * 12)
+    else:
+        rate = Decimal(str(atype.annual_rate or 0))
+        if rate <= 0:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Asset type '{atype.name}' has no annual rate set",
+            )
+        monthly = book_value(asset) * rate / 12
+
+    amount = _q(monthly * months)
+    return min(amount, _q(depreciable_remaining))
+
+
+def run_depreciation(db: Session, run_date: date) -> dict:
+    """Post depreciation for every registered asset up to run_date.
+
+    One journal entry per asset (DR depreciation expense / CR accumulated
+    depreciation) so drill-down stays per-asset. Assets with nothing to
+    post (fully depreciated, < 1 month elapsed) are skipped and counted.
+    """
+    assets = (
+        db.query(FixedAsset)
+        .filter(FixedAsset.status == FixedAssetStatus.REGISTERED)
+        .all()
+    )
+    posted = 0
+    skipped = 0
+    total = Decimal("0")
+    for asset in assets:
+        amount = period_depreciation(asset, run_date)
+        if amount <= 0:
+            skipped += 1
+            continue
+        atype = asset.asset_type
+        _require_type_accounts(atype)
+        create_journal_entry(
+            db,
+            run_date,
+            f"Depreciation — {asset.asset_number} {asset.name}",
+            [
+                {
+                    "account_id": atype.depreciation_expense_account_id,
+                    "debit": amount,
+                    "credit": Decimal("0"),
+                    "description": f"Depreciation {asset.asset_number}",
+                },
+                {
+                    "account_id": atype.accumulated_depreciation_account_id,
+                    "debit": Decimal("0"),
+                    "credit": amount,
+                    "description": f"Accumulated depreciation {asset.asset_number}",
+                },
+            ],
+            source_type="depreciation",
+            source_id=asset.id,
+        )
+        asset.accumulated_depreciation = _q(
+            Decimal(str(asset.accumulated_depreciation or 0)) + amount
+        )
+        asset.last_depreciation_date = run_date
+        posted += 1
+        total += amount
+    db.commit()
+    return {"posted": posted, "skipped": skipped, "total": float(_q(total))}
+
+
+def _disposal_account_id(db: Session) -> int:
+    acct = (
+        db.query(Account)
+        .filter(Account.account_number == DISPOSAL_ACCOUNT_NUMBER)
+        .first()
+    ) or db.query(Account).filter(Account.name == DISPOSAL_ACCOUNT_NAME).first()
+    if not acct:
+        acct = Account(
+            name=DISPOSAL_ACCOUNT_NAME,
+            account_number=DISPOSAL_ACCOUNT_NUMBER,
+            account_type=AccountType.EXPENSE,
+            is_system=True,
+        )
+        db.add(acct)
+        db.flush()
+    return acct.id
+
+
+def dispose_asset(
+    db: Session,
+    asset: FixedAsset,
+    disposal_date: date,
+    proceeds: Decimal,
+    deposit_account_id: int,
+) -> dict:
+    """Sell/dispose: derecognize cost + accumulated, book proceeds, and
+    post the residual as gain (credit) or loss (debit) on disposal."""
+    if asset.status == FixedAssetStatus.DISPOSED:
+        raise HTTPException(status_code=400, detail="Asset is already disposed")
+    atype = asset.asset_type
+    if not atype.asset_account_id:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Asset type '{atype.name}' has no fixed-asset account mapped",
+        )
+    _require_type_accounts(atype)
+
+    cost = _q(Decimal(str(asset.purchase_price)))
+    accumulated = _q(Decimal(str(asset.accumulated_depreciation or 0)))
+    proceeds = _q(Decimal(str(proceeds or 0)))
+
+    lines = []
+    if proceeds > 0:
+        lines.append(
+            {
+                "account_id": deposit_account_id,
+                "debit": proceeds,
+                "credit": Decimal("0"),
+                "description": f"Disposal proceeds {asset.asset_number}",
+            }
+        )
+    if accumulated > 0:
+        lines.append(
+            {
+                "account_id": atype.accumulated_depreciation_account_id,
+                "debit": accumulated,
+                "credit": Decimal("0"),
+                "description": f"Derecognize accumulated {asset.asset_number}",
+            }
+        )
+    lines.append(
+        {
+            "account_id": atype.asset_account_id,
+            "debit": Decimal("0"),
+            "credit": cost,
+            "description": f"Derecognize cost {asset.asset_number}",
+        }
+    )
+    residual = proceeds + accumulated - cost  # >0 gain, <0 loss
+    if residual != 0:
+        lines.append(
+            {
+                "account_id": _disposal_account_id(db),
+                "debit": -residual if residual < 0 else Decimal("0"),
+                "credit": residual if residual > 0 else Decimal("0"),
+                "description": f"{'Gain' if residual > 0 else 'Loss'} on disposal {asset.asset_number}",
+            }
+        )
+    txn = create_journal_entry(
+        db,
+        disposal_date,
+        f"Disposal — {asset.asset_number} {asset.name}",
+        lines,
+        source_type="asset_disposal",
+        source_id=asset.id,
+    )
+    asset.status = FixedAssetStatus.DISPOSED
+    asset.disposal_date = disposal_date
+    asset.disposal_proceeds = proceeds
+    db.commit()
+    return {
+        "transaction_id": txn.id,
+        "gain_loss": float(_q(residual)),
+    }
+
+
+def import_assets_csv(db: Session, csv_text: str) -> dict:
+    """Import assets from the CSV template:
+    name,asset_type,purchase_date,purchase_price,salvage_value,description
+
+    Asset types are matched by exact name and must exist (strict, like
+    the IIF importer's vendor handling): a typo'd type surfaces as a row
+    error rather than silently creating a half-configured type.
+    """
+    reader = csv.DictReader(io.StringIO(csv_text))
+    required = {"name", "asset_type", "purchase_date", "purchase_price"}
+    headers = set(reader.fieldnames or [])
+    if not required.issubset(headers):
+        raise HTTPException(
+            status_code=400,
+            detail=f"CSV must include columns: {sorted(required)}",
+        )
+    imported = 0
+    errors = []
+    for i, row in enumerate(reader, start=2):
+        try:
+            type_name = (row.get("asset_type") or "").strip()
+            atype = (
+                db.query(FixedAssetType)
+                .filter(FixedAssetType.name == type_name)
+                .first()
+            )
+            if not atype:
+                raise ValueError(f"asset type '{type_name}' not found")
+            purchase_date = date.fromisoformat((row.get("purchase_date") or "").strip())
+            asset = FixedAsset(
+                asset_number=next_asset_number(db),
+                name=(row.get("name") or "").strip(),
+                asset_type_id=atype.id,
+                purchase_date=purchase_date,
+                purchase_price=_q(Decimal(row.get("purchase_price") or "0")),
+                salvage_value=_q(Decimal(row.get("salvage_value") or "0")),
+                description=(row.get("description") or "").strip() or None,
+            )
+            if not asset.name:
+                raise ValueError("name is required")
+            db.add(asset)
+            db.flush()
+            imported += 1
+        except Exception as exc:
+            errors.append({"row": i, "message": str(exc)})
+    db.commit()
+    return {"imported": imported, "errors": errors}

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -57,6 +57,7 @@ const App = {
         // Phase 10: Quick Wins + Medium Effort Features
         '/budgets':       { page: 'budgets',         label: 'Budget vs Actual',   render: () => BudgetsPage.render() },
         '/bank-rules':    { page: 'bank-rules',      label: 'Bank Rules',         render: () => BankRulesPage.render() },
+        '/fixed-assets':  { page: 'fixed-assets',    label: 'Fixed Assets',       render: () => FixedAssetsPage.render() },
     },
 
     async navigate(hash) {

--- a/app/static/js/fixed_assets.js
+++ b/app/static/js/fixed_assets.js
@@ -1,0 +1,244 @@
+/**
+ * Fixed Assets — register, depreciation runs, disposal, CSV import.
+ * Designed from the joelmacklow fork's fixed-assets slice.
+ */
+const FixedAssetsPage = {
+    async render() {
+        const assets = await API.get('/fixed-assets');
+        return renderListPage({
+            title: 'Fixed Assets',
+            headerHtml: `<div class="btn-group">
+                    <button class="btn btn-primary" onclick="FixedAssetsPage.showAssetForm()">+ Register Asset</button>
+                    <button class="btn btn-secondary" onclick="FixedAssetsPage.showTypeForm()">+ Asset Type</button>
+                    <button class="btn btn-secondary" onclick="FixedAssetsPage.showDepreciationForm()">Run Depreciation</button>
+                    <button class="btn btn-secondary" onclick="FixedAssetsPage.showImportForm()">Import CSV</button>
+                </div>`,
+            empty: `<p>No fixed assets registered yet.</p>
+                <button class="btn btn-primary" onclick="FixedAssetsPage.showAssetForm()" style="margin-top:10px;">+ Register your first asset</button>`,
+            columns: [
+                { label: 'Asset #', key: 'asset_number' },
+                { label: 'Name', key: 'name' },
+                { label: 'Type', key: 'asset_type_name' },
+                { label: 'Purchased', key: 'purchase_date' },
+                { label: 'Status', key: 'status' },
+                { label: 'Cost', cls: 'amount', key: 'purchase_price' },
+                { label: 'Accum. Depr.', cls: 'amount', key: 'accumulated_depreciation' },
+                { label: 'Book Value', cls: 'amount', key: 'book_value' },
+                'Actions',
+            ],
+            sort: { id: 'fixed-assets', column: 'asset_number', direction: 'asc' },
+            items: assets,
+            row: a => `<tr data-status="${a.status}">
+                    <td><strong>${escapeHtml(a.asset_number)}</strong></td>
+                    <td>${escapeHtml(a.name)}</td>
+                    <td>${escapeHtml(a.asset_type_name || '')}</td>
+                    <td>${formatDate(a.purchase_date)}</td>
+                    <td>${escapeHtml(a.status)}</td>
+                    <td class="amount">${formatCurrency(a.purchase_price)}</td>
+                    <td class="amount">${formatCurrency(a.accumulated_depreciation)}</td>
+                    <td class="amount">${formatCurrency(a.book_value)}</td>
+                    <td class="actions">
+                        ${a.status === 'registered' ? `<button class="btn btn-sm btn-danger" onclick="FixedAssetsPage.showDisposeForm(${a.id})">Dispose</button>` : ''}
+                    </td>
+                </tr>`,
+        });
+    },
+
+    async showTypeForm() {
+        const accounts = await API.get('/accounts');
+        const opts = kind => accounts
+            .filter(a => kind ? a.account_type === kind : true)
+            .map(a => `<option value="${a.id}">${escapeHtml(a.account_number || '')} ${escapeHtml(a.name)}</option>`)
+            .join('');
+        openModal('New Asset Type', `
+            <form onsubmit="FixedAssetsPage.saveType(event)">
+                <div class="form-grid">
+                    <div class="form-group"><label>Name *</label>
+                        <input name="name" required placeholder="e.g. Computer Equipment"></div>
+                    <div class="form-group"><label>Depreciation Method</label>
+                        <select name="depreciation_method" onchange="FixedAssetsPage.methodChanged(this)">
+                            <option value="straight_line" selected>Straight line</option>
+                            <option value="declining_balance">Declining balance</option>
+                        </select></div>
+                    <div class="form-group"><label id="fa-life-label">Effective Life (years)</label>
+                        <input name="effective_life_years" type="number" step="0.5" value="5"></div>
+                    <div class="form-group"><label>Annual Rate (e.g. 0.20)</label>
+                        <input name="annual_rate" type="number" step="0.0001"></div>
+                    <div class="form-group"><label>Fixed Asset Account</label>
+                        <select name="asset_account_id"><option value="">--</option>${opts('asset')}</select></div>
+                    <div class="form-group"><label>Accumulated Depreciation Account</label>
+                        <select name="accumulated_depreciation_account_id"><option value="">--</option>${opts('asset')}</select></div>
+                    <div class="form-group"><label>Depreciation Expense Account</label>
+                        <select name="depreciation_expense_account_id"><option value="">--</option>${opts('expense')}</select></div>
+                </div>
+                <div class="form-actions">
+                    <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Create Type</button>
+                </div>
+            </form>`);
+    },
+
+    methodChanged() { /* labels stay visible; both inputs accepted */ },
+
+    async saveType(e) {
+        e.preventDefault();
+        const form = e.target;
+        const num = v => v ? parseFloat(v) : null;
+        const intOrNull = v => v ? parseInt(v) : null;
+        try {
+            await API.post('/fixed-assets/types', {
+                name: form.name.value,
+                depreciation_method: form.depreciation_method.value,
+                effective_life_years: num(form.effective_life_years.value),
+                annual_rate: num(form.annual_rate.value),
+                asset_account_id: intOrNull(form.asset_account_id.value),
+                accumulated_depreciation_account_id: intOrNull(form.accumulated_depreciation_account_id.value),
+                depreciation_expense_account_id: intOrNull(form.depreciation_expense_account_id.value),
+            });
+            toast('Asset type created');
+            closeModal();
+        } catch (err) { toast(err.message, 'error'); }
+    },
+
+    async showAssetForm() {
+        const types = await API.get('/fixed-assets/types');
+        if (!types.length) { toast('Create an asset type first', 'error'); return; }
+        const typeOpts = types.map(t => `<option value="${t.id}">${escapeHtml(t.name)}</option>`).join('');
+        openModal('Register Fixed Asset', `
+            <form onsubmit="FixedAssetsPage.saveAsset(event)">
+                <div class="form-grid">
+                    <div class="form-group"><label>Name *</label>
+                        <input name="name" required></div>
+                    <div class="form-group"><label>Asset Type *</label>
+                        <select name="asset_type_id" required>${typeOpts}</select></div>
+                    <div class="form-group"><label>Purchase Date *</label>
+                        <input name="purchase_date" type="date" required value="${todayISO()}"></div>
+                    <div class="form-group"><label>Purchase Price *</label>
+                        <input name="purchase_price" type="number" step="0.01" required></div>
+                    <div class="form-group"><label>Salvage Value</label>
+                        <input name="salvage_value" type="number" step="0.01" value="0"></div>
+                    <div class="form-group full-width"><label>Description</label>
+                        <textarea name="description"></textarea></div>
+                </div>
+                <div class="form-actions">
+                    <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Register Asset</button>
+                </div>
+            </form>`);
+    },
+
+    async saveAsset(e) {
+        e.preventDefault();
+        const form = e.target;
+        try {
+            await API.post('/fixed-assets', {
+                name: form.name.value,
+                asset_type_id: parseInt(form.asset_type_id.value),
+                purchase_date: form.purchase_date.value,
+                purchase_price: parseFloat(form.purchase_price.value),
+                salvage_value: parseFloat(form.salvage_value.value) || 0,
+                description: form.description.value || null,
+            });
+            toast('Asset registered');
+            closeModal();
+            App.navigate('#/fixed-assets');
+        } catch (err) { toast(err.message, 'error'); }
+    },
+
+    showDepreciationForm() {
+        openModal('Run Depreciation', `
+            <form onsubmit="FixedAssetsPage.runDepreciation(event)">
+                <div class="form-group"><label>Depreciate through *</label>
+                    <input name="run_date" type="date" required value="${todayISO()}"></div>
+                <div style="font-size:11px; color:var(--text-muted); margin:8px 0;">
+                    Posts one journal per asset (DR depreciation expense /
+                    CR accumulated depreciation) for the full months elapsed
+                    since each asset's last run.
+                </div>
+                <div class="form-actions">
+                    <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Run</button>
+                </div>
+            </form>`);
+    },
+
+    async runDepreciation(e) {
+        e.preventDefault();
+        try {
+            const result = await API.post('/fixed-assets/run-depreciation', {
+                run_date: e.target.run_date.value,
+            });
+            toast(`Depreciation posted for ${result.posted} assets (${formatCurrency(result.total)}); ${result.skipped} skipped`);
+            closeModal();
+            App.navigate('#/fixed-assets');
+        } catch (err) { toast(err.message, 'error'); }
+    },
+
+    async showDisposeForm(assetId) {
+        const accounts = await API.get('/accounts?account_type=asset');
+        const opts = accounts.map(a => `<option value="${a.id}">${escapeHtml(a.account_number || '')} ${escapeHtml(a.name)}</option>`).join('');
+        openModal('Dispose Asset', `
+            <form onsubmit="FixedAssetsPage.dispose(event, ${assetId})">
+                <div class="form-grid">
+                    <div class="form-group"><label>Disposal Date *</label>
+                        <input name="disposal_date" type="date" required value="${todayISO()}"></div>
+                    <div class="form-group"><label>Proceeds</label>
+                        <input name="proceeds" type="number" step="0.01" value="0"></div>
+                    <div class="form-group full-width"><label>Deposit Proceeds To *</label>
+                        <select name="deposit_account_id" required>${opts}</select></div>
+                </div>
+                <div class="form-actions">
+                    <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Dispose</button>
+                </div>
+            </form>`);
+    },
+
+    async dispose(e, assetId) {
+        e.preventDefault();
+        const form = e.target;
+        try {
+            const result = await API.post(`/fixed-assets/${assetId}/dispose`, {
+                disposal_date: form.disposal_date.value,
+                proceeds: parseFloat(form.proceeds.value) || 0,
+                deposit_account_id: parseInt(form.deposit_account_id.value),
+            });
+            const gl = result.gain_loss;
+            toast(gl === 0 ? 'Asset disposed' : `Asset disposed (${gl > 0 ? 'gain' : 'loss'} ${formatCurrency(Math.abs(gl))})`);
+            closeModal();
+            App.navigate('#/fixed-assets');
+        } catch (err) { toast(err.message, 'error'); }
+    },
+
+    showImportForm() {
+        openModal('Import Assets from CSV', `
+            <form onsubmit="FixedAssetsPage.importCsv(event)">
+                <div class="form-group">
+                    <label>CSV file (columns: name, asset_type, purchase_date, purchase_price, salvage_value, description)</label>
+                    <input type="file" id="fa-import-file" accept=".csv" required>
+                </div>
+                <div class="form-actions">
+                    <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Import</button>
+                </div>
+            </form>`);
+    },
+
+    async importCsv(e) {
+        e.preventDefault();
+        const file = $('#fa-import-file').files[0];
+        if (!file) return;
+        const formData = new FormData();
+        formData.append('file', file);
+        try {
+            const resp = await fetch('/api/fixed-assets/import-csv', { method: 'POST', body: formData });
+            const data = await resp.json();
+            if (!resp.ok) throw new Error(data.detail || 'Import failed');
+            const errs = data.errors.length ? ` (${data.errors.length} rows failed)` : '';
+            toast(`Imported ${data.imported} assets${errs}`);
+            if (data.errors.length) console.warn('Asset import errors:', data.errors);
+            closeModal();
+            App.navigate('#/fixed-assets');
+        } catch (err) { toast(err.message, 'error'); }
+    },
+};

--- a/app/static/js/reports.js
+++ b/app/static/js/reports.js
@@ -61,6 +61,10 @@ const ReportsPage = {
                     <div class="card-header">P&L by Class</div>
                     <p style="font-size:13px; color:var(--gray-500);">Income vs expenses split by class</p>
                 </div>
+                <div class="card" style="cursor:pointer" onclick="ReportsPage.fixedAssetReconciliation()">
+                    <div class="card-header">Fixed Asset Reconciliation</div>
+                    <p style="font-size:13px; color:var(--gray-500);">Register totals vs GL by asset type</p>
+                </div>
                 <div class="card" style="cursor:pointer" onclick="ReportsPage.balanceSheet()">
                     <div class="card-header">Balance Sheet</div>
                     <p style="font-size:13px; color:var(--gray-500);">Assets, liabilities, and equity</p>
@@ -816,4 +820,32 @@ ReportsPage.profitLossByClass = async function () {
                 </tr></tfoot>
             </table></div>`;
     });
+};
+
+// Fixed assets: register totals per type for GL reconciliation.
+ReportsPage.fixedAssetReconciliation = async function () {
+    const data = await API.get('/fixed-assets/reports/reconciliation');
+    const rows = data.types.map(t => `<tr>
+        <td>${escapeHtml(t.asset_type)}</td>
+        <td class="amount">${t.asset_count}</td>
+        <td class="amount">${formatCurrency(t.cost)}</td>
+        <td class="amount">${formatCurrency(t.accumulated_depreciation)}</td>
+        <td class="amount">${formatCurrency(t.book_value)}</td>
+    </tr>`).join('');
+    openModal('Fixed Asset Reconciliation', `
+        <div class="table-container"><table>
+            <thead><tr><th>Asset Type</th><th class="amount">Assets</th><th class="amount">Cost</th>
+            <th class="amount">Accum. Depr.</th><th class="amount">Book Value</th></tr></thead>
+            <tbody>${rows.length ? rows : '<tr><td colspan="5">No registered assets</td></tr>'}</tbody>
+            <tfoot><tr style="font-weight:700; background:var(--gray-50);">
+                <td>Total</td><td></td>
+                <td class="amount">${formatCurrency(data.total_cost)}</td>
+                <td class="amount">${formatCurrency(data.total_accumulated)}</td>
+                <td class="amount">${formatCurrency(data.total_book_value)}</td>
+            </tr></tfoot>
+        </table></div>
+        <div style="font-size:11px; color:var(--gray-500); margin-top:8px;">
+            Compare against the mapped fixed-asset and accumulated-depreciation
+            GL accounts — differences mean unposted acquisitions or manual GL edits.
+        </div>`);
 };

--- a/index.html
+++ b/index.html
@@ -122,6 +122,8 @@
                         <span class="nav-icon">&#9638;</span> Bank Accounts</a></li>
                     <li><a href="#/bank-rules" class="nav-link" data-page="bank-rules">
                         <span class="nav-icon">&#9889;</span> Bank Rules</a></li>
+                    <li><a href="#/fixed-assets" class="nav-link" data-page="fixed-assets">
+                        <span class="nav-icon">&#127970;</span> Fixed Assets</a></li>
                     <li><a href="#/deposits" class="nav-link" data-page="deposits">
                         <span class="nav-icon">&#9660;</span> Make Deposits</a></li>
                     <li><a href="#/check-register" class="nav-link" data-page="check-register">
@@ -240,6 +242,7 @@
     <script src="/static/js/cc_charges.js"></script>
     <!-- Phase 10: Quick Wins + Medium Effort Features -->
     <script src="/static/js/bank_rules.js"></script>
+    <script src="/static/js/fixed_assets.js"></script>
     <script src="/static/js/budgets.js"></script>
     <!-- App must be last -->
     <script src="/static/js/app.js"></script>

--- a/migrations/versions/f4a5b6c7d8e9_add_fixed_assets.py
+++ b/migrations/versions/f4a5b6c7d8e9_add_fixed_assets.py
@@ -1,0 +1,112 @@
+"""add_fixed_assets
+
+Fixed-asset register: types (with the three account mappings) and
+assets. Both are new tables, but existing desktop files upgrade via
+this revision since the launcher runs `alembic upgrade head`.
+
+Revision ID: f4a5b6c7d8e9
+Revises: e3f4a5b6c7d8
+Create Date: 2026-08-01
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "f4a5b6c7d8e9"
+down_revision: Union[str, None] = "e3f4a5b6c7d8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "fixed_asset_types",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(length=120), nullable=False, unique=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "asset_account_id",
+            sa.Integer(),
+            sa.ForeignKey("accounts.id"),
+            nullable=True,
+        ),
+        sa.Column(
+            "accumulated_depreciation_account_id",
+            sa.Integer(),
+            sa.ForeignKey("accounts.id"),
+            nullable=True,
+        ),
+        sa.Column(
+            "depreciation_expense_account_id",
+            sa.Integer(),
+            sa.ForeignKey("accounts.id"),
+            nullable=True,
+        ),
+        sa.Column(
+            "depreciation_method",
+            sa.Enum("STRAIGHT_LINE", "DECLINING_BALANCE", name="depreciationmethod"),
+            nullable=False,
+            server_default="STRAIGHT_LINE",
+        ),
+        sa.Column("effective_life_years", sa.Numeric(8, 2), nullable=True),
+        sa.Column("annual_rate", sa.Numeric(8, 4), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+        ),
+    )
+    op.create_table(
+        "fixed_assets",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("asset_number", sa.String(length=40), nullable=False, unique=True),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column(
+            "asset_type_id",
+            sa.Integer(),
+            sa.ForeignKey("fixed_asset_types.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "status",
+            sa.Enum("REGISTERED", "DISPOSED", name="fixedassetstatus"),
+            nullable=False,
+            server_default="REGISTERED",
+        ),
+        sa.Column("purchase_date", sa.Date(), nullable=False),
+        sa.Column(
+            "purchase_price", sa.Numeric(12, 2), nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "salvage_value", sa.Numeric(12, 2), nullable=False, server_default="0"
+        ),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "accumulated_depreciation",
+            sa.Numeric(12, 2),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column("last_depreciation_date", sa.Date(), nullable=True),
+        sa.Column("disposal_date", sa.Date(), nullable=True),
+        sa.Column("disposal_proceeds", sa.Numeric(12, 2), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+        ),
+    )
+    op.create_index("ix_fixed_assets_asset_type_id", "fixed_assets", ["asset_type_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_fixed_assets_asset_type_id", table_name="fixed_assets")
+    op.drop_table("fixed_assets")
+    op.drop_table("fixed_asset_types")

--- a/tests/test_fixed_assets.py
+++ b/tests/test_fixed_assets.py
@@ -1,0 +1,186 @@
+"""Fixed assets: depreciation math + journals, disposal gain/loss,
+CSV import, reconciliation report."""
+
+from decimal import Decimal
+
+import pytest
+
+from app.models.accounts import Account, AccountType
+from app.models.transactions import Transaction, TransactionLine
+
+
+@pytest.fixture
+def fa_accounts(db_session, seed_accounts):
+    asset = Account(name="Computer Equipment (Asset)", account_type=AccountType.ASSET)
+    accum = Account(name="Accum. Depr. — Computers", account_type=AccountType.ASSET)
+    expense = Account(name="Depreciation Expense", account_type=AccountType.EXPENSE)
+    db_session.add_all([asset, accum, expense])
+    db_session.commit()
+    return asset, accum, expense
+
+
+@pytest.fixture
+def computer_type(client, fa_accounts):
+    asset, accum, expense = fa_accounts
+    resp = client.post(
+        "/api/fixed-assets/types",
+        json={
+            "name": "Computers",
+            "depreciation_method": "straight_line",
+            "effective_life_years": 5,
+            "asset_account_id": asset.id,
+            "accumulated_depreciation_account_id": accum.id,
+            "depreciation_expense_account_id": expense.id,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+@pytest.fixture
+def laptop(client, computer_type):
+    resp = client.post(
+        "/api/fixed-assets",
+        json={
+            "name": "Dev laptop",
+            "asset_type_id": computer_type["id"],
+            "purchase_date": "2026-01-15",
+            "purchase_price": 3000,
+            "salvage_value": 600,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def test_asset_gets_number_and_derived_book_value(laptop):
+    assert laptop["asset_number"] == "FA-0001"
+    assert laptop["book_value"] == 3000.0
+
+
+def test_straight_line_depreciation_run(client, db_session, laptop, fa_accounts):
+    _, accum, expense = fa_accounts
+    # 2026-01-15 → 2026-07-15 = 6 full months; (3000-600)/60 = 40/mo → 240
+    resp = client.post(
+        "/api/fixed-assets/run-depreciation", json={"run_date": "2026-07-15"}
+    )
+    assert resp.status_code == 200, resp.text
+    result = resp.json()
+    assert result["posted"] == 1
+    assert result["total"] == 240.0
+
+    asset = client.get(f"/api/fixed-assets/{laptop['id']}").json()
+    assert asset["accumulated_depreciation"] == 240.0
+    assert asset["book_value"] == 2760.0
+
+    txn = (
+        db_session.query(Transaction)
+        .filter(Transaction.source_type == "depreciation")
+        .one()
+    )
+    lines = db_session.query(TransactionLine).filter_by(transaction_id=txn.id).all()
+    assert any(
+        ln.account_id == expense.id and ln.debit == Decimal("240.00") for ln in lines
+    )
+    assert any(
+        ln.account_id == accum.id and ln.credit == Decimal("240.00") for ln in lines
+    )
+
+    # Re-run same date: nothing further to post
+    again = client.post(
+        "/api/fixed-assets/run-depreciation", json={"run_date": "2026-07-15"}
+    ).json()
+    assert again["posted"] == 0
+
+
+def test_depreciation_never_breaches_salvage(client, laptop):
+    resp = client.post(
+        "/api/fixed-assets/run-depreciation", json={"run_date": "2099-12-31"}
+    ).json()
+    assert resp["total"] == 2400.0  # cost - salvage, capped
+    asset = client.get(f"/api/fixed-assets/{laptop['id']}").json()
+    assert asset["book_value"] == 600.0  # never below salvage
+
+
+def test_disposal_posts_gain(client, db_session, laptop, fa_accounts):
+    asset_acct, accum, _ = fa_accounts
+    client.post("/api/fixed-assets/run-depreciation", json={"run_date": "2026-07-15"})
+
+    bank = db_session.query(Account).filter(Account.name == "Checking").first()
+    if not bank:
+        bank = Account(name="Checking FA", account_type=AccountType.ASSET)
+        db_session.add(bank)
+        db_session.commit()
+
+    # book value 2760 after 240 depreciation; sell for 3000 → 240 gain
+    resp = client.post(
+        f"/api/fixed-assets/{laptop['id']}/dispose",
+        json={
+            "disposal_date": "2026-07-20",
+            "proceeds": 3000,
+            "deposit_account_id": bank.id,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["gain_loss"] == 240.0
+
+    txn = (
+        db_session.query(Transaction)
+        .filter(Transaction.source_type == "asset_disposal")
+        .one()
+    )
+    lines = db_session.query(TransactionLine).filter_by(transaction_id=txn.id).all()
+    assert sum(ln.debit or 0 for ln in lines) == sum(ln.credit or 0 for ln in lines)
+    # cost fully derecognized
+    assert any(
+        ln.account_id == asset_acct.id and ln.credit == Decimal("3000.00")
+        for ln in lines
+    )
+
+    asset = client.get(f"/api/fixed-assets/{laptop['id']}").json()
+    assert asset["status"] == "disposed"
+    # disposed assets can't be edited or double-disposed
+    assert (
+        client.put(f"/api/fixed-assets/{laptop['id']}", json={"name": "x"}).status_code
+        == 400
+    )
+    assert (
+        client.post(
+            f"/api/fixed-assets/{laptop['id']}/dispose",
+            json={
+                "disposal_date": "2026-07-21",
+                "proceeds": 1,
+                "deposit_account_id": bank.id,
+            },
+        ).status_code
+        == 400
+    )
+
+
+def test_csv_import(client, computer_type):
+    csv_text = (
+        "name,asset_type,purchase_date,purchase_price,salvage_value,description\n"
+        "Monitor,Computers,2026-02-01,500,0,27 inch\n"
+        "Desk,No Such Type,2026-02-01,900,0,\n"
+    )
+    import io
+
+    resp = client.post(
+        "/api/fixed-assets/import-csv",
+        files={"file": ("assets.csv", io.BytesIO(csv_text.encode()), "text/csv")},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["imported"] == 1
+    assert len(data["errors"]) == 1
+    assert "No Such Type" in data["errors"][0]["message"]
+
+
+def test_reconciliation_report(client, laptop):
+    client.post("/api/fixed-assets/run-depreciation", json={"run_date": "2026-07-15"})
+    data = client.get("/api/fixed-assets/reports/reconciliation").json()
+    row = next(t for t in data["types"] if t["asset_type"] == "Computers")
+    assert row["asset_count"] == 1
+    assert row["cost"] == 3000.0
+    assert row["accumulated_depreciation"] == 240.0
+    assert row["book_value"] == 2760.0


### PR DESCRIPTION
Fixed-asset management, implemented from the joelmacklow fork's spec (`docs/spec-fixed-assets-management.md` — Joel Macklow, @joelmacklow) and decoupled from that fork's NZ chart-template infrastructure: account roles come from **per-type mappings** (asset / accumulated depreciation / depreciation expense), never hardcoded account numbers.

Stacked on #27 (merge order: #26 → #27 → this) to keep the migration chain linear.

## What you get
- **Asset types** with the three account mappings and a depreciation policy: straight-line (effective life) or declining-balance (annual rate).
- **Asset register** (new nav page): auto-numbered FA-XXXX, sortable columns, book value always derived (cost − accumulated), disposed assets read-only.
- **Run Depreciation**: month-granular, one journal per asset (DR expense / CR accumulated) so drill-down stays per-asset; never breaches salvage; re-running the same date posts nothing.
- **Disposal**: derecognizes cost + accumulated, books proceeds to a chosen account, residual posts to a get-or-create "Gain/Loss on Asset Disposal" (7999).
- **CSV import** with strict type matching and per-row errors (upload-capped).
- **Fixed Asset Reconciliation** report: register totals per type to compare against the mapped GL accounts.

## Testing
Full suite **985 passed** (6 new fixed-asset tests + all invariants). Migration `f4a5b6c7d8e9` verified single-head + clean fresh-DB upgrade.

Deferred per the spec: depreciation history rows/reversal, attachments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)