### PR TITLE
Add community show-and-tell link to the sidebar footer

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -303,6 +303,19 @@ body {
     user-select: none;
 }
 
+.sidebar-footer .footer-link {
+    display: block;
+    margin-bottom: 4px;
+    font-size: 10px;
+    color: rgba(255,255,255,0.35);
+    text-decoration: none;
+}
+
+.sidebar-footer .footer-link:hover {
+    color: rgba(255,255,255,0.75);
+    text-decoration: underline;
+}
+
 /* Desktop-install update notice (fed by /api/system/update-check) */
 .update-badge {
     display: block;

--- a/index.html
+++ b/index.html
@@ -166,6 +166,11 @@
                         <span class="nav-icon">&#9632;</span> Companies</a></li>
                 </ul>
                 <div class="sidebar-footer" id="sidebar-footer">
+                    <!-- External URL: the desktop shim only intercepts
+                         same-origin _blank links, so this opens in the
+                         system browser (same path as the update badge). -->
+                    <a href="https://github.com/VonHoltenCodes/SlowBooks-Pro-2026/discussions/39"
+                       target="_blank" rel="noopener" class="footer-link">Using SlowBooks for real work? Tell us &rarr;</a>
                     <span id="app-version">Build 12.0.3190-R</span><br>
                     &copy; 2026 Slowbooks
                 </div>


### PR DESCRIPTION
Adds an opt-in invitation to the sidebar footer linking to the pinned ["Who's using SlowBooks?" Discussion (#39)](https://github.com/VonHoltenCodes/SlowBooks-Pro-2026/discussions/39).

- External `target="_blank"` link — the desktop shim only intercepts same-origin links, so this opens in the system browser (same mechanism as the update badge, verified against `desktop_shim.js`).
- Subtle footer styling consistent with the existing `.sidebar-footer` treatment; hover reveals it.
- No data collection, no telemetry — a link, nothing else.
- `test_wiring.py` green (its href scan only covers `/api/...` paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uzF92MM21Ac6Y6Gfei4ro