### PR TITLE
Release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
+### v2.3.0 — Migration onramps
+
+**Migrate Data** — one page that brings accounting history in from six
+systems, each behind the same dry-run-gated engine (nothing is written
+until every reconstructed journal balances and, when supplied, the
+trial balance reconciles):
+
+- **MYOB** — fully validated against MYOB's own Clearwater sample
+  company (101 accounts, 328 journals, ledger balanced to the cent,
+  every account reconciling exactly to MYOB's trial balance). Handles
+  tab-separated classic exports, dd/mm/yyyy dates, header accounts,
+  reused journal IDs, number-only GL rows, duplicate account names,
+  and per-type journal file bundles. docs/migrate-from-myob.md walks
+  the export flow.
+- **GnuCash** — fully validated against real 5.5 exports (multi-split
+  transactions, GUID grouping, signed per-split amounts, placeholder
+  accounts).
+- **Xero** — refactored onto the shared engine (behavior-identical).
+- **Zoho Books** — chart validated against a live account's export.
+- **Wave** — trial-balance report shape validated against a live
+  account's export; supports both debit/credit and signed
+  single-amount transaction exports.
+- **Sage 50** — account-ID resolution, mm/dd dates, Sage's descriptive
+  account types.
+- Opening balances: trial-balance residuals that net to zero (the
+  source system's account-setup balances, absent from any journal
+  export) are detected and imported as one balanced opening journal.
+
+**Dependencies** — refreshed across the board for the release
+(FastAPI 0.141, Stripe SDK 15, cryptography 50, argon2-cffi 25,
+python-multipart 0.0.32, psycopg2-binary 2.9.12); pip-audit clean.
+The route-table introspection tests were taught FastAPI 0.141's new
+nested-router shape, with a tripwire so a future shape change can
+never silently empty the auth-contract suite again.
+
 ### v2.2.0 — The fork-integration release
 
 The largest single release since 2.0: work mined from four community

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 # Single source of truth for the application version: app/main.py reports
 # it on the FastAPI app and /health, /api/system serves it to the frontend
 # footer, and the Windows release workflow parses it for the installer.
-__version__ = "2.2.0"
+__version__ = "2.3.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Web framework + ASGI server
-fastapi>=0.135.0,<0.137  # bumped to allow starlette 1.x for PYSEC-2026-161
+fastapi>=0.135.0,<0.142  # cap tracks latest tested (0.141.x, v2.3.0 release pass)
 uvicorn[standard]>=0.32.0,<1.0
 # Explicit starlette pin overrides fastapi's looser upper bound. Fixes:
 #   CVE-2024-47874  (DoS via multipart; fixed in 0.40.0)
@@ -10,7 +10,7 @@ starlette>=1.0.1,<2.0
 # Database
 sqlalchemy>=2.0.40,<3.0
 alembic>=1.16.0,<2.0
-psycopg2-binary==2.9.10  # 2.9.10+ ships Python 3.13 wheels; 2.9.9 forces source build on slim images
+psycopg2-binary==2.9.12  # 2.9.10+ ships Python 3.13 wheels; 2.9.9 forces source build on slim images
 
 # Validation + settings
 pydantic>=2.11.0,<3.0
@@ -23,14 +23,14 @@ weasyprint==69.0  # 68.1 affected by CVE-2026-49452 (CSS injection via presentat
 pydyf==0.12.1
 
 # Form upload parsing
-python-multipart==0.0.31  # CVE-2026-53538/-53539 (fixed 0.0.30), CVE-2026-53540 (fixed 0.0.31) — multipart parsing DoS hardening
+python-multipart==0.0.32  # CVE-2026-53538/-53539 (fixed 0.0.30), CVE-2026-53540 (fixed 0.0.31) — multipart parsing DoS hardening
 
 # Bank-statement parsing + dates
 ofxparse>=0.21,<1.0
 python-dateutil>=2.9.0,<3.0
 
 # Third-party integrations
-stripe>=8.0.0,<10.0
+stripe>=8.0.0,<16.0  # core Checkout/Webhook APIs stable across majors; verified by provider tests
 python-quickbooks>=0.9.0,<1.0
 intuit-oauth>=1.2.0,<2.0
 # Explicit pyjwt pin — intuit-oauth's transitive dep was at 2.7.0 (two CVEs).
@@ -44,12 +44,12 @@ pyjwt>=2.10.0,<3.0
 # none affect our Fernet/PBKDF2HMAC-only usage.
 # (46.x cap previously fixed: CVE-2023-50782, CVE-2024-0727, CVE-2024-12797,
 #  PYSEC-2024-225, PYSEC-2026-35, CVE-2026-26007, GHSA-h4gh-qq45-vh27)
-cryptography>=48.0.1,<49.0
+cryptography>=48.0.1,<51.0  # 49/50 reviewed: legacy-OpenSSL drops only; Fernet/PBKDF2 usage unaffected
 httpx>=0.27.0,<1.0
 # (orjson dropped — FastAPI 0.121+ serializes via Pydantic natively and
 #  deprecated ORJSONResponse in 0.136; we no longer pin a custom encoder.)
 
 # Auth + rate limiting
-argon2-cffi>=23.1.0,<24.0
+argon2-cffi>=23.1.0,<26.0
 itsdangerous>=2.1.0,<3.0  # Starlette SessionMiddleware signer
 slowapi>=0.1.9,<1.0

--- a/tests/test_sensitive_route_auth_contract.py
+++ b/tests/test_sensitive_route_auth_contract.py
@@ -43,9 +43,25 @@ def _fill_params(path: str) -> str:
     return re.sub(r"\{[^}]+\}", "1", path)
 
 
+def _iter_app_routes(routes):
+    """Yield concrete routes across FastAPI versions.
+
+    FastAPI 0.141 wraps each include_router() in an _IncludedRouter that
+    carries no .path itself — the real APIRoutes live on its
+    .original_router. Older versions put routes directly in app.routes.
+    Duck-typed so both shapes work.
+    """
+    for route in routes:
+        if hasattr(route, "path"):
+            yield route
+        inner = getattr(route, "original_router", None)
+        if inner is not None:
+            yield from _iter_app_routes(inner.routes)
+
+
 def _api_routes():
     out = []
-    for route in app.routes:
+    for route in _iter_app_routes(app.routes):
         path = getattr(route, "path", "")
         methods = getattr(route, "methods", None) or set()
         if not path.startswith("/api/"):
@@ -62,6 +78,13 @@ def _is_exempt(path: str) -> bool:
     if filled in _AUTH_EXEMPT_EXACT or filled.startswith(_AUTH_EXEMPT_PREFIXES):
         return True
     return bool(_AUTH_EXEMPT_RE and _AUTH_EXEMPT_RE.match(filled))
+
+
+def test_route_table_is_not_empty():
+    """A FastAPI upgrade that changes the route-table shape must fail
+    loudly here, not silently empty the parametrized contract below
+    (which pytest reports as a single skip)."""
+    assert len(_api_routes()) > 100
 
 
 @pytest.mark.parametrize("method,path", _api_routes())

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -56,13 +56,29 @@ def _normalize_js_path(raw: str) -> str:
     return path
 
 
+def _iter_app_routes(routes):
+    """Yield concrete routes across FastAPI versions.
+
+    FastAPI 0.141 wraps each include_router() in an _IncludedRouter that
+    carries no .path itself — the real APIRoutes live on its
+    .original_router. Older versions put routes directly in app.routes.
+    Duck-typed so both shapes work.
+    """
+    for route in routes:
+        if hasattr(route, "path"):
+            yield route
+        inner = getattr(route, "original_router", None)
+        if inner is not None:
+            yield from _iter_app_routes(inner.routes)
+
+
 @pytest.fixture(scope="module")
 def app_routes():
     """List of (METHOD, [path_segments]) for every registered FastAPI route."""
     from app.main import app
 
     out = []
-    for route in app.routes:
+    for route in _iter_app_routes(app.routes):
         methods = getattr(route, "methods", None) or set()
         segs = route.path.split("/")
         for m in methods:


### PR DESCRIPTION
Version bump + changelog for the migration-onramps release, plus the full dependency refresh (FastAPI 0.141, Stripe 15, cryptography 50 — all caps reviewed, pip-audit clean, 1033 tests green). Includes the FastAPI 0.141 route-table compatibility fix with an anti-silent-skip tripwire on the auth contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)