### PR TITLE
Release prep: version-stable lint + CodeQL stack-trace fix

### DIFF
--- a/app/services/fixed_assets.py
+++ b/app/services/fixed_assets.py
@@ -13,7 +13,7 @@ import csv
 import io
 import logging
 from datetime import date
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
@@ -311,7 +311,16 @@ def import_assets_csv(db: Session, csv_text: str) -> dict:
             db.add(asset)
             db.flush()
             imported += 1
-        except Exception as exc:
+        except (ValueError, InvalidOperation) as exc:
+            # Expected parse/validation failures carry safe, row-scoped
+            # messages the operator needs to fix their CSV.
             errors.append({"row": i, "message": str(exc)})
+        except Exception:
+            # Unexpected failures must not echo internals to the client
+            # (CodeQL py/stack-trace-exposure) — log the detail, return a
+            # generic row error.
+            logger.exception("Asset CSV import failed on row %s", i)
+            errors.append({"row": i, "message": "Unexpected error importing this row"})
+            db.rollback()
     db.commit()
     return {"imported": imported, "errors": errors}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,13 @@
 # per-file-ignores apply consistently in CI and locally. Black is configured
 # via its own defaults (88-char line length).
 
+[tool.ruff.lint]
+# Explicit ruleset = version-stable CI. ruff 0.16 widened its defaults
+# (FURB/UP/B/I/DTZ/...) which failed the build with zero code changes;
+# these are the classic defaults the codebase is written against.
+# Widen deliberately, not by upgrade surprise.
+select = ["E4", "E7", "E9", "F"]
+
 [tool.ruff.lint.per-file-ignores]
 # E741 (ambiguous variable name 'l'): tests have several legacy loops like
 #   for l in lines: ...


### PR DESCRIPTION
Two release blockers:
1. **CI lint went red on main with zero code changes** — CI installs `ruff>=0.6.0` and ruff 0.16 widened its default ruleset (2,483 findings appeared overnight). `pyproject.toml` now pins `select = ["E4","E7","E9","F"]` so lint is version-stable; both ruff 0.15 and 0.16 pass.
2. **CodeQL alert #36** (`py/stack-trace-exposure`): the fixed-asset CSV import echoed `str(exc)` from a blind except. Expected parse errors keep their safe row messages; unexpected exceptions log server-side, return a generic row error, and roll back the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)