### PR TITLE
Feature: Xero import (dry-run) + opening-balance wizard

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -67,6 +67,8 @@ from app.routes import bank_import, tax, backups
 from app.routes import classes as classes_routes
 from app.routes import fx as fx_routes
 from app.routes import fixed_assets as fixed_assets_routes
+from app.routes import xero_import as xero_import_routes
+from app.routes import opening_balances as opening_balances_routes
 
 # Phase 6: Ambitious
 from app.routes import companies, employees, payroll
@@ -369,6 +371,8 @@ app.include_router(accounts.router)
 app.include_router(classes_routes.router)
 app.include_router(fx_routes.router)
 app.include_router(fixed_assets_routes.router)
+app.include_router(xero_import_routes.router)
+app.include_router(opening_balances_routes.router)
 app.include_router(customers.router)
 app.include_router(vendors.router)
 app.include_router(items.router)

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -57,6 +57,9 @@ DEFAULT_SETTINGS = {
     "smtp_use_tls": "true",
     # Feature 15: Company Logo
     "company_logo_path": "",
+    # Opening-balance wizard readiness metadata
+    "chart_setup_source": "",
+    "chart_setup_ready_at": "",
     # Multi-currency: ISO code the general ledger is kept in
     "home_currency": "USD",
     # Stripe Online Payments

--- a/app/routes/opening_balances.py
+++ b/app/routes/opening_balances.py
@@ -1,0 +1,165 @@
+# ============================================================================
+# Opening-balance wizard — guided opening balances without manual
+# journal-entry knowledge (joelmacklow spec: spec-opening-balance-wizard).
+#
+# Posting rules (per spec):
+#   positive asset amounts DEBIT the account
+#   positive liability/equity amounts CREDIT the account
+#   negative amounts invert the normal side; zero lines are ignored
+#   unbalanced entries are rejected unless auto-balance posts the
+#   difference to a chosen equity account
+# ============================================================================
+
+from datetime import date as dt_date
+from decimal import Decimal
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.accounts import Account, AccountType
+from app.services.accounting import _q, create_journal_entry
+from app.services.settings_service import get_all_settings
+
+router = APIRouter(prefix="/api/opening-balances", tags=["opening_balances"])
+
+_BALANCE_SHEET_TYPES = (AccountType.ASSET, AccountType.LIABILITY, AccountType.EQUITY)
+
+
+class OpeningBalanceLine(BaseModel):
+    account_id: int
+    amount: Decimal
+
+
+class OpeningBalanceCreate(BaseModel):
+    date: dt_date
+    description: str = "Opening balances"
+    reference: Optional[str] = None
+    lines: list[OpeningBalanceLine] = []
+    auto_balance_account_id: Optional[int] = None
+
+
+def _chart_ready(db: Session) -> bool:
+    return (
+        db.query(Account)
+        .filter(
+            Account.account_type.in_(_BALANCE_SHEET_TYPES), Account.is_active.is_(True)
+        )
+        .first()
+        is not None
+    )
+
+
+@router.get("/status")
+def status(db: Session = Depends(get_db)):
+    settings = get_all_settings(db)
+    accounts = (
+        db.query(Account)
+        .filter(
+            Account.account_type.in_(_BALANCE_SHEET_TYPES), Account.is_active.is_(True)
+        )
+        .order_by(Account.account_type, Account.account_number)
+        .all()
+    )
+    return {
+        "ready": len(accounts) > 0,
+        "chart_setup_source": settings.get("chart_setup_source") or None,
+        "chart_setup_ready_at": settings.get("chart_setup_ready_at") or None,
+        "accounts": [
+            {
+                "id": a.id,
+                "name": a.name,
+                "account_number": a.account_number,
+                "account_type": a.account_type.value,
+            }
+            for a in accounts
+        ],
+    }
+
+
+@router.post("")
+def create_opening_balances(data: OpeningBalanceCreate, db: Session = Depends(get_db)):
+    if not _chart_ready(db):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Chart of accounts is not ready — load a chart or run a "
+                "Xero import first"
+            ),
+        )
+
+    journal_lines = []
+    total_debit = Decimal("0")
+    total_credit = Decimal("0")
+    for line in data.lines:
+        amount = _q(Decimal(str(line.amount)))
+        if amount == 0:
+            continue
+        account = db.get(Account, line.account_id)
+        if not account or account.account_type not in _BALANCE_SHEET_TYPES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Account {line.account_id} is not an active balance-sheet account",
+            )
+        debit_normal = account.account_type == AccountType.ASSET
+        # positive amount goes to the account's normal side; negative inverts
+        debit_side = debit_normal if amount > 0 else not debit_normal
+        magnitude = abs(amount)
+        journal_lines.append(
+            {
+                "account_id": account.id,
+                "debit": magnitude if debit_side else Decimal("0"),
+                "credit": Decimal("0") if debit_side else magnitude,
+                "description": f"Opening balance — {account.name}",
+            }
+        )
+        total_debit += magnitude if debit_side else Decimal("0")
+        total_credit += Decimal("0") if debit_side else magnitude
+
+    if not journal_lines:
+        raise HTTPException(
+            status_code=400, detail="No non-zero opening balances given"
+        )
+
+    difference = total_debit - total_credit
+    if difference != 0:
+        if not data.auto_balance_account_id:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Opening balances are unbalanced by {abs(difference)} — "
+                    f"correct the amounts or choose an equity account to "
+                    f"auto-balance against"
+                ),
+            )
+        equity = db.get(Account, data.auto_balance_account_id)
+        if not equity or equity.account_type != AccountType.EQUITY:
+            raise HTTPException(
+                status_code=400,
+                detail="Auto-balance account must be an equity account",
+            )
+        journal_lines.append(
+            {
+                "account_id": equity.id,
+                "debit": -difference if difference < 0 else Decimal("0"),
+                "credit": difference if difference > 0 else Decimal("0"),
+                "description": f"Opening balance equity adjustment — {equity.name}",
+            }
+        )
+
+    txn = create_journal_entry(
+        db,
+        data.date,
+        data.description,
+        journal_lines,
+        source_type="opening_balance",
+        reference=data.reference,
+    )
+    db.commit()
+    return {
+        "transaction_id": txn.id,
+        "lines": len(journal_lines),
+        "auto_balanced": difference != 0,
+    }

--- a/app/routes/xero_import.py
+++ b/app/routes/xero_import.py
@@ -1,0 +1,65 @@
+# ============================================================================
+# Xero import — upload the CSV bundle, dry-run, then import.
+# Dry-run mutates NOTHING (the contract the UI leans on); import re-runs
+# the dry-run internally and refuses when it fails.
+# ============================================================================
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.services.settings_service import set_setting
+from app.services.upload_limits import read_limited
+from app.services.xero_import import classify_filename, dry_run, run_import
+
+router = APIRouter(prefix="/api/xero-import", tags=["xero_import"])
+
+
+async def _bundle_from_uploads(files: list[UploadFile]) -> dict:
+    bundle: dict[str, str] = {}
+    unrecognized = []
+    for file in files:
+        kind = classify_filename(file.filename)
+        if not kind:
+            unrecognized.append(file.filename)
+            continue
+        content = await read_limited(file, label=f"Xero CSV {file.filename}")
+        try:
+            text = content.decode("utf-8-sig")
+        except UnicodeDecodeError:
+            text = content.decode("latin-1")
+        bundle[kind] = text
+    if unrecognized:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Could not classify files by name: {unrecognized}. Expected "
+                f"filenames containing 'chart'/'accounts', 'ledger'/'journal', "
+                f"or 'trial'."
+            ),
+        )
+    return bundle
+
+
+@router.post("/dry-run")
+async def xero_dry_run(
+    files: list[UploadFile] = File(...), db: Session = Depends(get_db)
+):
+    bundle = await _bundle_from_uploads(files)
+    return dry_run(db, bundle)
+
+
+@router.post("/import")
+async def xero_import(
+    files: list[UploadFile] = File(...), db: Session = Depends(get_db)
+):
+    bundle = await _bundle_from_uploads(files)
+    result = run_import(db, bundle)
+    if result["ok"]:
+        # Opening-balance wizard readiness metadata (spec: state tracking)
+        from datetime import date
+
+        set_setting(db, "chart_setup_source", "xero_import")
+        set_setting(db, "chart_setup_ready_at", date.today().isoformat())
+        db.commit()
+    return result

--- a/app/services/xero_import.py
+++ b/app/services/xero_import.py
@@ -1,0 +1,331 @@
+# ============================================================================
+# Xero CSV import — chart of accounts + general ledger, with dry-run.
+#
+# Implements the joelmacklow fork's Xero-import spec
+# (docs/spec-xero-import-capability.md): file types detected by name,
+# Xero column aliases tolerated, and a DRY-RUN that must pass before
+# import will execute — parse errors, unbalanced journals, unmapped
+# account types, and trial-balance mismatches all block.
+#
+# CSV-only; no XLSX, no live Xero API (per the spec's constraints).
+# ============================================================================
+
+import csv
+import io
+import logging
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+
+from sqlalchemy.orm import Session
+
+from app.models.accounts import Account, AccountType
+from app.services.accounting import _q, create_journal_entry
+
+logger = logging.getLogger(__name__)
+
+# Xero account "Type"/"Class" values → our AccountType
+_XERO_TYPE_MAP = {
+    "bank": AccountType.ASSET,
+    "current asset": AccountType.ASSET,
+    "current assets": AccountType.ASSET,
+    "fixed asset": AccountType.ASSET,
+    "fixed assets": AccountType.ASSET,
+    "inventory": AccountType.ASSET,
+    "non-current asset": AccountType.ASSET,
+    "prepayment": AccountType.ASSET,
+    "asset": AccountType.ASSET,
+    "current liability": AccountType.LIABILITY,
+    "current liabilities": AccountType.LIABILITY,
+    "liability": AccountType.LIABILITY,
+    "non-current liability": AccountType.LIABILITY,
+    "equity": AccountType.EQUITY,
+    "revenue": AccountType.INCOME,
+    "sales": AccountType.INCOME,
+    "income": AccountType.INCOME,
+    "other income": AccountType.INCOME,
+    "direct costs": AccountType.COGS,
+    "cost of goods sold": AccountType.COGS,
+    "expense": AccountType.EXPENSE,
+    "expenses": AccountType.EXPENSE,
+    "overheads": AccountType.EXPENSE,
+    "depreciation": AccountType.EXPENSE,
+}
+
+# Filename fragments → bundle slot
+_FILE_KINDS = (
+    ("chart", "coa"),
+    ("account", "coa"),
+    ("general", "gl"),
+    ("ledger", "gl"),
+    ("journal", "gl"),
+    ("trial", "tb"),
+)
+
+
+def classify_filename(name: str) -> str | None:
+    lowered = (name or "").lower()
+    for fragment, kind in _FILE_KINDS:
+        if fragment in lowered:
+            return kind
+    return None
+
+
+def _field(row: dict, *aliases: str) -> str:
+    for alias in aliases:
+        for key, value in row.items():
+            if key and key.strip().lstrip("﻿").lower() == alias:
+                return (value or "").strip()
+    return ""
+
+
+def _decimal(raw: str) -> Decimal:
+    raw = (raw or "").strip().replace(",", "").replace("$", "")
+    if not raw:
+        return Decimal("0")
+    negative = raw.startswith("(") and raw.endswith(")")
+    if negative:
+        raw = raw[1:-1]
+    try:
+        value = Decimal(raw)
+    except InvalidOperation:
+        raise ValueError(f"unparseable amount: {raw!r}")
+    return -value if negative else value
+
+
+def _date(raw: str):
+    raw = (raw or "").strip()
+    for fmt in ("%d %b %Y", "%d/%m/%Y", "%m/%d/%Y", "%Y-%m-%d", "%d %B %Y"):
+        try:
+            return datetime.strptime(raw, fmt).date()
+        except ValueError:
+            continue
+    raise ValueError(f"unparseable date: {raw!r}")
+
+
+def parse_coa(csv_text: str) -> tuple[list[dict], list[str]]:
+    accounts, errors = [], []
+    for i, row in enumerate(csv.DictReader(io.StringIO(csv_text)), start=2):
+        name = _field(row, "name", "account name", "account")
+        if not name:
+            continue
+        xero_type = _field(row, "type", "account type", "class").lower()
+        acct_type = _XERO_TYPE_MAP.get(xero_type)
+        if not acct_type:
+            errors.append(f"COA row {i}: unmapped Xero account type {xero_type!r}")
+            continue
+        accounts.append(
+            {
+                "code": _field(row, "code", "account code", "*code") or None,
+                "name": name,
+                "type": acct_type,
+                "description": _field(row, "description") or None,
+            }
+        )
+    return accounts, errors
+
+
+def parse_gl(csv_text: str) -> tuple[list[dict], list[str]]:
+    """Parse GL rows and group them into journals.
+
+    Grouping key: Xero's journal number when present, otherwise
+    (date, reference/source) — every group must balance to zero.
+    """
+    rows, errors = [], []
+    for i, row in enumerate(csv.DictReader(io.StringIO(csv_text)), start=2):
+        acct = _field(row, "account", "account name")
+        date_raw = _field(row, "date", "journal date")
+        if not acct and not date_raw:
+            continue  # blank/summary row
+        try:
+            rows.append(
+                {
+                    "journal": _field(
+                        row,
+                        "journal number",
+                        "journal no",
+                        "journal #",
+                        "journalnumber",
+                    ),
+                    "date": _date(date_raw),
+                    "account": acct,
+                    "code": _field(row, "account code", "code") or None,
+                    "description": _field(row, "description", "details", "narration"),
+                    "reference": _field(row, "reference", "source"),
+                    "debit": _decimal(_field(row, "debit", "debit (source)")),
+                    "credit": _decimal(_field(row, "credit", "credit (source)")),
+                }
+            )
+        except ValueError as exc:
+            errors.append(f"GL row {i}: {exc}")
+
+    journals: dict = {}
+    for row in rows:
+        key = row["journal"] or f"{row['date'].isoformat()}|{row['reference']}"
+        journals.setdefault(key, []).append(row)
+    return list(journals.values()), errors
+
+
+def parse_tb(csv_text: str) -> tuple[dict, list[str]]:
+    """Trial balance: {account_name_lower: net_debit_minus_credit}."""
+    balances, errors = {}, []
+    for i, row in enumerate(csv.DictReader(io.StringIO(csv_text)), start=2):
+        name = _field(row, "account", "account name", "name")
+        if not name:
+            continue
+        try:
+            debit = _decimal(_field(row, "debit", "debit ytd", "ytd debit"))
+            credit = _decimal(_field(row, "credit", "credit ytd", "ytd credit"))
+        except ValueError as exc:
+            errors.append(f"TB row {i}: {exc}")
+            continue
+        # Strip Xero's "Name (Code)" suffix for matching
+        key = name.split("(")[0].strip().lower()
+        balances[key] = balances.get(key, Decimal("0")) + debit - credit
+    return balances, errors
+
+
+def dry_run(db: Session, bundle: dict) -> dict:
+    """Validate a bundle {kind: csv_text}. Nothing is written.
+
+    Returns {ok, errors, warnings, accounts, journals} — `ok` False on
+    anything that would corrupt an import (missing GL/COA, parse errors,
+    unbalanced journals, unmapped accounts, TB mismatches).
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if "coa" not in bundle:
+        errors.append(
+            "Missing chart of accounts CSV (filename containing 'chart' or 'accounts')"
+        )
+    if "gl" not in bundle:
+        errors.append(
+            "Missing general ledger CSV (filename containing 'general', 'ledger', or 'journal')"
+        )
+    if errors:
+        return {
+            "ok": False,
+            "errors": errors,
+            "warnings": warnings,
+            "accounts": 0,
+            "journals": 0,
+        }
+
+    accounts, coa_errors = parse_coa(bundle["coa"])
+    errors.extend(coa_errors)
+    journals, gl_errors = parse_gl(bundle["gl"])
+    errors.extend(gl_errors)
+
+    known = {a["name"].lower() for a in accounts}
+    known |= {
+        a.name.lower() for a in db.query(Account).all()
+    }  # existing accounts also satisfy GL references
+
+    simulated: dict[str, Decimal] = {}
+    for group in journals:
+        total = sum(r["debit"] - r["credit"] for r in group)
+        if _q(abs(total)) > Decimal("0.01"):
+            ref = group[0]["journal"] or group[0]["reference"] or group[0]["date"]
+            errors.append(f"Journal {ref}: unbalanced by {_q(total)}")
+        for row in group:
+            name = row["account"].split("(")[0].strip().lower()
+            if name not in known:
+                errors.append(
+                    f"GL references account {row['account']!r} not present in the "
+                    f"chart of accounts"
+                )
+                known.add(name)  # report once
+            simulated[name] = (
+                simulated.get(name, Decimal("0")) + row["debit"] - row["credit"]
+            )
+
+    if "tb" in bundle:
+        tb, tb_errors = parse_tb(bundle["tb"])
+        errors.extend(tb_errors)
+        for name, expected in tb.items():
+            got = simulated.get(name, Decimal("0"))
+            if _q(got - expected) != 0:
+                errors.append(
+                    f"Trial balance mismatch for {name!r}: GL nets {_q(got)}, "
+                    f"trial balance says {_q(expected)}"
+                )
+    else:
+        warnings.append("No trial balance CSV supplied — balance verification skipped")
+
+    return {
+        "ok": not errors,
+        "errors": errors,
+        "warnings": warnings,
+        "accounts": len(accounts),
+        "journals": len(journals),
+    }
+
+
+def run_import(db: Session, bundle: dict) -> dict:
+    """Execute the import. Refuses when the dry-run fails (spec rule)."""
+    verdict = dry_run(db, bundle)
+    if not verdict["ok"]:
+        return {**verdict, "imported_accounts": 0, "imported_journals": 0}
+
+    accounts, _ = parse_coa(bundle["coa"])
+    created = 0
+    by_name: dict[str, Account] = {a.name.lower(): a for a in db.query(Account).all()}
+    for spec in accounts:
+        key = spec["name"].lower()
+        if key in by_name:
+            continue
+        acct = Account(
+            name=spec["name"],
+            account_number=spec["code"],
+            account_type=spec["type"],
+            description=spec["description"],
+        )
+        # Xero codes can collide with the seeded chart's numbers — keep the
+        # name authoritative and drop the code rather than fail the row.
+        if spec["code"] and (
+            db.query(Account).filter(Account.account_number == spec["code"]).first()
+        ):
+            acct.account_number = None
+        db.add(acct)
+        db.flush()
+        by_name[key] = acct
+        created += 1
+
+    journals, _ = parse_gl(bundle["gl"])
+    posted = 0
+    for group in journals:
+        lines = []
+        for row in group:
+            acct = by_name[row["account"].split("(")[0].strip().lower()]
+            debit = _q(row["debit"])
+            credit = _q(row["credit"])
+            if debit == 0 and credit == 0:
+                continue
+            lines.append(
+                {
+                    "account_id": acct.id,
+                    "debit": debit,
+                    "credit": credit,
+                    "description": row["description"] or None,
+                }
+            )
+        if not lines:
+            continue
+        first = group[0]
+        create_journal_entry(
+            db,
+            first["date"],
+            first["description"]
+            or f"Xero import {first['journal'] or first['reference']}",
+            lines,
+            source_type="xero_import",
+            reference=(first["journal"] or first["reference"] or None),
+        )
+        posted += 1
+
+    db.commit()
+    return {
+        **verdict,
+        "imported_accounts": created,
+        "imported_journals": posted,
+    }

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -58,6 +58,8 @@ const App = {
         '/budgets':       { page: 'budgets',         label: 'Budget vs Actual',   render: () => BudgetsPage.render() },
         '/bank-rules':    { page: 'bank-rules',      label: 'Bank Rules',         render: () => BankRulesPage.render() },
         '/fixed-assets':  { page: 'fixed-assets',    label: 'Fixed Assets',       render: () => FixedAssetsPage.render() },
+        '/xero-import':   { page: 'xero-import',     label: 'Xero Import',        render: () => XeroImportPage.render() },
+        '/opening-balances': { page: 'opening-balances', label: 'Opening Balances', render: () => OpeningBalancesPage.render() },
     },
 
     async navigate(hash) {

--- a/app/static/js/opening_balances.js
+++ b/app/static/js/opening_balances.js
@@ -1,0 +1,97 @@
+/**
+ * Opening Balances — guided setup without manual journal knowledge.
+ * Positive amounts land on each account's normal side; the auto-balance
+ * helper posts any difference to a chosen equity account.
+ */
+const OpeningBalancesPage = {
+    _accounts: [],
+
+    async render() {
+        const status = await API.get('/opening-balances/status');
+        if (!status.ready) {
+            return `
+                <div class="page-header"><h2>Opening Balances</h2></div>
+                <div class="empty-state">
+                    <p>Your chart of accounts isn't set up yet.</p>
+                    <p style="font-size:12px; margin-top:8px;">
+                        Load a chart in <a href="#/settings">Settings</a> or migrate one
+                        via <a href="#/xero-import">Xero Import</a>, then come back here.
+                    </p>
+                </div>`;
+        }
+        OpeningBalancesPage._accounts = status.accounts;
+        const groups = { asset: 'Assets', liability: 'Liabilities', equity: 'Equity' };
+        let rows = '';
+        for (const [type, label] of Object.entries(groups)) {
+            const accts = status.accounts.filter(a => a.account_type === type);
+            if (!accts.length) continue;
+            rows += `<tr><td colspan="2" style="font-weight:700; background:var(--gray-50);">${label}</td></tr>`;
+            rows += accts.map(a => `<tr>
+                <td>${escapeHtml(a.account_number || '')} ${escapeHtml(a.name)}</td>
+                <td class="amount"><input type="number" step="0.01" class="ob-amount" data-account="${a.id}"
+                    style="width:120px; text-align:right;" oninput="OpeningBalancesPage.recalc()"></td>
+            </tr>`).join('');
+        }
+        const equityOpts = status.accounts.filter(a => a.account_type === 'equity')
+            .map(a => `<option value="${a.id}">${escapeHtml(a.name)}</option>`).join('');
+        return `
+            <div class="page-header"><h2>Opening Balances</h2></div>
+            <div class="card" style="max-width:720px;">
+                <div class="form-grid">
+                    <div class="form-group"><label>As of Date *</label>
+                        <input type="date" id="ob-date" value="${todayISO()}"></div>
+                    <div class="form-group"><label>Reference</label>
+                        <input type="text" id="ob-reference" placeholder="e.g. OB-2026"></div>
+                </div>
+                <div class="table-container" style="margin-top:8px;"><table>
+                    <thead><tr><th>Account</th><th class="amount">Opening Balance</th></tr></thead>
+                    <tbody>${rows}</tbody>
+                </table></div>
+                <div style="margin-top:12px; display:flex; gap:12px; align-items:center; flex-wrap:wrap;">
+                    <div id="ob-difference" style="font-weight:700;">Difference: $0.00</div>
+                    <label style="font-size:11px;">
+                        <input type="checkbox" id="ob-auto-balance"> Auto-balance to
+                    </label>
+                    <select id="ob-equity-account">${equityOpts}</select>
+                </div>
+                <div class="form-actions" style="margin-top:12px;">
+                    <button class="btn btn-primary" onclick="OpeningBalancesPage.save()">Post Opening Balances</button>
+                </div>
+            </div>`;
+    },
+
+    recalc() {
+        let debit = 0, credit = 0;
+        $$('.ob-amount').forEach(input => {
+            const amount = parseFloat(input.value) || 0;
+            if (!amount) return;
+            const acct = OpeningBalancesPage._accounts.find(a => a.id == input.dataset.account);
+            const debitNormal = acct.account_type === 'asset';
+            const debitSide = amount > 0 ? debitNormal : !debitNormal;
+            if (debitSide) debit += Math.abs(amount); else credit += Math.abs(amount);
+        });
+        const el = $('#ob-difference');
+        if (el) el.textContent = `Difference: ${formatCurrency(debit - credit)}`;
+    },
+
+    async save() {
+        const lines = [];
+        $$('.ob-amount').forEach(input => {
+            const amount = parseFloat(input.value) || 0;
+            if (amount) lines.push({ account_id: parseInt(input.dataset.account), amount });
+        });
+        const autoBalance = $('#ob-auto-balance').checked;
+        try {
+            const result = await API.post('/opening-balances', {
+                date: $('#ob-date').value,
+                reference: $('#ob-reference').value || null,
+                lines,
+                auto_balance_account_id: autoBalance ? parseInt($('#ob-equity-account').value) : null,
+            });
+            toast(result.auto_balanced
+                ? 'Opening balances posted (equity auto-balanced)'
+                : 'Opening balances posted');
+            App.navigate('#/accounts');
+        } catch (err) { toast(err.message, 'error'); }
+    },
+};

--- a/app/static/js/xero_import.js
+++ b/app/static/js/xero_import.js
@@ -1,0 +1,85 @@
+/**
+ * Xero Import — upload the CSV bundle, dry-run, then import.
+ * The Import button only unlocks after a passing dry-run.
+ */
+const XeroImportPage = {
+    _dryRunOk: false,
+
+    async render() {
+        XeroImportPage._dryRunOk = false;
+        return `
+            <div class="page-header">
+                <h2>Xero Import</h2>
+                <div style="font-size:10px; color:var(--text-muted);">
+                    Migrate accounting history from Xero CSV report exports
+                </div>
+            </div>
+            <div class="card" style="max-width:640px;">
+                <p style="font-size:12px; margin-bottom:8px;">
+                    Export from Xero as CSV and upload together: <strong>Chart of
+                    Accounts</strong> and <strong>General Ledger</strong> (required),
+                    <strong>Trial Balance</strong> (recommended — enables balance
+                    verification). Files are recognized by name.
+                </p>
+                <input type="file" id="xero-files" multiple accept=".csv" onchange="XeroImportPage.reset()">
+                <div class="form-actions" style="margin-top:12px;">
+                    <button class="btn btn-primary" onclick="XeroImportPage.dryRun()">Dry Run</button>
+                    <button class="btn btn-danger" id="xero-import-btn" disabled onclick="XeroImportPage.doImport()">Import</button>
+                </div>
+                <div id="xero-result" style="margin-top:12px; font-size:12px;"></div>
+            </div>`;
+    },
+
+    reset() {
+        XeroImportPage._dryRunOk = false;
+        const btn = $('#xero-import-btn');
+        if (btn) btn.disabled = true;
+        const out = $('#xero-result');
+        if (out) out.innerHTML = '';
+    },
+
+    _formData() {
+        const files = $('#xero-files').files;
+        if (!files.length) { toast('Choose the CSV files first', 'error'); return null; }
+        const fd = new FormData();
+        for (const f of files) fd.append('files', f);
+        return fd;
+    },
+
+    _renderResult(data, imported) {
+        const errs = data.errors.map(e => `<li style="color:var(--danger);">${escapeHtml(e)}</li>`).join('');
+        const warns = data.warnings.map(w => `<li style="color:var(--warning, #a8761f);">${escapeHtml(w)}</li>`).join('');
+        const head = imported
+            ? (data.ok ? `<strong>Imported ${data.imported_accounts} accounts and ${data.imported_journals} journals.</strong>`
+                       : '<strong style="color:var(--danger);">Import refused — fix the dry-run errors below.</strong>')
+            : (data.ok ? `<strong>Dry run passed:</strong> ${data.accounts} accounts, ${data.journals} journals ready to import.`
+                       : '<strong style="color:var(--danger);">Dry run failed:</strong>');
+        $('#xero-result').innerHTML = `${head}<ul style="margin-top:6px;">${errs}${warns}</ul>`;
+    },
+
+    async dryRun() {
+        const fd = XeroImportPage._formData();
+        if (!fd) return;
+        try {
+            const resp = await fetch('/api/xero-import/dry-run', { method: 'POST', body: fd });
+            const data = await resp.json();
+            if (!resp.ok) throw new Error(data.detail || 'Dry run failed');
+            XeroImportPage._dryRunOk = data.ok;
+            $('#xero-import-btn').disabled = !data.ok;
+            XeroImportPage._renderResult(data, false);
+        } catch (err) { toast(err.message, 'error'); }
+    },
+
+    async doImport() {
+        if (!XeroImportPage._dryRunOk) { toast('Run a passing dry run first', 'error'); return; }
+        const fd = XeroImportPage._formData();
+        if (!fd) return;
+        try {
+            const resp = await fetch('/api/xero-import/import', { method: 'POST', body: fd });
+            const data = await resp.json();
+            if (!resp.ok) throw new Error(data.detail || 'Import failed');
+            XeroImportPage._renderResult(data, true);
+            if (data.ok) toast(`Imported ${data.imported_accounts} accounts, ${data.imported_journals} journals`);
+        } catch (err) { toast(err.message, 'error'); }
+    },
+};

--- a/index.html
+++ b/index.html
@@ -124,6 +124,10 @@
                         <span class="nav-icon">&#9889;</span> Bank Rules</a></li>
                     <li><a href="#/fixed-assets" class="nav-link" data-page="fixed-assets">
                         <span class="nav-icon">&#127970;</span> Fixed Assets</a></li>
+                    <li><a href="#/opening-balances" class="nav-link" data-page="opening-balances">
+                        <span class="nav-icon">&#9878;</span> Opening Balances</a></li>
+                    <li><a href="#/xero-import" class="nav-link" data-page="xero-import">
+                        <span class="nav-icon">&#10515;</span> Xero Import</a></li>
                     <li><a href="#/deposits" class="nav-link" data-page="deposits">
                         <span class="nav-icon">&#9660;</span> Make Deposits</a></li>
                     <li><a href="#/check-register" class="nav-link" data-page="check-register">
@@ -243,6 +247,8 @@
     <!-- Phase 10: Quick Wins + Medium Effort Features -->
     <script src="/static/js/bank_rules.js"></script>
     <script src="/static/js/fixed_assets.js"></script>
+    <script src="/static/js/xero_import.js"></script>
+    <script src="/static/js/opening_balances.js"></script>
     <script src="/static/js/budgets.js"></script>
     <!-- App must be last -->
     <script src="/static/js/app.js"></script>

--- a/tests/test_xero_import.py
+++ b/tests/test_xero_import.py
@@ -1,0 +1,251 @@
+"""Xero import: dry-run contract (mutates nothing, blocks bad bundles)
+and import execution; opening-balance wizard posting rules."""
+
+import io
+
+from decimal import Decimal
+
+from app.models.accounts import Account, AccountType
+from app.models.transactions import Transaction, TransactionLine
+
+COA_CSV = (
+    "Code,Name,Type,Description\n"
+    "090,Business Bank,Bank,Main account\n"
+    "200,Sales,Revenue,\n"
+    "400,Advertising,Expense,\n"
+)
+
+GL_CSV = (
+    "Journal Number,Date,Account,Description,Reference,Debit,Credit\n"
+    '1,01/03/2026,Business Bank,Invoice paid,INV-1,"1,150.00",\n'
+    '1,01/03/2026,Sales,Invoice paid,INV-1,,"1,150.00"\n'
+    "2,05/03/2026,Advertising,Ad spend,BILL-9,200.00,\n"
+    "2,05/03/2026,Business Bank,Ad spend,BILL-9,,200.00\n"
+)
+
+TB_CSV = (
+    "Account,Debit,Credit\n"
+    "Business Bank,950.00,\n"
+    "Sales,,1150.00\n"
+    "Advertising,200.00,\n"
+)
+
+
+def _files(**named):
+    return [
+        ("files", (name, io.BytesIO(text.encode()), "text/csv"))
+        for name, text in named.items()
+    ]
+
+
+def test_dry_run_passes_and_mutates_nothing(client, db_session, seed_accounts):
+    before = db_session.query(Account).count()
+    resp = client.post(
+        "/api/xero-import/dry-run",
+        files=_files(
+            **{
+                "ChartOfAccounts.csv": COA_CSV,
+                "GeneralLedger.csv": GL_CSV,
+                "TrialBalance.csv": TB_CSV,
+            }
+        ),
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["ok"] is True, data
+    assert data["accounts"] == 3
+    assert data["journals"] == 2
+    assert db_session.query(Account).count() == before  # nothing written
+
+
+def test_dry_run_flags_unbalanced_journal(client, seed_accounts):
+    bad_gl = GL_CSV.replace('"1,150.00"\n', '"1,100.00"\n', 1)
+    resp = client.post(
+        "/api/xero-import/dry-run",
+        files=_files(**{"chart.csv": COA_CSV, "ledger.csv": bad_gl}),
+    )
+    data = resp.json()
+    assert data["ok"] is False
+    assert any("unbalanced" in e.lower() for e in data["errors"])
+
+
+def test_dry_run_flags_tb_mismatch(client, seed_accounts):
+    bad_tb = TB_CSV.replace("950.00", "900.00")
+    resp = client.post(
+        "/api/xero-import/dry-run",
+        files=_files(
+            **{"chart.csv": COA_CSV, "ledger.csv": GL_CSV, "trial.csv": bad_tb}
+        ),
+    )
+    data = resp.json()
+    assert data["ok"] is False
+    assert any("mismatch" in e.lower() for e in data["errors"])
+
+
+def test_dry_run_requires_gl_and_coa(client, seed_accounts):
+    resp = client.post(
+        "/api/xero-import/dry-run", files=_files(**{"trial.csv": TB_CSV})
+    )
+    data = resp.json()
+    assert data["ok"] is False
+    assert len(data["errors"]) == 2
+
+
+def test_import_creates_accounts_and_journals(client, db_session, seed_accounts):
+    resp = client.post(
+        "/api/xero-import/import",
+        files=_files(
+            **{
+                "chart.csv": COA_CSV,
+                "ledger.csv": GL_CSV,
+                "trial.csv": TB_CSV,
+            }
+        ),
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["imported_accounts"] == 3
+    assert data["imported_journals"] == 2
+
+    bank = db_session.query(Account).filter(Account.name == "Business Bank").one()
+    assert bank.account_type == AccountType.ASSET
+
+    journals = (
+        db_session.query(Transaction)
+        .filter(Transaction.source_type == "xero_import")
+        .all()
+    )
+    assert len(journals) == 2
+    for txn in journals:
+        lines = db_session.query(TransactionLine).filter_by(transaction_id=txn.id).all()
+        assert sum(ln.debit or 0 for ln in lines) == sum(ln.credit or 0 for ln in lines)
+
+    # readiness metadata recorded for the opening-balance wizard
+    status = client.get("/api/opening-balances/status").json()
+    assert status["chart_setup_source"] == "xero_import"
+
+
+def test_import_refuses_when_dry_run_fails(client, db_session, seed_accounts):
+    before = db_session.query(Transaction).count()
+    bad_gl = GL_CSV.replace('"1,150.00"\n', '"1,100.00"\n', 1)
+    resp = client.post(
+        "/api/xero-import/import",
+        files=_files(**{"chart.csv": COA_CSV, "ledger.csv": bad_gl}),
+    )
+    data = resp.json()
+    assert data["ok"] is False
+    assert data["imported_journals"] == 0
+    assert db_session.query(Transaction).count() == before
+
+
+# ── Opening-balance wizard ───────────────────────────────────────────────
+
+
+def _acct(db_session, name, acct_type):
+    row = Account(name=name, account_type=acct_type)
+    db_session.add(row)
+    db_session.commit()
+    return row
+
+
+def test_opening_balances_post_balanced_entry(client, db_session, seed_accounts):
+    checking = _acct(db_session, "OB Checking", AccountType.ASSET)
+    loan = _acct(db_session, "OB Loan", AccountType.LIABILITY)
+    equity = _acct(db_session, "OB Equity", AccountType.EQUITY)
+
+    resp = client.post(
+        "/api/opening-balances",
+        json={
+            "date": "2026-01-01",
+            "lines": [
+                {"account_id": checking.id, "amount": 5000},
+                {"account_id": loan.id, "amount": 3000},
+                {"account_id": equity.id, "amount": 2000},
+            ],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    txn = (
+        db_session.query(Transaction)
+        .filter(Transaction.source_type == "opening_balance")
+        .one()
+    )
+    lines = db_session.query(TransactionLine).filter_by(transaction_id=txn.id).all()
+    assert sum(ln.debit or 0 for ln in lines) == Decimal("5000.00")
+    assert sum(ln.credit or 0 for ln in lines) == Decimal("5000.00")
+
+
+def test_opening_balances_auto_balance(client, db_session, seed_accounts):
+    checking = _acct(db_session, "OB2 Checking", AccountType.ASSET)
+    equity = _acct(db_session, "OB2 Equity", AccountType.EQUITY)
+
+    # Unbalanced without helper → 400
+    unbalanced = client.post(
+        "/api/opening-balances",
+        json={
+            "date": "2026-01-01",
+            "lines": [{"account_id": checking.id, "amount": 750}],
+        },
+    )
+    assert unbalanced.status_code == 400
+    assert "unbalanced" in unbalanced.json()["detail"].lower()
+
+    # With auto-balance to equity → posts, difference lands on equity
+    resp = client.post(
+        "/api/opening-balances",
+        json={
+            "date": "2026-01-01",
+            "lines": [{"account_id": checking.id, "amount": 750}],
+            "auto_balance_account_id": equity.id,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["auto_balanced"] is True
+    txn = (
+        db_session.query(Transaction)
+        .filter(Transaction.source_type == "opening_balance")
+        .order_by(Transaction.id.desc())
+        .first()
+    )
+    lines = db_session.query(TransactionLine).filter_by(transaction_id=txn.id).all()
+    assert any(
+        ln.account_id == equity.id and ln.credit == Decimal("750.00") for ln in lines
+    )
+
+
+def test_opening_balances_rejects_zero_only(client, db_session, seed_accounts):
+    checking = _acct(db_session, "OB3 Checking", AccountType.ASSET)
+    resp = client.post(
+        "/api/opening-balances",
+        json={
+            "date": "2026-01-01",
+            "lines": [{"account_id": checking.id, "amount": 0}],
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_negative_amount_inverts_side(client, db_session, seed_accounts):
+    checking = _acct(db_session, "OB4 Checking", AccountType.ASSET)
+    equity = _acct(db_session, "OB4 Equity", AccountType.EQUITY)
+    # negative asset = credit side (e.g. overdrawn account)
+    resp = client.post(
+        "/api/opening-balances",
+        json={
+            "date": "2026-01-01",
+            "lines": [{"account_id": checking.id, "amount": -100}],
+            "auto_balance_account_id": equity.id,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    txn = (
+        db_session.query(Transaction)
+        .filter(Transaction.source_type == "opening_balance")
+        .order_by(Transaction.id.desc())
+        .first()
+    )
+    lines = db_session.query(TransactionLine).filter_by(transaction_id=txn.id).all()
+    assert any(
+        ln.account_id == checking.id and ln.credit == Decimal("100.00") for ln in lines
+    )


### PR DESCRIPTION
Two migration-onramp features from the joelmacklow fork's specs (Joel Macklow, @joelmacklow), re-implemented for upstream. Stacked on #28 (merge order #26 → #27 → #28 → this).

## Xero Import
Upload Xero CSV report exports (Chart of Accounts + General Ledger required, Trial Balance recommended — recognized by filename). **Dry-run is the contract**: it parses everything, verifies each reconstructed journal balances, flags GL accounts missing from the chart, cross-checks GL nets against the Trial Balance — and mutates *nothing* (pinned by test). The Import button only unlocks after a passing dry-run, and the server re-verifies and refuses independently. Import creates missing accounts and posts every journal through the standard engine.

## Opening Balances wizard
A guided page for entering opening balances without journal-entry knowledge: positive amounts land on each account's normal side (assets debit; liabilities/equity credit), negatives invert, and an auto-balance helper posts any difference to a chosen equity account. Produces one balanced journal entry. Blocked state (no chart yet) links to Settings and Xero Import; a successful Xero import records the readiness metadata.

## Testing
Full suite **995 passed** (10 new). No schema changes — both features ride the existing journal engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)