### PR TITLE
Multi-currency: realized FX on bill payments (closes the v1 A/P gap)

### DIFF
--- a/app/models/bills.py
+++ b/app/models/bills.py
@@ -115,6 +115,9 @@ class BillPayment(Base):
     check_number = Column(String(50), nullable=True)
     pay_from_account_id = Column(Integer, ForeignKey("accounts.id"), nullable=True)
     notes = Column(Text, nullable=True)
+    # Multi-currency: payment currency + rate it settled at (GL is home)
+    currency = Column(String(3), nullable=True)
+    exchange_rate = Column(Numeric(18, 8), nullable=True)
     transaction_id = Column(Integer, ForeignKey("transactions.id"), nullable=True)
     is_voided = Column(Boolean, default=False, nullable=False)
 

--- a/app/routes/bill_payments.py
+++ b/app/routes/bill_payments.py
@@ -42,6 +42,15 @@ def create_bill_payment(data: BillPaymentCreate, db: Session = Depends(get_db)):
     if not vendor:
         raise HTTPException(status_code=404, detail="Vendor not found")
 
+    from app.services.currency import (
+        document_currency,
+        fx_gain_loss_account_id,
+        resolve_rate,
+        to_home,
+    )
+
+    pay_currency, pay_rate = resolve_rate(db, data.currency, data.exchange_rate)
+
     alloc_total = sum(a.amount for a in data.allocations)
     if alloc_total > data.amount:
         raise HTTPException(status_code=400, detail="Allocations exceed payment amount")
@@ -54,10 +63,15 @@ def create_bill_payment(data: BillPaymentCreate, db: Session = Depends(get_db)):
         check_number=data.check_number,
         pay_from_account_id=data.pay_from_account_id,
         notes=data.notes,
+        currency=pay_currency,
+        exchange_rate=pay_rate,
     )
     db.add(payment)
     db.flush()
 
+    # Home-currency value of A/P relieved per allocation (at each bill's
+    # booked rate) — the realized-FX basis, mirroring the A/R side.
+    ap_home_debits: list[Decimal] = []
     for alloc_data in data.allocations:
         bill = db.query(Bill).filter(Bill.id == alloc_data.bill_id).first()
         if not bill:
@@ -68,6 +82,20 @@ def create_bill_payment(data: BillPaymentCreate, db: Session = Depends(get_db)):
             raise HTTPException(
                 status_code=400, detail="Allocation exceeds bill balance"
             )
+
+        bill_currency = document_currency(bill, db)
+        if bill_currency != pay_currency:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Payment currency {pay_currency} does not match bill "
+                    f"{bill.bill_number} currency {bill_currency}; pay each "
+                    f"currency with a separate payment"
+                ),
+            )
+        ap_home_debits.append(
+            to_home(alloc_data.amount, bill.exchange_rate or Decimal("1"))
+        )
 
         db.add(
             BillPaymentAllocation(
@@ -93,20 +121,40 @@ def create_bill_payment(data: BillPaymentCreate, db: Session = Depends(get_db)):
         bank_id = checking.id if checking else None
 
     if ap_id and bank_id:
+        # Cash paid, in home currency at the payment-date rate; A/P
+        # relieved at each bill's BOOKED rate. Unallocated remainder (a
+        # vendor prepayment) has no booking rate yet, so it relieves at
+        # the payment rate.
+        cash_home = to_home(data.amount, pay_rate)
+        unallocated = Decimal(str(data.amount)) - Decimal(str(alloc_total))
+        ap_home = sum(ap_home_debits, Decimal("0")) + to_home(unallocated, pay_rate)
         journal_lines = [
             {
                 "account_id": ap_id,
-                "debit": Decimal(str(data.amount)),
+                "debit": ap_home,
                 "credit": Decimal("0"),
                 "description": f"Bill payment to {vendor.name}",
             },
             {
                 "account_id": bank_id,
                 "debit": Decimal("0"),
-                "credit": Decimal(str(data.amount)),
+                "credit": cash_home,
                 "description": f"Bill payment to {vendor.name}",
             },
         ]
+        # Realized FX: settling A/P cheaper than booked = gain (credit),
+        # dearer = loss (debit). Mirror of the customer-payment side.
+        residual = ap_home - cash_home
+        if residual != 0:
+            fx_id = fx_gain_loss_account_id(db)
+            journal_lines.append(
+                {
+                    "account_id": fx_id,
+                    "debit": -residual if residual < 0 else Decimal("0"),
+                    "credit": residual if residual > 0 else Decimal("0"),
+                    "description": f"Realized FX on bill payment to {vendor.name}",
+                }
+            )
         txn = create_journal_entry(
             db,
             data.date,

--- a/migrations/versions/a5b6c7d8e9f0_bill_payment_currency.py
+++ b/migrations/versions/a5b6c7d8e9f0_bill_payment_currency.py
@@ -1,0 +1,35 @@
+"""bill_payment_currency
+
+Currency + settlement rate on bill payments — closes the multi-currency
+v1 gap: A/P now realizes FX gain/loss the same way A/R does.
+
+Revision ID: a5b6c7d8e9f0
+Revises: f4a5b6c7d8e9
+Create Date: 2026-08-01
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "a5b6c7d8e9f0"
+down_revision: Union[str, None] = "f4a5b6c7d8e9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("bill_payments") as batch_op:
+        batch_op.add_column(sa.Column("currency", sa.String(length=3), nullable=True))
+        batch_op.add_column(
+            sa.Column("exchange_rate", sa.Numeric(18, 8), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("bill_payments") as batch_op:
+        batch_op.drop_column("exchange_rate")
+        batch_op.drop_column("currency")

--- a/tests/test_multi_currency.py
+++ b/tests/test_multi_currency.py
@@ -247,3 +247,145 @@ def test_foreign_bill_posts_home_gl(client, db_session, seed_accounts):
     )
     lines = db_session.query(TransactionLine).filter_by(transaction_id=txn.id).all()
     assert sum(ln.debit or 0 for ln in lines) == Decimal("220.00")
+
+
+# ── A/P realized FX (bill payments) ──────────────────────────────────────
+
+
+@pytest.fixture
+def eur_bill(client, db_session, seed_accounts):
+    from app.models.contacts import Vendor
+
+    vendor = Vendor(name="Euro AP Supplier", is_active=True)
+    db_session.add(vendor)
+    db_session.commit()
+    expense = (
+        db_session.query(Account).filter(Account.name == "Office Supplies").first()
+    ) or db_session.query(Account).first()
+    resp = client.post(
+        "/api/bills",
+        json={
+            "vendor_id": vendor.id,
+            "bill_number": "EUR-AP-1",
+            "date": "2026-07-01",
+            "currency": "EUR",
+            "exchange_rate": "1.10",
+            "lines": [
+                {
+                    "account_id": expense.id,
+                    "description": "supplies",
+                    "quantity": 1,
+                    "rate": 100,
+                }
+            ],
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    return resp.json()
+
+
+def test_cross_currency_bill_payment_rejected(client, eur_bill):
+    resp = client.post(
+        "/api/bill-payments",
+        json={
+            "vendor_id": eur_bill["vendor_id"],
+            "date": "2026-07-10",
+            "amount": 100,
+            "currency": "USD",
+            "allocations": [{"bill_id": eur_bill["id"], "amount": 100}],
+        },
+    )
+    assert resp.status_code == 400
+    assert "does not match" in resp.json()["detail"]
+
+
+def _bill_payment_fx_lines(db_session):
+    fx_acct = db_session.query(Account).filter(Account.account_number == "6999").first()
+    txn = (
+        db_session.query(Transaction)
+        .filter(Transaction.source_type == "bill_payment")
+        .order_by(Transaction.id.desc())
+        .first()
+    )
+    lines = db_session.query(TransactionLine).filter_by(transaction_id=txn.id).all()
+    assert sum(ln.debit or 0 for ln in lines) == sum(ln.credit or 0 for ln in lines)
+    if fx_acct is None:
+        return []  # FX account never created — no FX activity at all
+    return [ln for ln in lines if ln.account_id == fx_acct.id]
+
+
+def test_bill_payment_realizes_fx_gain(client, db_session, eur_bill):
+    """Bill booked at 1.10 (A/P 110 home); settled at 1.05 (cash 105)
+    → 5.00 gain (credit) — paying cheaper than booked."""
+    resp = client.post(
+        "/api/bill-payments",
+        json={
+            "vendor_id": eur_bill["vendor_id"],
+            "date": "2026-07-10",
+            "amount": 100,
+            "currency": "EUR",
+            "exchange_rate": "1.05",
+            "allocations": [{"bill_id": eur_bill["id"], "amount": 100}],
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    fx_lines = _bill_payment_fx_lines(db_session)
+    assert len(fx_lines) == 1
+    assert fx_lines[0].credit == Decimal("5.00")
+
+    bill = client.get(f"/api/bills/{eur_bill['id']}").json()
+    assert bill["status"] == "paid"
+    assert Decimal(str(bill["balance_due"])) == Decimal("0.00")
+
+
+def test_bill_payment_realizes_fx_loss(client, db_session, eur_bill):
+    resp = client.post(
+        "/api/bill-payments",
+        json={
+            "vendor_id": eur_bill["vendor_id"],
+            "date": "2026-07-10",
+            "amount": 100,
+            "currency": "EUR",
+            "exchange_rate": "1.20",
+            "allocations": [{"bill_id": eur_bill["id"], "amount": 100}],
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    fx_lines = _bill_payment_fx_lines(db_session)
+    assert fx_lines[0].debit == Decimal("10.00")
+
+
+def test_home_currency_bill_payment_has_no_fx_line(client, db_session, seed_accounts):
+    from app.models.contacts import Vendor
+
+    vendor = Vendor(name="Home AP Vendor", is_active=True)
+    db_session.add(vendor)
+    db_session.commit()
+    expense = db_session.query(Account).first()
+    bill = client.post(
+        "/api/bills",
+        json={
+            "vendor_id": vendor.id,
+            "bill_number": "USD-AP-1",
+            "date": "2026-07-01",
+            "lines": [
+                {
+                    "account_id": expense.id,
+                    "description": "x",
+                    "quantity": 1,
+                    "rate": 50,
+                }
+            ],
+        },
+    ).json()
+    resp = client.post(
+        "/api/bill-payments",
+        json={
+            "vendor_id": vendor.id,
+            "date": "2026-07-10",
+            "amount": 50,
+            "allocations": [{"bill_id": bill["id"], "amount": 50}],
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    assert _bill_payment_fx_lines(db_session) == []


### PR DESCRIPTION
Closes the one documented gap from #27: bill payments on foreign-currency bills now realize FX gain/loss, exactly mirroring the customer-payment side.

- `BillPayment` gains `currency` + `exchange_rate` (migration `a5b6c7d8e9f0`, single-head verified).
- Allocations must match each bill's currency (clear 400 otherwise).
- Journal: **DR A/P at each bill's booked rate, CR bank at the payment-date rate**, residual → Exchange Gain/Loss (6999). Settling A/P cheaper than booked = gain (credit); dearer = loss (debit). Vendor prepayment remainders relieve at the payment rate.

## Testing
Full suite **1012 passed** (4 new: cross-currency rejection, gain and loss postings with balanced entries, home-currency no-FX-line).

With this merged, A/R and A/P are symmetric — multi-currency has no known gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)