### PR TITLE
Feature: financial-report PDFs + statements pack

### DIFF
--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -57,6 +57,8 @@ DEFAULT_SETTINGS = {
     "smtp_use_tls": "true",
     # Feature 15: Company Logo
     "company_logo_path": "",
+    # Report PDF paper size: letter | a4
+    "pdf_paper_size": "letter",
     # Opening-balance wizard readiness metadata
     "chart_setup_source": "",
     "chart_setup_ready_at": "",

--- a/app/routes/reports/financial.py
+++ b/app/routes/reports/financial.py
@@ -535,3 +535,164 @@ def profit_loss_by_class(
         "total_expenses": sum(c["expenses"] for c in columns),
         "total_net_income": sum(c["net_income"] for c in columns),
     }
+
+
+# ── Financial-report PDFs ────────────────────────────────────────────────
+# One shared renderer (report_pdf.html + _report_theme.html) with the
+# pdf_paper_size setting (letter default, a4 selectable). The statements
+# pack bundles P&L + Balance Sheet + Trial Balance into one document.
+
+
+def _money(value) -> str:
+    amount = Decimal(str(value or 0))
+    sign = "-" if amount < 0 else ""
+    return f"{sign}${abs(amount):,.2f}"
+
+
+def _pl_section(data: dict) -> dict:
+    rows = []
+    for label, key, total_key in (
+        ("Income", "income", "total_income"),
+        ("Cost of Goods Sold", "cogs", "total_cogs"),
+    ):
+        rows.append({"cells": [label, ""], "style": "subtotal"})
+        for item in data[key]:
+            rows.append(
+                {"cells": [f"  {item['account_name']}", _money(item["amount"])]}
+            )
+        rows.append(
+            {"cells": [f"Total {label}", _money(data[total_key])], "style": "subtotal"}
+        )
+    rows.append(
+        {"cells": ["Gross Profit", _money(data["gross_profit"])], "style": "subtotal"}
+    )
+    rows.append({"cells": ["Expenses", ""], "style": "subtotal"})
+    for item in data["expenses"]:
+        rows.append({"cells": [f"  {item['account_name']}", _money(item["amount"])]})
+    rows.append(
+        {
+            "cells": ["Total Expenses", _money(data["total_expenses"])],
+            "style": "subtotal",
+        }
+    )
+    rows.append(
+        {"cells": ["Net Income", _money(data["net_income"])], "style": "grand-total"}
+    )
+    return {
+        "title": "Profit & Loss",
+        "period": f"{data['start_date']} — {data['end_date']}",
+        "columns": ["", "Amount"],
+        "rows": rows,
+    }
+
+
+def _bs_section(data: dict) -> dict:
+    rows = []
+    for label, key, total_key in (
+        ("Assets", "assets", "total_assets"),
+        ("Liabilities", "liabilities", "total_liabilities"),
+        ("Equity", "equity", "total_equity"),
+    ):
+        rows.append({"cells": [label, ""], "style": "subtotal"})
+        for item in data[key]:
+            rows.append(
+                {"cells": [f"  {item['account_name']}", _money(item["amount"])]}
+            )
+        rows.append(
+            {"cells": [f"Total {label}", _money(data[total_key])], "style": "subtotal"}
+        )
+    rows.append(
+        {
+            "cells": [
+                "Liabilities + Equity",
+                _money(data["total_liabilities"] + data["total_equity"]),
+            ],
+            "style": "grand-total",
+        }
+    )
+    return {
+        "title": "Balance Sheet",
+        "period": f"As of {data['as_of_date']}",
+        "columns": ["", "Amount"],
+        "rows": rows,
+    }
+
+
+def _tb_section(data: dict) -> dict:
+    rows = [
+        {
+            "cells": [
+                f"{item['account_number']} {item['account_name']}".strip(),
+                _money(item["total_debit"]),
+                _money(item["total_credit"]),
+            ]
+        }
+        for item in data["items"]
+    ]
+    rows.append(
+        {
+            "cells": [
+                "Total",
+                _money(data["total_debit"]),
+                _money(data["total_credit"]),
+            ],
+            "style": "grand-total",
+        }
+    )
+    return {
+        "title": "Trial Balance",
+        "period": f"{data['start_date']} — {data['end_date']}",
+        "columns": ["Account", "Debit", "Credit"],
+        "rows": rows,
+    }
+
+
+def _pdf_response(sections, db, filename: str):
+    from fastapi.responses import Response
+    from app.services.pdf_service import generate_report_pdf
+    from app.services.settings_service import get_all_settings
+
+    pdf_bytes = generate_report_pdf(sections, get_all_settings(db))
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'inline; filename="{filename}"'},
+    )
+
+
+@router.get("/profit-loss/pdf")
+def profit_loss_pdf(
+    start_date: date = Query(default=None),
+    end_date: date = Query(default=None),
+    db: Session = Depends(get_db),
+):
+    data = profit_loss(start_date, end_date, db)
+    return _pdf_response([_pl_section(data)], db, "profit-loss.pdf")
+
+
+@router.get("/balance-sheet/pdf")
+def balance_sheet_pdf(
+    as_of_date: date = Query(default=None), db: Session = Depends(get_db)
+):
+    data = balance_sheet(as_of_date, db)
+    return _pdf_response([_bs_section(data)], db, "balance-sheet.pdf")
+
+
+@router.get("/financial-statements/pdf")
+def financial_statements_pdf(
+    start_date: date = Query(default=None),
+    end_date: date = Query(default=None),
+    db: Session = Depends(get_db),
+):
+    """The statements pack: P&L, Balance Sheet, and Trial Balance in one
+    audit-ready document (each statement on its own page)."""
+    pl = profit_loss(start_date, end_date, db)
+    bs = balance_sheet(date.fromisoformat(pl["end_date"]), db)
+    tb = trial_balance(
+        date.fromisoformat(pl["start_date"]), date.fromisoformat(pl["end_date"]), db
+    )
+    return _pdf_response(
+        [_pl_section(pl), _bs_section(bs), _tb_section(tb)],
+        db,
+        "financial-statements.pdf",
+    )

--- a/app/services/pdf_service.py
+++ b/app/services/pdf_service.py
@@ -235,3 +235,22 @@ def generate_check_pdf(check_data: dict, company_settings: dict) -> bytes:
     check_data["amount_words"] = _amount_to_words(check_data.get("amount", 0))
     html_str = template.render(check=check_data, company=company_settings)
     return HTML(string=html_str, url_fetcher=_safe_url_fetcher).write_pdf()
+
+
+def generate_report_pdf(sections: list, company_settings: dict) -> bytes:
+    """Render one or more financial-report sections into a single PDF.
+
+    sections: [{title, period, columns: [...], rows: [{cells, style}]}]
+    Paper size comes from the pdf_paper_size setting (letter | a4) so US
+    and international installs both print natively.
+    """
+    from datetime import date
+
+    template = _jinja_env.get_template("report_pdf.html")
+    html_str = template.render(
+        sections=sections,
+        company=company_settings,
+        paper_size=(company_settings.get("pdf_paper_size") or "letter").lower(),
+        generated_on=date.today().isoformat(),
+    )
+    return HTML(string=html_str, url_fetcher=_safe_url_fetcher).write_pdf()

--- a/app/static/js/reports.js
+++ b/app/static/js/reports.js
@@ -61,6 +61,10 @@ const ReportsPage = {
                     <div class="card-header">P&L by Class</div>
                     <p style="font-size:13px; color:var(--gray-500);">Income vs expenses split by class</p>
                 </div>
+                <div class="card" style="cursor:pointer" onclick="ReportsPage.financialStatementsPdf()">
+                    <div class="card-header">Financial Statements Pack (PDF)</div>
+                    <p style="font-size:13px; color:var(--gray-500);">P&L + Balance Sheet + Trial Balance, one audit-ready PDF</p>
+                </div>
                 <div class="card" style="cursor:pointer" onclick="ReportsPage.fixedAssetReconciliation()">
                     <div class="card-header">Fixed Asset Reconciliation</div>
                     <p style="font-size:13px; color:var(--gray-500);">Register totals vs GL by asset type</p>
@@ -848,4 +852,15 @@ ReportsPage.fixedAssetReconciliation = async function () {
             Compare against the mapped fixed-asset and accumulated-depreciation
             GL accounts — differences mean unposted acquisitions or manual GL edits.
         </div>`);
+};
+
+// Financial statements pack — one PDF with P&L, Balance Sheet, Trial Balance.
+ReportsPage.financialStatementsPdf = async function () {
+    await ReportsPage.openPeriodModal("Financial Statements Pack", "this_year_to_date", async (_period, range) => {
+        window.open(`/api/reports/financial-statements/pdf?start_date=${range.start}&end_date=${range.end}`, '_blank');
+        return `<div style="font-size:12px;">The statements pack opened in a new tab —
+            P&L and Trial Balance for ${escapeHtml(range.start)} — ${escapeHtml(range.end)},
+            Balance Sheet as of ${escapeHtml(range.end)}. Paper size follows
+            Settings → Report PDF Paper Size.</div>`;
+    });
 };

--- a/app/static/js/reports.js
+++ b/app/static/js/reports.js
@@ -401,6 +401,7 @@ const ReportsPage = {
     async profitLoss(prefill) {
         await ReportsPage.openPeriodModal("Profit & Loss", "this_year_to_date", async (_period, range) => {
             const data = await API.get(`/reports/profit-loss?start_date=${range.start}&end_date=${range.end}`);
+            const pdfBtn = `<div style="text-align:right; margin-bottom:6px;"><button class="btn btn-sm btn-secondary" onclick="window.open('/api/reports/profit-loss/pdf?start_date=${range.start}&end_date=${range.end}','_blank')">Save PDF</button></div>`;
             // Build the onclick payload outside the template so we can
             // HTML-escape the embedded double quotes from JSON.stringify().
             // Otherwise the inner " breaks the outer onclick="…" attribute.
@@ -416,7 +417,7 @@ const ReportsPage = {
                         </td><td class="amount">${formatCurrency(Math.abs(i.amount))}</td></tr>`
                 ).join("");
             };
-            return `
+            return `${pdfBtn}
                 <p style="margin-bottom:12px; color:var(--gray-500);">${formatDate(data.start_date)} &mdash; ${formatDate(data.end_date)}</p>
                 <div class="table-container"><table>
                     <thead><tr><th>Account</th><th class="amount">Amount</th></tr></thead>
@@ -439,6 +440,7 @@ const ReportsPage = {
     async balanceSheet(prefill) {
         await ReportsPage.openPeriodModal("Balance Sheet", "this_year_to_date", async (_period, params) => {
             const data = await API.get(`/reports/balance-sheet?as_of_date=${params.as_of_date}`);
+            const pdfBtn = `<div style="text-align:right; margin-bottom:6px;"><button class="btn btn-sm btn-secondary" onclick="window.open('/api/reports/balance-sheet/pdf?as_of_date=${params.as_of_date}','_blank')">Save PDF</button></div>`;
             const drillCall = (i) => escapeHtml(
                 `ReportsPage.openDrillDown(${i.account_id},${JSON.stringify(i.account_name)},null,${JSON.stringify(params.as_of_date)})`
             );
@@ -448,7 +450,7 @@ const ReportsPage = {
                        onclick="${drillCall(i)}">${escapeHtml(i.account_name)}</a>
                     </td><td class="amount">${formatCurrency(Math.abs(i.amount))}</td></tr>`
             ).join("") || `<tr><td colspan="2" style="color:var(--gray-400);">None</td></tr>`;
-            return `
+            return `${pdfBtn}
                 <p style="margin-bottom:12px; color:var(--gray-500);">As of ${formatDate(data.as_of_date)}</p>
                 <div class="table-container"><table>
                     <thead><tr><th>Account</th><th class="amount">Amount</th></tr></thead>

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -79,6 +79,11 @@ const SettingsPage = {
                             <textarea name="invoice_notes">${escapeHtml(s.invoice_notes || '')}</textarea></div>
                         <div class="form-group full-width"><label>Invoice Footer</label>
                             <input name="invoice_footer" value="${escapeHtml(s.invoice_footer || '')}"></div>
+                        <div class="form-group"><label>Report PDF Paper Size</label>
+                            <select name="pdf_paper_size">
+                                <option value="letter" ${s.pdf_paper_size !== 'a4' ? 'selected' : ''}>US Letter</option>
+                                <option value="a4" ${s.pdf_paper_size === 'a4' ? 'selected' : ''}>A4</option>
+                            </select></div>
                     </div>
                 </div>
 

--- a/app/templates/_report_theme.html
+++ b/app/templates/_report_theme.html
@@ -1,0 +1,40 @@
+{# Shared print theme for financial-report PDFs.
+   Paper size comes from the pdf_paper_size setting (letter default,
+   a4 selectable) — parameterized rather than hardcoded so US and
+   international installs both print natively. Ported concept from the
+   joelmacklow fork's _document_theme partial. #}
+<style>
+    @page {
+        size: {{ 'A4' if paper_size == 'a4' else 'letter' }};
+        margin: 18mm 16mm 20mm 16mm;
+        @bottom-center {
+            content: "{{ company.get('company_name', '') }} — page " counter(page) " of " counter(pages);
+            font-size: 8px;
+            color: #888;
+        }
+    }
+    body {
+        font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+        font-size: 10.5px;
+        color: #1a1a2e;
+        margin: 0;
+    }
+    h1 { font-size: 18px; margin: 0 0 2px; }
+    h2 { font-size: 13px; margin: 18px 0 6px; border-bottom: 2px solid #1a1a2e; padding-bottom: 3px; }
+    .report-header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 14px; }
+    .report-meta { font-size: 9.5px; color: #555; text-align: right; }
+    table.report { width: 100%; border-collapse: collapse; }
+    table.report th {
+        text-align: left; font-size: 9px; text-transform: uppercase;
+        letter-spacing: 0.04em; color: #555; border-bottom: 1px solid #999;
+        padding: 3px 6px;
+    }
+    table.report th.amount, table.report td.amount { text-align: right; white-space: nowrap; }
+    table.report td { padding: 3px 6px; border-bottom: 0.5px solid #e2e2e2; }
+    table.report tr.subtotal td { font-weight: 700; border-top: 1px solid #999; }
+    table.report tr.grand-total td {
+        font-weight: 700; border-top: 2px solid #1a1a2e;
+        border-bottom: 3px double #1a1a2e; font-size: 11px;
+    }
+    .section-break { page-break-before: always; }
+</style>

--- a/app/templates/report_pdf.html
+++ b/app/templates/report_pdf.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    {% include "_report_theme.html" %}
+</head>
+<body>
+    {% for section in sections %}
+    <div {% if not loop.first %}class="section-break"{% endif %}>
+        <div class="report-header">
+            <div>
+                <h1>{{ section.title }}</h1>
+                <div style="font-size:12px; font-weight:600;">{{ company.get('company_name', '') }}</div>
+            </div>
+            <div class="report-meta">
+                {{ section.period }}<br>
+                Generated {{ generated_on }}
+            </div>
+        </div>
+        <table class="report">
+            <thead>
+                <tr>
+                    {% for col in section.columns %}
+                    <th {% if not loop.first %}class="amount"{% endif %}>{{ col }}</th>
+                    {% endfor %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for row in section.rows %}
+                <tr class="{{ row.style or '' }}">
+                    {% for cell in row.cells %}
+                    <td {% if not loop.first %}class="amount"{% endif %}>{{ cell }}</td>
+                    {% endfor %}
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% endfor %}
+</body>
+</html>

--- a/tests/test_report_pdfs.py
+++ b/tests/test_report_pdfs.py
@@ -1,0 +1,78 @@
+"""Financial-report PDFs: render smoke tests for both paper sizes and
+the statements pack."""
+
+from datetime import date
+from decimal import Decimal
+
+from app.models.accounts import Account, AccountType
+from app.services.accounting import create_journal_entry
+from app.services.settings_service import set_setting
+
+
+def _post_activity(db_session):
+    income = (
+        db_session.query(Account)
+        .filter(Account.account_type == AccountType.INCOME)
+        .first()
+    )
+    expense = (
+        db_session.query(Account)
+        .filter(Account.account_type == AccountType.EXPENSE)
+        .first()
+    )
+    create_journal_entry(
+        db_session,
+        date(2026, 6, 15),
+        "pdf smoke revenue",
+        [
+            {"account_id": expense.id, "debit": Decimal("40"), "credit": Decimal("0")},
+            {"account_id": income.id, "debit": Decimal("0"), "credit": Decimal("40")},
+        ],
+    )
+    db_session.commit()
+
+
+def test_profit_loss_pdf_renders(client, db_session, seed_accounts):
+    _post_activity(db_session)
+    resp = client.get(
+        "/api/reports/profit-loss/pdf?start_date=2026-01-01&end_date=2026-12-31"
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/pdf"
+    assert resp.content[:5] == b"%PDF-"
+
+
+def test_balance_sheet_pdf_renders(client, db_session, seed_accounts):
+    _post_activity(db_session)
+    resp = client.get("/api/reports/balance-sheet/pdf?as_of_date=2026-12-31")
+    assert resp.status_code == 200
+    assert resp.content[:5] == b"%PDF-"
+
+
+def test_statements_pack_renders_both_paper_sizes(client, db_session, seed_accounts):
+    _post_activity(db_session)
+    for size in ("letter", "a4"):
+        set_setting(db_session, "pdf_paper_size", size)
+        db_session.commit()
+        resp = client.get(
+            "/api/reports/financial-statements/pdf"
+            "?start_date=2026-01-01&end_date=2026-12-31"
+        )
+        assert resp.status_code == 200, (size, resp.text)
+        assert resp.content[:5] == b"%PDF-"
+        # A4 and letter pages differ in size, so the rendered bytes must too
+    set_setting(db_session, "pdf_paper_size", "letter")
+    db_session.commit()
+
+
+def test_pack_differs_by_paper_size(client, db_session, seed_accounts):
+    _post_activity(db_session)
+    outputs = {}
+    for size in ("letter", "a4"):
+        set_setting(db_session, "pdf_paper_size", size)
+        db_session.commit()
+        outputs[size] = client.get(
+            "/api/reports/financial-statements/pdf"
+            "?start_date=2026-01-01&end_date=2026-12-31"
+        ).content
+    assert outputs["letter"] != outputs["a4"]


### PR DESCRIPTION
Final wave of the fork-integration program. Ports the joelmacklow fork's report-PDF pipeline concept (Joel Macklow, @joelmacklow) onto upstream's existing WeasyPrint service. Stacked on #29 (merge order #26 → #27 → #28 → #29 → this).

## What you get
- **Print any financial report**: `/api/reports/profit-loss/pdf`, `/api/reports/balance-sheet/pdf` — rendered from the *same* report functions the SPA reads, so the PDF can never disagree with the screen.
- **Financial Statements Pack**: one audit-ready PDF with P&L, Balance Sheet, and Trial Balance, each on its own page with page numbering — new card in Reports.
- **Paper size is a setting** (`pdf_paper_size`: US Letter default, A4 selectable in Settings). The fork hardcoded A4 for NZ; upstream stays letter-first with A4 one dropdown away.
- Shared `_report_theme.html` print theme for future report PDFs.

## Testing
Full suite **1005 passed** (4 new render smoke tests: `%PDF` magic per endpoint, both paper sizes, letter-vs-A4 byte difference).

---
This completes all planned waves: 4 forks mined with attribution, payments (Stripe abstraction + PayPal + Square, sandbox-verified), class tracking, multi-currency, fixed assets, Xero import + opening balances, and report PDFs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)