### PR TITLE
SimpleFIN bank feeds: automatic transaction sync with a user-held credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Full feature catalog (300+ entries across every module) lives in **[docs/feature
 ![Duplicate detection warning on customer create](screenshots/duplicate-detection.png)
 
 - **Online payments** — Stripe, PayPal, and Square behind one provider abstraction, with desktop-mode payment recording. Setup guides: [Stripe](docs/setup-stripe.md), [PayPal](docs/setup-paypal.md), [Square](docs/setup-square.md).
+- **Bank feeds** — Automatic transaction sync via [SimpleFIN](https://www.simplefin.org/): you hold the bank credential (no middleman server, no developer API keys), transactions dedup against OFX/CSV imports, and bank rules auto-categorize on arrival. See **[docs/setup-bank-feeds.md](docs/setup-bank-feeds.md)**.
 - **QuickBooks Online sync** — OAuth + bidirectional sync. See **[docs/setup-qbo.md](docs/setup-qbo.md)**.
 - **QB2003 interop** — IIF import/export with type-mapping, validation, round-trip safety, and INVOICE/PAYMENT/ESTIMATE/BILL/DEPOSIT transaction blocks (classes included).
 - **Fixed assets** — Register, depreciation runs, disposal with gain/loss, CSV import, reconciliation report.

--- a/app/main.py
+++ b/app/main.py
@@ -63,7 +63,7 @@ from app.routes import csv as csv_routes
 from app.routes import uploads
 
 # Phase 5: Advanced Integration
-from app.routes import bank_import, tax, backups
+from app.routes import bank_import, simplefin, tax, backups
 from app.routes import classes as classes_routes
 from app.routes import fx as fx_routes
 from app.routes import fixed_assets as fixed_assets_routes
@@ -400,6 +400,7 @@ app.include_router(csv_routes.router)
 app.include_router(uploads.router)
 # Phase 5: Advanced Integration
 app.include_router(bank_import.router)
+app.include_router(simplefin.router)
 app.include_router(tax.router)
 app.include_router(backups.router)
 app.include_router(system_routes.router)

--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -84,6 +84,12 @@ DEFAULT_SETTINGS = {
     # Square signs webhooks over the EXACT notification URL registered in
     # its dashboard; set this to that URL (required for webhook verification)
     "square_notification_url": "",
+    # SimpleFIN bank feeds (user-held bridge.simplefin.org credential).
+    # access_url embeds basic-auth creds — listed in SECRET_KEYS.
+    "simplefin_access_url": "",
+    "simplefin_account_map": "{}",  # JSON {simplefin id: bank_account_id}
+    "simplefin_accounts_cache": "[]",  # last-seen bridge accounts, for the UI
+    "simplefin_last_sync": "",
     # QuickBooks Online Integration
     "qbo_enabled": "false",
     "qbo_client_id": "",

--- a/app/routes/settings.py
+++ b/app/routes/settings.py
@@ -35,6 +35,7 @@ SECRET_KEYS = frozenset(
         "qbo_client_secret",
         "qbo_access_token",
         "qbo_refresh_token",
+        "simplefin_access_url",
     }
 )
 SECRET_PLACEHOLDER = "********"

--- a/app/routes/simplefin.py
+++ b/app/routes/simplefin.py
@@ -1,0 +1,146 @@
+# ============================================================================
+# SimpleFIN bank feed routes — connect (claim), map accounts, sync.
+#
+# The user signs up for a SimpleFIN bridge themselves and pastes a setup
+# token; we never hold a developer credential. All endpoints are
+# session-authenticated (nothing here is webhook/public). Error messages
+# are fixed strings from SimpleFINError — raw exception text never
+# reaches a response.
+# ============================================================================
+
+import json
+from datetime import date, datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.banking import BankAccount
+from app.services import simplefin_service
+from app.services.settings_service import get_setting_raw, set_setting
+from app.services.simplefin_service import SimpleFINError
+
+router = APIRouter(prefix="/api/simplefin", tags=["simplefin"])
+
+
+class ClaimRequest(BaseModel):
+    setup_token: str
+
+
+class MapRequest(BaseModel):
+    mapping: dict[str, int]
+
+
+def _connected(db: Session) -> str:
+    access_url = get_setting_raw(db, "simplefin_access_url") or ""
+    if not access_url:
+        raise HTTPException(status_code=400, detail="SimpleFIN is not connected")
+    return access_url
+
+
+@router.get("/status")
+def status(db: Session = Depends(get_db)):
+    access_url = get_setting_raw(db, "simplefin_access_url") or ""
+    try:
+        cache = json.loads(get_setting_raw(db, "simplefin_accounts_cache") or "[]")
+    except ValueError:
+        cache = []
+    return {
+        "connected": bool(access_url),
+        "last_sync": get_setting_raw(db, "simplefin_last_sync") or "",
+        "account_map": simplefin_service.parse_account_map(
+            get_setting_raw(db, "simplefin_account_map") or "{}"
+        ),
+        "accounts": cache if isinstance(cache, list) else [],
+    }
+
+
+@router.post("/claim")
+def claim(payload: ClaimRequest, db: Session = Depends(get_db)):
+    """Exchange a one-time setup token for the permanent access URL."""
+    try:
+        access_url = simplefin_service.claim_access_url(payload.setup_token)
+        data = simplefin_service.fetch_accounts(access_url)
+    except SimpleFINError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    accounts = simplefin_service.account_summaries(data)
+    set_setting(db, "simplefin_access_url", access_url)
+    set_setting(db, "simplefin_accounts_cache", json.dumps(accounts))
+    set_setting(db, "simplefin_account_map", "{}")
+    set_setting(db, "simplefin_last_sync", "")
+    db.commit()
+    return {"connected": True, "accounts": accounts}
+
+
+@router.post("/map")
+def save_mapping(payload: MapRequest, db: Session = Depends(get_db)):
+    """Store which bridge account feeds which SlowBooks bank account."""
+    _connected(db)
+    clean: dict[str, int] = {}
+    for sf_id, bank_account_id in payload.mapping.items():
+        if not bank_account_id:
+            continue  # unmapped rows are simply omitted
+        ba = db.query(BankAccount).filter(BankAccount.id == bank_account_id).first()
+        if not ba:
+            raise HTTPException(
+                status_code=404, detail=f"Bank account {bank_account_id} not found"
+            )
+        clean[str(sf_id)] = int(bank_account_id)
+    set_setting(db, "simplefin_account_map", json.dumps(clean))
+    db.commit()
+    return {"account_map": clean}
+
+
+@router.post("/sync")
+def sync(db: Session = Depends(get_db)):
+    """Pull transactions for every mapped account through dedup + rules."""
+    access_url = _connected(db)
+    account_map = simplefin_service.parse_account_map(
+        get_setting_raw(db, "simplefin_account_map") or "{}"
+    )
+    if not account_map:
+        raise HTTPException(
+            status_code=400,
+            detail="Map at least one SimpleFIN account to a bank account first",
+        )
+
+    last_sync_raw = get_setting_raw(db, "simplefin_last_sync") or ""
+    if last_sync_raw:
+        try:
+            last = date.fromisoformat(last_sync_raw[:10])
+            start = last - timedelta(days=simplefin_service.RESYNC_OVERLAP_DAYS)
+        except ValueError:
+            start = date.today() - timedelta(days=simplefin_service.FIRST_SYNC_DAYS)
+    else:
+        start = date.today() - timedelta(days=simplefin_service.FIRST_SYNC_DAYS)
+
+    try:
+        data = simplefin_service.fetch_accounts(access_url, start_date=start)
+    except SimpleFINError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+
+    result = simplefin_service.sync_accounts(db, data, account_map)
+    set_setting(
+        db,
+        "simplefin_accounts_cache",
+        json.dumps(simplefin_service.account_summaries(data)),
+    )
+    set_setting(
+        db,
+        "simplefin_last_sync",
+        datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    )
+    db.commit()
+    return result
+
+
+@router.post("/disconnect")
+def disconnect(db: Session = Depends(get_db)):
+    """Forget the access URL, mapping, and cache. Imported rows stay."""
+    set_setting(db, "simplefin_access_url", "")
+    set_setting(db, "simplefin_account_map", "{}")
+    set_setting(db, "simplefin_accounts_cache", "[]")
+    set_setting(db, "simplefin_last_sync", "")
+    db.commit()
+    return {"connected": False}

--- a/app/services/ofx_import.py
+++ b/app/services/ofx_import.py
@@ -79,9 +79,16 @@ def _extract_tag(block: str, tag: str) -> str:
 
 
 def import_transactions(
-    db: Session, bank_account_id: int, transactions: list[dict]
+    db: Session,
+    bank_account_id: int,
+    transactions: list[dict],
+    import_source: str = "ofx",
 ) -> dict:
-    """Import parsed transactions, deduplicating by FITID."""
+    """Import parsed transactions, deduplicating by FITID.
+
+    Shared by the OFX upload path and the SimpleFIN feed (which passes
+    import_source="simplefin" and SimpleFIN transaction ids as fitids).
+    """
     imported = 0
     skipped = 0
 
@@ -109,7 +116,7 @@ def import_transactions(
             payee=txn.get("payee", ""),
             description=txn.get("memo", ""),
             import_id=fitid,
-            import_source="ofx",
+            import_source=import_source,
             match_status="unmatched",
         )
         db.add(bt)

--- a/app/services/simplefin_service.py
+++ b/app/services/simplefin_service.py
@@ -1,0 +1,241 @@
+# ============================================================================
+# SimpleFIN bank feeds — pull account balances + transactions from a
+# SimpleFIN Bridge (bridge.simplefin.org) the *user* signs up for.
+#
+# Protocol (https://www.simplefin.org/protocol.html):
+#   1. User pastes a one-time SETUP TOKEN (base64 of a claim URL).
+#   2. We POST the claim URL once and receive a permanent ACCESS URL with
+#      embedded basic-auth credentials — stored as a secret setting.
+#   3. Sync = GET {access_url}/accounts?start-date=... — plain JSON, no
+#      OAuth, no webhooks. Desktop-friendly: outbound HTTPS only.
+#
+# Transactions are funneled through the same dedup + bank-rules path as
+# OFX (import_transactions), keyed on SimpleFIN's stable transaction id.
+# Request builders are pure functions returning httpx-ready dicts so unit
+# tests can assert the exact URL/params without touching the network
+# (same pattern as app/services/payments and ai_service).
+# ============================================================================
+
+import base64
+import binascii
+import json
+import logging
+from datetime import date, datetime, time, timezone
+from decimal import Decimal, InvalidOperation
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+from sqlalchemy.orm import Session
+
+from app.services.ofx_import import import_transactions
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = 30.0
+
+# First sync reaches back this far; later syncs re-request a small overlap
+# window before the last sync (dedup makes the overlap harmless). The
+# reference bridge caps requests at 90 days and returns a warning when
+# exceeded — 85 stays cleanly inside regardless of timezone arithmetic.
+FIRST_SYNC_DAYS = 85
+RESYNC_OVERLAP_DAYS = 7
+
+
+class SimpleFINError(Exception):
+    """Raised with a user-safe message — never wraps raw exception text."""
+
+
+def send(request: dict, timeout: float = DEFAULT_TIMEOUT) -> httpx.Response:
+    """Execute a request dict from a build_* function (hardened defaults)."""
+    with httpx.Client(
+        verify=True,
+        follow_redirects=False,
+        timeout=timeout,
+        headers={"User-Agent": "slowbooks-bankfeed"},
+        trust_env=False,
+    ) as client:
+        return client.request(
+            request["method"],
+            request["url"],
+            params=request.get("params"),
+            auth=request.get("auth"),
+            content=request.get("content"),
+        )
+
+
+def decode_setup_token(setup_token: str) -> str:
+    """Base64 setup token → claim URL. HTTPS is enforced."""
+    token = (setup_token or "").strip()
+    if not token:
+        raise SimpleFINError("Setup token is empty")
+    try:
+        claim_url = base64.b64decode(token, validate=True).decode("utf-8").strip()
+    except (binascii.Error, UnicodeDecodeError):
+        raise SimpleFINError("That doesn't look like a SimpleFIN setup token")
+    if not claim_url.startswith("https://"):
+        raise SimpleFINError("Setup token must contain an https claim URL")
+    return claim_url
+
+
+def build_claim_request(claim_url: str) -> dict:
+    # Claiming is a bare POST; the response body is the access URL.
+    return {"method": "POST", "url": claim_url, "content": b""}
+
+
+def claim_access_url(setup_token: str) -> str:
+    """Exchange a setup token for the permanent access URL (one-time)."""
+    claim_url = decode_setup_token(setup_token)
+    resp = send(build_claim_request(claim_url))
+    if resp.status_code != 200:
+        logger.warning("SimpleFIN claim failed: HTTP %s", resp.status_code)
+        raise SimpleFINError(
+            "The SimpleFIN bridge rejected the token (setup tokens are "
+            "single-use — generate a fresh one and try again)"
+        )
+    access_url = resp.text.strip()
+    parts = urlsplit(access_url)
+    if parts.scheme != "https" or not parts.username:
+        raise SimpleFINError("The bridge returned an unusable access URL")
+    return access_url
+
+
+def _split_credentials(access_url: str) -> tuple[str, tuple[str, str]]:
+    """https://user:pass@host/path → (bare URL, (user, pass))."""
+    parts = urlsplit(access_url)
+    if parts.scheme != "https" or not parts.username:
+        raise SimpleFINError("Stored SimpleFIN access URL is invalid — reconnect")
+    host = parts.hostname or ""
+    if parts.port:
+        host = f"{host}:{parts.port}"
+    bare = urlunsplit((parts.scheme, host, parts.path, parts.query, parts.fragment))
+    return bare, (parts.username, parts.password or "")
+
+
+def build_accounts_request(access_url: str, start_date: date | None = None) -> dict:
+    bare, auth = _split_credentials(access_url)
+    params = {}
+    if start_date is not None:
+        epoch = datetime.combine(start_date, time.min, tzinfo=timezone.utc)
+        params["start-date"] = int(epoch.timestamp())
+    return {
+        "method": "GET",
+        "url": bare.rstrip("/") + "/accounts",
+        "params": params,
+        "auth": auth,
+    }
+
+
+def fetch_accounts(access_url: str, start_date: date | None = None) -> dict:
+    resp = send(build_accounts_request(access_url, start_date))
+    if resp.status_code == 403:
+        raise SimpleFINError(
+            "The SimpleFIN bridge refused the stored credentials — "
+            "disconnect and connect again with a fresh token"
+        )
+    if resp.status_code != 200:
+        logger.warning("SimpleFIN accounts fetch failed: HTTP %s", resp.status_code)
+        raise SimpleFINError("The SimpleFIN bridge is unavailable right now")
+    try:
+        data = resp.json()
+    except ValueError:
+        raise SimpleFINError("The SimpleFIN bridge returned an unreadable response")
+    if not isinstance(data, dict) or not isinstance(data.get("accounts"), list):
+        raise SimpleFINError("The SimpleFIN bridge returned an unreadable response")
+    return data
+
+
+def account_summaries(data: dict) -> list[dict]:
+    """UI-facing snapshot of the bridge's accounts (no transactions)."""
+    out = []
+    for acct in data.get("accounts", []):
+        org = acct.get("org") or {}
+        out.append(
+            {
+                "id": str(acct.get("id", "")),
+                "name": str(acct.get("name", "")),
+                "org": str(org.get("name") or org.get("domain") or ""),
+                "currency": str(acct.get("currency", "")),
+                "balance": str(acct.get("balance", "")),
+            }
+        )
+    return out
+
+
+def to_import_rows(sf_account: dict) -> tuple[list[dict], list[str]]:
+    """SimpleFIN transactions → the dict shape import_transactions expects.
+
+    Skips pending transactions (their ids are not stable until posted).
+    """
+    rows, errors = [], []
+    name = str(sf_account.get("name", "")) or str(sf_account.get("id", ""))
+    for txn in sf_account.get("transactions", []):
+        if txn.get("pending"):
+            continue
+        txn_id = str(txn.get("id", "")).strip()
+        posted = txn.get("posted") or txn.get("transacted_at")
+        try:
+            amount = Decimal(str(txn.get("amount", "")))
+            txn_date = datetime.fromtimestamp(int(posted), tz=timezone.utc).date()
+        except (InvalidOperation, TypeError, ValueError, OSError, OverflowError):
+            errors.append(f"{name}: skipped a transaction with malformed data")
+            continue
+        if not txn_id:
+            errors.append(f"{name}: skipped a transaction without a stable id")
+            continue
+        rows.append(
+            {
+                "fitid": txn_id,
+                "date": txn_date,
+                "amount": amount,
+                "payee": str(txn.get("payee") or txn.get("description") or ""),
+                "memo": str(txn.get("memo") or txn.get("description") or ""),
+                "type": "",
+            }
+        )
+    return rows, errors
+
+
+def parse_account_map(raw: str) -> dict[str, int]:
+    """Settings JSON → {simplefin_account_id: bank_account_id}."""
+    try:
+        data = json.loads(raw or "{}")
+    except ValueError:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    out = {}
+    for key, value in data.items():
+        try:
+            out[str(key)] = int(value)
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def sync_accounts(
+    db: Session,
+    data: dict,
+    account_map: dict[str, int],
+) -> dict:
+    """Import every mapped bridge account's transactions. Returns totals."""
+    imported = skipped = 0
+    warnings: list[str] = []
+    by_id = {str(a.get("id", "")): a for a in data.get("accounts", [])}
+    for sf_id, bank_account_id in account_map.items():
+        sf_account = by_id.get(sf_id)
+        if sf_account is None:
+            warnings.append(
+                "A mapped account was missing from the bridge response "
+                "(bank connection may need attention on the SimpleFIN side)"
+            )
+            continue
+        rows, row_errors = to_import_rows(sf_account)
+        warnings.extend(row_errors)
+        result = import_transactions(
+            db, bank_account_id, rows, import_source="simplefin"
+        )
+        imported += result["imported"]
+        skipped += result["skipped"]
+    for sf_error in data.get("errors", []):
+        warnings.append(str(sf_error))
+    return {"imported": imported, "skipped": skipped, "warnings": warnings}

--- a/app/services/simplefin_service.py
+++ b/app/services/simplefin_service.py
@@ -18,8 +18,10 @@
 
 import base64
 import binascii
+import ipaddress
 import json
 import logging
+import socket
 from datetime import date, datetime, time, timezone
 from decimal import Decimal, InvalidOperation
 from urllib.parse import urlsplit, urlunsplit
@@ -45,8 +47,36 @@ class SimpleFINError(Exception):
     """Raised with a user-safe message — never wraps raw exception text."""
 
 
+def _assert_public_https(url: str) -> None:
+    """SSRF guard: bridge URLs are user-supplied by design (self-hosted
+    bridges are a feature), so before any request we require https and
+    refuse hosts that resolve to non-public addresses — loopback, RFC1918,
+    link-local/metadata, and friends. A hostile setup token must not be
+    able to point SlowBooks at localhost services or the LAN."""
+    parts = urlsplit(url)
+    if parts.scheme != "https":
+        raise SimpleFINError("Bridge URLs must use https")
+    host = parts.hostname or ""
+    if not host:
+        raise SimpleFINError("Bridge URL has no hostname")
+    try:
+        infos = socket.getaddrinfo(host, parts.port or 443, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        raise SimpleFINError("Could not resolve the bridge hostname")
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        if not ip.is_global:
+            raise SimpleFINError(
+                "Bridge host resolves to a private or local address — refusing"
+            )
+
+
 def send(request: dict, timeout: float = DEFAULT_TIMEOUT) -> httpx.Response:
-    """Execute a request dict from a build_* function (hardened defaults)."""
+    """Execute a request dict from a build_* function (hardened defaults).
+
+    Every outbound URL passes the SSRF guard first — this is the single
+    network chokepoint for the SimpleFIN feature."""
+    _assert_public_https(request["url"])
     with httpx.Client(
         verify=True,
         follow_redirects=False,

--- a/app/static/js/banking.js
+++ b/app/static/js/banking.js
@@ -9,7 +9,10 @@
  */
 const BankingPage = {
     async render() {
-        const accounts = await API.get('/banking/accounts');
+        const [accounts, feed] = await Promise.all([
+            API.get('/banking/accounts'),
+            API.get('/simplefin/status'),
+        ]);
         let html = `
             <div class="page-header">
                 <h2>Bank Accounts</h2>
@@ -31,7 +34,102 @@ const BankingPage = {
             }
             html += `</div>`;
         }
+        html += BankingPage._renderFeedSection(feed, accounts);
         return html;
+    },
+
+    // ------------------------------------------------------------------
+    // SimpleFIN bank feeds — the user brings their own bridge credential
+    // (bridge.simplefin.org); we claim the token once, then sync on click.
+    // ------------------------------------------------------------------
+    _renderFeedSection(feed, accounts) {
+        let body;
+        if (!feed.connected) {
+            body = `
+                <p style="font-size:12px; margin-bottom:8px;">
+                    Pull transactions straight from your bank — no file exports.
+                    Sign up at <a href="https://bridge.simplefin.org" target="_blank" rel="noopener">bridge.simplefin.org</a>,
+                    connect your bank there, then paste your <strong>setup token</strong> below.
+                    Your credential stays on this machine; SlowBooks has no middleman server.
+                </p>
+                <form onsubmit="BankingPage.connectSimpleFIN(event)">
+                    <div class="form-group">
+                        <label>SimpleFIN setup token</label>
+                        <input type="password" id="simplefin-token" required autocomplete="off"
+                               placeholder="Paste the one-time setup token">
+                    </div>
+                    <div class="form-actions">
+                        <button type="submit" class="btn btn-primary">Connect</button>
+                    </div>
+                </form>`;
+        } else {
+            const options = (sfId) => {
+                const mapped = feed.account_map[sfId] || '';
+                return ['<option value="">— not imported —</option>']
+                    .concat(accounts.map(ba =>
+                        `<option value="${ba.id}" ${ba.id === mapped ? 'selected' : ''}>${escapeHtml(ba.name)}</option>`))
+                    .join('');
+            };
+            const rows = feed.accounts.map(a => `<tr>
+                    <td>${escapeHtml(a.name)}<div style="font-size:10px; color:var(--gray-400);">${escapeHtml(a.org || '')}</div></td>
+                    <td class="amount">${escapeHtml(a.balance)} ${escapeHtml(a.currency)}</td>
+                    <td><select data-sfid="${escapeHtml(a.id)}" class="simplefin-map">${options(a.id)}</select></td>
+                </tr>`).join('');
+            body = `
+                <p style="font-size:12px; margin-bottom:8px;">
+                    Connected. Choose which SlowBooks bank account each feed lands in,
+                    then sync — duplicates are skipped automatically and bank rules apply.
+                    ${feed.last_sync ? `Last sync: ${escapeHtml(feed.last_sync.replace('T', ' '))}` : 'Not synced yet.'}
+                </p>
+                <div class="table-container"><table>
+                    <thead><tr><th>Bank feed</th><th class="amount">Balance</th><th>Imports into</th></tr></thead>
+                    <tbody>${rows}</tbody>
+                </table></div>
+                <div class="form-actions" style="margin-top:12px;">
+                    <button class="btn btn-primary" onclick="BankingPage.syncSimpleFIN()">Sync Now</button>
+                    <button class="btn btn-secondary" onclick="BankingPage.disconnectSimpleFIN()">Disconnect</button>
+                </div>`;
+        }
+        return `<div class="card" style="margin-top:16px;">
+            <div class="card-header">Bank Feeds (SimpleFIN)</div>${body}</div>`;
+    },
+
+    async connectSimpleFIN(e) {
+        e.preventDefault();
+        const token = $('#simplefin-token').value.trim();
+        if (!token) return;
+        try {
+            const data = await API.post('/simplefin/claim', { setup_token: token });
+            toast(`Connected — found ${data.accounts.length} account(s). Now map them below.`);
+            App.navigate('#/banking');
+        } catch (err) { toast(err.message, 'error'); }
+    },
+
+    async saveSimpleFINMap() {
+        const mapping = {};
+        document.querySelectorAll('.simplefin-map').forEach(sel => {
+            mapping[sel.dataset.sfid] = sel.value ? parseInt(sel.value, 10) : 0;
+        });
+        await API.post('/simplefin/map', { mapping });
+    },
+
+    async syncSimpleFIN() {
+        try {
+            await BankingPage.saveSimpleFINMap();
+            const r = await API.post('/simplefin/sync');
+            toast(`Synced: ${r.imported} new, ${r.skipped} duplicates skipped`);
+            if (r.warnings.length) toast(r.warnings[0], 'error');
+            App.navigate('#/banking');
+        } catch (err) { toast(err.message, 'error'); }
+    },
+
+    async disconnectSimpleFIN() {
+        if (!confirm('Disconnect the SimpleFIN bank feed? Imported transactions are kept.')) return;
+        try {
+            await API.post('/simplefin/disconnect');
+            toast('Bank feed disconnected');
+            App.navigate('#/banking');
+        } catch (err) { toast(err.message, 'error'); }
     },
 
     async viewRegister(bankAccountId) {

--- a/docs/setup-bank-feeds.md
+++ b/docs/setup-bank-feeds.md
@@ -1,0 +1,66 @@
+# Bank Feeds (SimpleFIN) — pull transactions straight from your bank
+
+SlowBooks can sync bank transactions automatically using
+[SimpleFIN](https://www.simplefin.org/), an open protocol where **you**
+hold the bank credential — not SlowBooks, and not any middleman server we
+run. There is no SlowBooks cloud in the loop: your machine talks directly
+to your SimpleFIN bridge over HTTPS.
+
+## How it works
+
+1. You sign up for a SimpleFIN bridge — the reference one is
+   [bridge.simplefin.org](https://bridge.simplefin.org/) (about **$1.50/month**,
+   paid by you to them; SlowBooks takes nothing).
+2. On the bridge's site, you connect your bank(s). The bridge handles the
+   bank login, MFA, and aggregation.
+3. The bridge gives you a one-time **setup token**. Paste it into
+   **Banking → Bank Feeds (SimpleFIN) → Connect**.
+4. SlowBooks exchanges the token once for a permanent read-only access
+   credential, stored encrypted-at-rest in your company file and never
+   shown again (Settings displays `********`).
+5. Map each bridge account to a SlowBooks bank account, then click
+   **Sync Now** whenever you want fresh transactions.
+
+Synced transactions land in the same review flow as OFX/CSV imports:
+
+- **Duplicates are skipped automatically** (dedup on the bridge's stable
+  transaction id, same mechanism as OFX FITIDs) — syncing twice never
+  double-imports.
+- **Bank rules apply on arrival** — anything your rules match is
+  auto-categorized, the rest waits in the register as unmatched.
+- Pending transactions are ignored until they post (their ids aren't
+  stable before that).
+
+The first sync reaches back roughly three months; every later sync re-checks a 7-day
+overlap window before your last sync so late-posting transactions are
+never missed.
+
+## Trying it without a bank
+
+SimpleFIN publishes a public demo. Generate a demo setup token at
+[beta-bridge.simplefin.org/info/developers](https://beta-bridge.simplefin.org/info/developers)
+and paste it in — you'll get a fake "SimpleFIN Savings" account with
+sample transactions to play with. Disconnect afterward to clear it.
+
+## Notes & troubleshooting
+
+- **Setup tokens are single-use.** If a connect attempt fails and the
+  token was consumed, generate a fresh token on the bridge site.
+- **Desktop installs work fully** — the sync is outbound HTTPS polling;
+  no webhooks, no ports to open, no server required.
+- **Disconnecting** (Banking → Bank Feeds → Disconnect) forgets the
+  credential, mapping, and cache. Transactions already imported stay in
+  your registers.
+- **Coverage** is whatever your bridge supports — the reference bridge
+  covers most US and Canadian institutions.
+- If a mapped account stops appearing in syncs, the bank connection
+  usually needs re-authentication **on the bridge's site**, not in
+  SlowBooks.
+
+## Why SimpleFIN and not Plaid?
+
+Plaid requires the application developer to hold API credentials and run
+a server that proxies every user's bank data. That's the opposite of the
+SlowBooks design (your data, your machine, no phone-home). SimpleFIN
+inverts the relationship: each user brings their own credential, and the
+data flows straight to their computer.

--- a/tests/test_simplefin.py
+++ b/tests/test_simplefin.py
@@ -298,3 +298,29 @@ def test_disconnect_route_clears_settings(authed_client, db_session):
     assert (get_setting_raw(db_session, "simplefin_access_url") or "") == ""
     status = authed_client.get("/api/simplefin/status").json()
     assert status["connected"] is False
+
+
+# ---------------------------------------------------------------------------
+# SSRF guard — user-supplied bridge URLs must never reach private space
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://127.0.0.1/simplefin/claim/X",
+        "https://10.0.0.5/simplefin/claim/X",
+        "https://192.168.68.1/simplefin/claim/X",
+        "https://169.254.169.254/latest/meta-data",
+        "https://[::1]/simplefin/claim/X",
+        "http://bridge.example.com/simplefin/claim/X",
+    ],
+)
+def test_ssrf_guard_rejects_non_public(url):
+    with pytest.raises(sf.SimpleFINError):
+        sf._assert_public_https(url)
+
+
+def test_ssrf_guard_allows_public_literal():
+    # Literal public IP: getaddrinfo resolves numerically, no DNS involved
+    sf._assert_public_https("https://1.1.1.1/simplefin")

--- a/tests/test_simplefin.py
+++ b/tests/test_simplefin.py
@@ -1,0 +1,300 @@
+"""SimpleFIN bank feeds: token claim, request builders, sync dedup,
+bank-rule parity with OFX, settings redaction, and route error paths."""
+
+import base64
+import json
+from datetime import date
+from decimal import Decimal
+
+import httpx
+import pytest
+
+from app.models.accounts import Account, AccountType
+from app.models.bank_rules import BankRule
+from app.models.banking import BankAccount, BankTransaction
+from app.services import simplefin_service as sf
+from app.services.settings_service import get_setting_raw, set_setting
+
+CLAIM_URL = "https://bridge.example.com/simplefin/claim/DEMO"
+ACCESS_URL = "https://user123:pass456@bridge.example.com/simplefin"
+
+SF_DATA = {
+    "errors": [],
+    "accounts": [
+        {
+            "id": "ACT-1",
+            "name": "Demo Checking",
+            "org": {"name": "Demo Bank"},
+            "currency": "USD",
+            "balance": "1234.56",
+            "transactions": [
+                {
+                    "id": "TXN-1",
+                    "posted": 1786320000,  # 2026-08-10 UTC
+                    "amount": "-55.50",
+                    "description": "Fishing bait",
+                    "payee": "Johns Fishin Shack",
+                },
+                {
+                    "id": "TXN-2",
+                    "posted": 1786233600,
+                    "amount": "2500.00",
+                    "description": "Payroll",
+                    "payee": "ACME LLC",
+                },
+                {
+                    "id": "TXN-PENDING",
+                    "posted": 1786320000,
+                    "amount": "-9.99",
+                    "description": "Pending card hold",
+                    "pending": True,
+                },
+            ],
+        }
+    ],
+}
+
+
+def _token(url=CLAIM_URL):
+    return base64.b64encode(url.encode()).decode()
+
+
+def _resp(status=200, text="", json_body=None):
+    if json_body is not None:
+        return httpx.Response(status, json=json_body)
+    return httpx.Response(status, text=text)
+
+
+def _mk_bank_account(db_session, name="Feed Checking"):
+    ba = BankAccount(name=name, bank_name="Demo Bank")
+    db_session.add(ba)
+    db_session.commit()
+    return ba
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_decode_setup_token_roundtrip():
+    assert sf.decode_setup_token(_token()) == CLAIM_URL
+
+
+def test_decode_setup_token_rejects_http():
+    with pytest.raises(sf.SimpleFINError):
+        sf.decode_setup_token(_token("http://insecure.example.com/claim"))
+
+
+def test_decode_setup_token_rejects_garbage():
+    with pytest.raises(sf.SimpleFINError):
+        sf.decode_setup_token("not-base64!!!")
+    with pytest.raises(sf.SimpleFINError):
+        sf.decode_setup_token("")
+
+
+def test_build_accounts_request_splits_credentials():
+    req = sf.build_accounts_request(ACCESS_URL, start_date=date(2026, 8, 1))
+    assert req["url"] == "https://bridge.example.com/simplefin/accounts"
+    assert req["auth"] == ("user123", "pass456")
+    assert req["params"]["start-date"] == 1785542400  # 2026-08-01T00:00Z
+    # credentials must not leak into the URL itself
+    assert "user123" not in req["url"]
+
+
+def test_build_accounts_request_rejects_credless_url():
+    with pytest.raises(sf.SimpleFINError):
+        sf.build_accounts_request("https://bridge.example.com/simplefin")
+
+
+def test_to_import_rows_shapes_and_skips_pending():
+    rows, errors = sf.to_import_rows(SF_DATA["accounts"][0])
+    assert errors == []
+    assert [r["fitid"] for r in rows] == ["TXN-1", "TXN-2"]
+    assert rows[0]["amount"] == Decimal("-55.50")
+    assert rows[0]["date"] == date(2026, 8, 10)
+    assert rows[0]["payee"] == "Johns Fishin Shack"
+
+
+def test_to_import_rows_flags_malformed():
+    rows, errors = sf.to_import_rows(
+        {"name": "X", "transactions": [{"id": "T", "posted": "nope", "amount": "1"}]}
+    )
+    assert rows == []
+    assert len(errors) == 1
+    assert "nope" not in errors[0]  # message stays generic, no raw data echo
+
+
+def test_parse_account_map_tolerates_junk():
+    assert sf.parse_account_map('{"A": 3, "B": "4", "C": "x"}') == {"A": 3, "B": 4}
+    assert sf.parse_account_map("not json") == {}
+    assert sf.parse_account_map("[1,2]") == {}
+
+
+# ---------------------------------------------------------------------------
+# Claim + fetch against a mocked transport
+# ---------------------------------------------------------------------------
+
+
+def test_claim_access_url(monkeypatch):
+    monkeypatch.setattr(sf, "send", lambda req, **kw: _resp(text=ACCESS_URL + "\n"))
+    assert sf.claim_access_url(_token()) == ACCESS_URL
+
+
+def test_claim_access_url_rejected_token(monkeypatch):
+    monkeypatch.setattr(sf, "send", lambda req, **kw: _resp(status=403))
+    with pytest.raises(sf.SimpleFINError):
+        sf.claim_access_url(_token())
+
+
+def test_fetch_accounts_error_paths(monkeypatch):
+    monkeypatch.setattr(sf, "send", lambda req, **kw: _resp(status=500))
+    with pytest.raises(sf.SimpleFINError):
+        sf.fetch_accounts(ACCESS_URL)
+    monkeypatch.setattr(sf, "send", lambda req, **kw: _resp(text="<html>"))
+    with pytest.raises(sf.SimpleFINError):
+        sf.fetch_accounts(ACCESS_URL)
+
+
+# ---------------------------------------------------------------------------
+# Sync: dedup + bank rules through the shared OFX path
+# ---------------------------------------------------------------------------
+
+
+def test_sync_imports_dedups_and_applies_rules(db_session):
+    ba = _mk_bank_account(db_session)
+    expense = Account(name="Bait Expense", account_type=AccountType.EXPENSE)
+    db_session.add(expense)
+    db_session.commit()
+    db_session.add(
+        BankRule(
+            name="bait",
+            pattern="fishin",
+            rule_type="contains",
+            account_id=expense.id,
+            priority=10,
+            is_active=True,
+        )
+    )
+    db_session.commit()
+
+    result = sf.sync_accounts(db_session, SF_DATA, {"ACT-1": ba.id})
+    assert result["imported"] == 2
+    assert result["skipped"] == 0
+    assert result["warnings"] == []
+
+    txns = (
+        db_session.query(BankTransaction)
+        .filter(BankTransaction.bank_account_id == ba.id)
+        .all()
+    )
+    assert {t.import_id for t in txns} == {"TXN-1", "TXN-2"}
+    assert all(t.import_source == "simplefin" for t in txns)
+    bait = next(t for t in txns if t.import_id == "TXN-1")
+    assert bait.match_status == "auto"
+    assert bait.category_account_id == expense.id
+
+    # Second sync of the same window: everything dedups
+    again = sf.sync_accounts(db_session, SF_DATA, {"ACT-1": ba.id})
+    assert again["imported"] == 0
+    assert again["skipped"] == 2
+
+
+def test_sync_warns_on_missing_mapped_account(db_session):
+    ba = _mk_bank_account(db_session)
+    result = sf.sync_accounts(db_session, SF_DATA, {"GONE": ba.id})
+    assert result["imported"] == 0
+    assert len(result["warnings"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+def test_claim_route_stores_secret_and_returns_accounts(
+    authed_client, db_session, monkeypatch
+):
+    responses = [_resp(text=ACCESS_URL), _resp(json_body=SF_DATA)]
+    monkeypatch.setattr(sf, "send", lambda req, **kw: responses.pop(0))
+    r = authed_client.post("/api/simplefin/claim", json={"setup_token": _token()})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["connected"] is True
+    assert body["accounts"][0]["id"] == "ACT-1"
+    assert get_setting_raw(db_session, "simplefin_access_url") == ACCESS_URL
+
+    # The access URL is a credential: GET /api/settings must redact it
+    settings = authed_client.get("/api/settings").json()
+    assert ACCESS_URL not in json.dumps(settings)
+    assert settings["simplefin_access_url"] == "********"
+
+
+def test_claim_route_bad_token_is_400(authed_client):
+    r = authed_client.post(
+        "/api/simplefin/claim", json={"setup_token": "!!definitely not base64!!"}
+    )
+    assert r.status_code == 400
+
+
+def test_map_route_validates_bank_account(authed_client, db_session):
+    set_setting(db_session, "simplefin_access_url", ACCESS_URL)
+    db_session.commit()
+    r = authed_client.post("/api/simplefin/map", json={"mapping": {"ACT-1": 99999}})
+    assert r.status_code == 404
+
+    ba = _mk_bank_account(db_session, name="Mapped Checking")
+    r = authed_client.post(
+        "/api/simplefin/map", json={"mapping": {"ACT-1": ba.id, "ACT-2": 0}}
+    )
+    assert r.status_code == 200
+    assert r.json()["account_map"] == {"ACT-1": ba.id}
+
+
+def test_sync_route_requires_connection_and_mapping(authed_client, db_session):
+    r = authed_client.post("/api/simplefin/sync")
+    assert r.status_code == 400  # not connected
+
+    set_setting(db_session, "simplefin_access_url", ACCESS_URL)
+    db_session.commit()
+    r = authed_client.post("/api/simplefin/sync")
+    assert r.status_code == 400  # connected but nothing mapped
+
+
+def test_sync_route_end_to_end(authed_client, db_session, monkeypatch):
+    ba = _mk_bank_account(db_session, name="Synced Checking")
+    set_setting(db_session, "simplefin_access_url", ACCESS_URL)
+    set_setting(db_session, "simplefin_account_map", json.dumps({"ACT-1": ba.id}))
+    db_session.commit()
+    monkeypatch.setattr(sf, "send", lambda req, **kw: _resp(json_body=SF_DATA))
+
+    r = authed_client.post("/api/simplefin/sync")
+    assert r.status_code == 200
+    assert r.json()["imported"] == 2
+    assert get_setting_raw(db_session, "simplefin_last_sync")
+
+    status = authed_client.get("/api/simplefin/status").json()
+    assert status["connected"] is True
+    assert status["accounts"][0]["name"] == "Demo Checking"
+    assert status["account_map"] == {"ACT-1": ba.id}
+
+
+def test_sync_route_bridge_down_is_502(authed_client, db_session, monkeypatch):
+    ba = _mk_bank_account(db_session, name="Down Checking")
+    set_setting(db_session, "simplefin_access_url", ACCESS_URL)
+    set_setting(db_session, "simplefin_account_map", json.dumps({"ACT-1": ba.id}))
+    db_session.commit()
+    monkeypatch.setattr(sf, "send", lambda req, **kw: _resp(status=500))
+    r = authed_client.post("/api/simplefin/sync")
+    assert r.status_code == 502
+
+
+def test_disconnect_route_clears_settings(authed_client, db_session):
+    set_setting(db_session, "simplefin_access_url", ACCESS_URL)
+    set_setting(db_session, "simplefin_account_map", '{"ACT-1": 1}')
+    db_session.commit()
+    r = authed_client.post("/api/simplefin/disconnect")
+    assert r.status_code == 200
+    assert (get_setting_raw(db_session, "simplefin_access_url") or "") == ""
+    status = authed_client.get("/api/simplefin/status").json()
+    assert status["connected"] is False


### PR DESCRIPTION
## What

Automatic bank-transaction sync via the open [SimpleFIN protocol](https://www.simplefin.org/protocol.html). The user signs up with a SimpleFIN bridge themselves (~$1.50/mo to the bridge, reference: bridge.simplefin.org), pastes a one-time setup token, maps bridge accounts to SlowBooks bank accounts, and syncs on demand.

**Why SimpleFIN over Plaid**: no developer account, no API keys held by the app, no proxy server touching user bank data — each user brings their own read-only credential and data flows straight to their machine. Outbound HTTPS polling only, so desktop installs work with zero setup.

## How

- `app/services/simplefin_service.py` — token decode/claim, pure request builders (assertable without network mocks, same pattern as payments/`ai_service`), account summaries, transaction conversion, sync orchestration.
- Reuses `ofx_import.import_transactions` (new `import_source` param) — dedup on SimpleFIN's stable transaction ids exactly like OFX FITIDs, then the shared bank-rules engine. No new accounting concepts.
- `app/routes/simplefin.py` — status / claim / map / sync / disconnect, all session-authenticated. Error messages are fixed strings; raw exception text never reaches responses.
- Access URL (contains basic-auth creds) added to `SECRET_KEYS` → redacted on GET /api/settings.
- Banking page UI: connect form → mapping table → Sync Now / Disconnect.
- `docs/setup-bank-feeds.md` + README highlight.

## Verification

- 1058 tests green (20 new: token validation, request builders, dedup idempotency, rule application, redaction, route error paths); black + ruff clean; wiring/orphan-route and auth-contract suites pass.
- **Live end-to-end smoke against the real demo bridge**: fresh DB → auth setup → claim demo token → map → sync imported 161 transactions → second sync deduped 100% → register populated → settings redaction confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uzF92MM21Ac6Y6Gfei4ro