### PR TITLE
Fix stale UI after desktop updates (WebView2 disk cache)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -253,6 +253,12 @@ async def security_headers(request: Request, call_next):
         "Permissions-Policy",
         "camera=(), microphone=(), geolocation=()",
     )
+    # WebView2's persistent desktop profile heuristically caches responses
+    # that carry validators (ETag/Last-Modified) but no Cache-Control — after
+    # an app update it kept rendering the previous version's cached HTML/JS.
+    # no-cache still allows ETag/304 revalidation (free on localhost) but
+    # forbids serving from cache without asking.
+    _set_if_unset(response.headers, "Cache-Control", "no-cache")
     _set_if_unset(response.headers, "Content-Security-Policy", _CSP)
     # HSTS instructs browsers to refuse plain HTTP for HSTS_MAX_AGE seconds.
     # Only emit when HTTPS is actually enforced; sending it under plain HTTP

--- a/desktop_launcher.py
+++ b/desktop_launcher.py
@@ -68,6 +68,36 @@ def _config_dir() -> Path:
     return get_data_dir().parent if FROZEN else Path(__file__).resolve().parent
 
 
+def _purge_stale_webview_cache(storage_dir: Path, current_version: str) -> None:
+    """Drop WebView2's HTTP disk cache on the first launch of a new version.
+
+    The persistent profile (private_mode=False fix from v2.1.1) also
+    persists the renderer's disk cache across app updates — field report:
+    a 2.4.1 update kept rendering the previous version's cached
+    index.html/JS. Cookies are deliberately left alone so logins survive;
+    only the cache directories go.
+    """
+    import shutil
+
+    marker = storage_dir / "app-version.txt"
+    try:
+        if (
+            marker.exists()
+            and marker.read_text(encoding="utf-8").strip() == current_version
+        ):
+            return
+    except OSError:
+        pass
+    for pattern in ("**/Cache", "**/Code Cache", "**/GPUCache"):
+        for path in storage_dir.glob(pattern):
+            if path.is_dir():
+                shutil.rmtree(path, ignore_errors=True)
+    try:
+        marker.write_text(current_version, encoding="utf-8")
+    except OSError:
+        pass  # purge again next launch; never block startup on this
+
+
 ENV_FILE = _config_dir() / ".env"
 ENV_EXAMPLE = ROOT / ".env.example"
 
@@ -728,6 +758,9 @@ def run_window(port: int, log_fh=None) -> int:
     # restarts as a bonus.
     storage_dir = get_data_dir() / "webview"
     storage_dir.mkdir(parents=True, exist_ok=True)
+    from app import __version__ as app_version
+
+    _purge_stale_webview_cache(storage_dir, app_version)
 
     api = PickerApi(port, log_fh)
     webview.create_window(

--- a/tests/test_desktop_mode.py
+++ b/tests/test_desktop_mode.py
@@ -259,3 +259,48 @@ def test_save_backup_file_avoids_overwrite(sqlite_live_db, db_session, picker_ap
     second = api.save_backup_file(created["filename"])
     assert first["success"] and second["success"]
     assert first["path"] != second["path"]
+
+
+# ---------------------------------------------------------------------------
+# Stale-UI-after-update guards: no-cache headers + webview cache purge
+# ---------------------------------------------------------------------------
+
+
+def test_html_and_static_send_no_cache(client):
+    """WebView2's persistent profile must never blind-serve cached UI:
+    every response carries Cache-Control: no-cache (ETag/304 still work)."""
+    for path in ("/", "/static/js/app.js"):
+        resp = client.get(path)
+        assert resp.status_code == 200
+        assert resp.headers.get("cache-control") == "no-cache", path
+
+
+def test_webview_cache_purged_on_version_change(tmp_path):
+    import desktop_launcher
+
+    storage = tmp_path / "webview"
+    profile = storage / "EBWebView" / "Default"
+    cache = profile / "Cache" / "Cache_Data"
+    code_cache = profile / "Code Cache" / "js"
+    cache.mkdir(parents=True)
+    code_cache.mkdir(parents=True)
+    (cache / "f_000001").write_bytes(b"stale")
+    cookies = profile / "Cookies"
+    cookies.write_bytes(b"keep me")
+
+    desktop_launcher._purge_stale_webview_cache(storage, "9.9.9")
+    assert not cache.exists()
+    assert not code_cache.exists()
+    assert cookies.read_bytes() == b"keep me"  # logins survive
+    assert (storage / "app-version.txt").read_text().strip() == "9.9.9"
+
+    # Same version again: marker short-circuits, nothing recreated/deleted
+    probe = profile / "Cache"
+    probe.mkdir(parents=True)
+    desktop_launcher._purge_stale_webview_cache(storage, "9.9.9")
+    assert probe.exists()
+
+    # New version purges again
+    desktop_launcher._purge_stale_webview_cache(storage, "10.0.0")
+    assert not probe.exists()
+    assert (storage / "app-version.txt").read_text().strip() == "10.0.0"


### PR DESCRIPTION
Field report: after updating to v2.4.1 the desktop app still rendered the previous version's splash/About. Root cause: the persistent WebView2 profile (v2.1.1 cookie fix) also persists the HTTP disk cache, and responses carried ETag/Last-Modified but no Cache-Control — heuristic caching served stale HTML/JS. Verified the shipped 2.4.1 artifact contains the new UI; the stale render is purely client cache.

- `Cache-Control: no-cache` on all responses via the existing security-headers middleware (`_set_if_unset`, so explicit headers still win); ETag/304 revalidation unaffected.
- Launcher purges the WebView2 `Cache`/`Code Cache`/`GPUCache` dirs on first launch of a new version (version marker in the profile dir); cookies untouched so logins survive. This covers the 2.4.1→2.4.2 transition, whose cache predates the new headers.
- Tests: no-cache header on `/` and `/static/js/app.js`; purge unit test (purges on version change, no-ops on same version, preserves Cookies).
- 1066 tests green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uzF92MM21Ac6Y6Gfei4ro