### PR TITLE
Server Edition core: LAN serving, SQLite WAL tuning, edition header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, "claude/**"]
+    branches: [main, server-edition, "claude/**", "se/**"]
   pull_request:
-    branches: [main]
+    branches: [main, server-edition]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, server-edition]
   schedule:
     - cron: "0 6 * * 1"  # Weekly on Monday at 6am UTC
 

--- a/app/database.py
+++ b/app/database.py
@@ -25,6 +25,31 @@ if not _is_sqlite:
         pool_use_lifo=True,
     )
 engine = create_engine(DATABASE_URL, **_engine_kwargs)
+
+
+def enable_sqlite_tuning(target_engine) -> None:
+    """Concurrency PRAGMAs for SQLite engines (Server Edition groundwork).
+
+    WAL lets readers proceed while one writer commits — the difference
+    between "works for an office" and "database is locked" the moment a
+    second person opens a report mid-save. busy_timeout makes brief lock
+    contention wait instead of erroring; NORMAL sync is the recommended
+    pairing with WAL. Harmless no-ops on :memory: databases.
+    """
+    from sqlalchemy import event
+
+    @event.listens_for(target_engine, "connect")
+    def _tune(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA journal_mode=WAL")
+        cur.execute("PRAGMA busy_timeout=5000")
+        cur.execute("PRAGMA synchronous=NORMAL")
+        cur.close()
+
+
+if _is_sqlite:
+    enable_sqlite_tuning(engine)
+
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 

--- a/app/routes/system.py
+++ b/app/routes/system.py
@@ -36,6 +36,11 @@ def _is_desktop() -> bool:
     return os.environ.get("SLOWBOOKS_DESKTOP") == "1"
 
 
+def _is_server_mode() -> bool:
+    """True when the launcher is serving beyond loopback (--serve-lan)."""
+    return os.environ.get("SLOWBOOKS_SERVER_MODE") == "1"
+
+
 def _parse(v) -> tuple:
     """'2.1.0' (or 'v2.1.0') → (2, 1, 0) for comparison."""
     out = []
@@ -56,7 +61,11 @@ def is_newer(remote: str, local: str) -> bool:
 
 @router.get("")
 async def system_info():
-    return {"version": __version__, "desktop": _is_desktop()}
+    return {
+        "version": __version__,
+        "desktop": _is_desktop(),
+        "server_mode": _is_server_mode(),
+    }
 
 
 @router.get("/update-check")

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -676,7 +676,14 @@ const App = {
             const info = await res.json();
             const versionEl = $('#app-version');
             if (versionEl && info.version) {
-                versionEl.textContent = `v${info.version}`;
+                versionEl.textContent = info.server_mode
+                    ? `v${info.version} · Server`
+                    : `v${info.version}`;
+            }
+            if (info.server_mode) {
+                // Serving the LAN: the deployment announces itself.
+                document.querySelectorAll('.sidebar-edition, .splash-subtitle')
+                    .forEach(el => { el.textContent = 'Server Edition'; });
             }
             if (!info.desktop) return;
 

--- a/desktop_launcher.py
+++ b/desktop_launcher.py
@@ -18,6 +18,9 @@ anywhere Python does). What it does, in order:
 To switch companies: close the window and relaunch — the picker appears
 again. Flags:
   --no-window   start the server and print the URL (no native window)
+  --serve-lan   Server Edition mode: serve the LAN, no window (binds
+                0.0.0.0, or --bind IP for one interface). Plain HTTP —
+                trusted networks only for now.
   --setup-only  prepare .env and data directories, then exit
   --smoke-test  CI self-test: create a company, boot the server, render a
                 PDF, exit 0/1
@@ -224,14 +227,17 @@ def prepare_env() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _server_env(db_url: str, port: int) -> dict:
+def _server_env(db_url: str, port: int, bind_host: str = "127.0.0.1") -> dict:
     env = dict(os.environ)
     env.update(
         {
             "DATABASE_URL": db_url,
             "APP_DEBUG": "true",
             "FORCE_HTTPS": "false",
-            "APP_HOST": "127.0.0.1",
+            "APP_HOST": bind_host,
+            # Server Edition groundwork: anything beyond loopback flips the
+            # flag the frontend uses to show the SERVER EDITION header.
+            "SLOWBOOKS_SERVER_MODE": "0" if bind_host == "127.0.0.1" else "1",
             "APP_PORT": str(port),
             "SLOWBOOKS_DATA_DIR": str(get_data_dir()),
             # Where app/config.py loads .env from (the install dir is
@@ -282,7 +288,9 @@ def migrate(db_url: str, output=None) -> None:
     )
 
 
-def start_server(db_url: str, port: int, output=None) -> subprocess.Popen:
+def start_server(
+    db_url: str, port: int, output=None, bind_host: str = "127.0.0.1"
+) -> subprocess.Popen:
     if FROZEN:
         # Re-exec this same bundled exe; --_serve (handled at the top of
         # main()) turns the child into the uvicorn server. cwd must be
@@ -297,7 +305,7 @@ def start_server(db_url: str, port: int, output=None) -> subprocess.Popen:
             "uvicorn",
             "app.main:app",
             "--host",
-            "127.0.0.1",
+            bind_host,
             "--port",
             str(port),
             # cmd.exe consoles don't render ANSI colors by default; without
@@ -308,14 +316,19 @@ def start_server(db_url: str, port: int, output=None) -> subprocess.Popen:
     return subprocess.Popen(
         cmd,
         cwd=cwd,
-        env=_server_env(db_url, port),
+        env=_server_env(db_url, port, bind_host),
         stdout=output,
         stderr=subprocess.STDOUT if output else None,
     )
 
 
-def wait_for_health(proc: subprocess.Popen, port: int, timeout: float = 120) -> bool:
-    url = f"http://127.0.0.1:{port}/health"
+def wait_for_health(
+    proc: subprocess.Popen,
+    port: int,
+    timeout: float = 120,
+    host: str = "127.0.0.1",
+) -> bool:
+    url = f"http://{host}:{port}/health"
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if proc.poll() is not None:
@@ -350,7 +363,9 @@ def _server_already_running(port: int) -> bool:
         return False
 
 
-def launch_company(filename: str, port: int, output=None) -> subprocess.Popen:
+def launch_company(
+    filename: str, port: int, output=None, bind_host: str = "127.0.0.1"
+) -> subprocess.Popen:
     """Point the app at a company file, migrate it, and start the server."""
     from app.services import company_service
 
@@ -373,8 +388,10 @@ def launch_company(filename: str, port: int, output=None) -> subprocess.Popen:
 
     migrate(db_url, output=output)
 
-    proc = start_server(db_url, port, output=output)
-    if not wait_for_health(proc, port):
+    proc = start_server(db_url, port, output=output, bind_host=bind_host)
+    # 0.0.0.0 includes loopback; a specific interface bind does not.
+    health_host = "127.0.0.1" if bind_host in ("127.0.0.1", "0.0.0.0") else bind_host
+    if not wait_for_health(proc, port, host=health_host):
         stop_server(proc)
         raise RuntimeError(
             f"Server did not become healthy on port {port}. "
@@ -804,7 +821,35 @@ def run_window(port: int, log_fh=None) -> int:
 # ---------------------------------------------------------------------------
 
 
-def run_headless(port: int) -> int:
+def _lan_addresses() -> list[str]:
+    """Best-effort list of this machine's reachable names/IPs for the
+    'your team connects at ...' banner. Never raises."""
+    import socket
+
+    seen: list[str] = []
+    try:
+        hostname = socket.gethostname()
+        if hostname:
+            seen.append(hostname)
+    except OSError:
+        pass
+    try:
+        # UDP "connect" to a public address picks the primary interface
+        # without sending a packet.
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(("8.8.8.8", 80))
+            ip = s.getsockname()[0]
+            if ip and ip not in seen:
+                seen.append(ip)
+        finally:
+            s.close()
+    except OSError:
+        pass
+    return seen
+
+
+def run_headless(port: int, bind_host: str = "127.0.0.1") -> int:
     from app.services import company_service
 
     filename = company_service.get_last_opened()
@@ -822,12 +867,22 @@ def run_headless(port: int) -> int:
 
     print(f"Opening company file: {filename}")
     try:
-        proc = launch_company(filename, port)
+        proc = launch_company(filename, port, bind_host=bind_host)
     except (ValueError, RuntimeError, subprocess.CalledProcessError) as exc:
         print(f"ERROR: {exc}")
         return 1
 
-    print(f"SlowBooks Pro is running at http://127.0.0.1:{port}")
+    if bind_host == "127.0.0.1":
+        print(f"SlowBooks Pro is running at http://127.0.0.1:{port}")
+    else:
+        print("SlowBooks Pro — SERVER EDITION mode (LAN serving)")
+        print(f"Listening on {bind_host}:{port}. Your team connects at:")
+        for addr in _lan_addresses():
+            print(f"    http://{addr}:{port}")
+        print(
+            "NOTE: traffic is plain HTTP — use this only on a network you "
+            "trust, and make sure Windows Firewall allows the port."
+        )
     print("Press Ctrl+C to stop.")
     try:
         proc.wait()
@@ -857,7 +912,8 @@ def _serve() -> int:
         raise
 
     port = int(os.environ.get("APP_PORT", "3001"))
-    uvicorn.run(app.main.app, host="127.0.0.1", port=port, use_colors=False)
+    host = os.environ.get("APP_HOST", "127.0.0.1")
+    uvicorn.run(app.main.app, host=host, port=port, use_colors=False)
     return 0
 
 
@@ -951,6 +1007,18 @@ def main() -> int:
         ),
     )
     parser.add_argument("--port", type=int, default=None)
+    parser.add_argument(
+        "--serve-lan",
+        action="store_true",
+        help="Server Edition mode: serve to the local network (no window). "
+        "Binds 0.0.0.0 unless --bind is given.",
+    )
+    parser.add_argument(
+        "--bind",
+        default=None,
+        metavar="IP",
+        help="with --serve-lan: bind a specific interface instead of all",
+    )
     args = parser.parse_args()
 
     # A frozen console=False exe has no console at all — always behave as
@@ -1012,6 +1080,8 @@ def main() -> int:
 
         port = args.port or int(get_env_value("APP_PORT") or "3001")
 
+        if args.serve_lan:
+            return run_headless(port, bind_host=args.bind or "0.0.0.0")
         if args.no_window:
             return run_headless(port)
         return run_window(port, log_fh)

--- a/tests/test_server_mode.py
+++ b/tests/test_server_mode.py
@@ -1,0 +1,80 @@
+"""Server Edition groundwork (PR-S1): LAN bind plumbing, SQLite WAL
+tuning, and the /api/system server_mode flag the UI keys its header off."""
+
+import sqlite3
+
+from sqlalchemy import create_engine, text
+
+import desktop_launcher
+from app.database import enable_sqlite_tuning
+
+# ---------------------------------------------------------------------------
+# SQLite concurrency tuning
+# ---------------------------------------------------------------------------
+
+
+def test_sqlite_tuning_enables_wal(tmp_path):
+    db = tmp_path / "tuned.db"
+    engine = create_engine(f"sqlite:///{db}")
+    enable_sqlite_tuning(engine)
+    with engine.connect() as conn:
+        mode = conn.execute(text("PRAGMA journal_mode")).scalar()
+        busy = conn.execute(text("PRAGMA busy_timeout")).scalar()
+        sync = conn.execute(text("PRAGMA synchronous")).scalar()
+    assert str(mode).lower() == "wal"
+    assert int(busy) == 5000
+    assert int(sync) == 1  # NORMAL
+
+    # WAL is persistent in the file: a plain sqlite3 connection sees it too
+    raw = sqlite3.connect(db)
+    assert raw.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+    raw.close()
+
+
+def test_sqlite_tuning_harmless_on_memory_db():
+    engine = create_engine("sqlite:///:memory:")
+    enable_sqlite_tuning(engine)
+    with engine.connect() as conn:
+        mode = conn.execute(text("PRAGMA journal_mode")).scalar()
+    assert str(mode).lower() == "memory"  # no-op, no error
+
+
+# ---------------------------------------------------------------------------
+# Launcher bind plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_server_env_default_is_loopback():
+    env = desktop_launcher._server_env("sqlite:///x.db", 3001)
+    assert env["APP_HOST"] == "127.0.0.1"
+    assert env["SLOWBOOKS_SERVER_MODE"] == "0"
+
+
+def test_server_env_lan_bind_sets_server_mode():
+    env = desktop_launcher._server_env("sqlite:///x.db", 3001, bind_host="0.0.0.0")
+    assert env["APP_HOST"] == "0.0.0.0"
+    assert env["SLOWBOOKS_SERVER_MODE"] == "1"
+    env = desktop_launcher._server_env(
+        "sqlite:///x.db", 3001, bind_host="192.168.68.50"
+    )
+    assert env["SLOWBOOKS_SERVER_MODE"] == "1"
+
+
+def test_lan_addresses_never_raises():
+    addrs = desktop_launcher._lan_addresses()
+    assert isinstance(addrs, list)
+    assert all(isinstance(a, str) and a for a in addrs)
+
+
+# ---------------------------------------------------------------------------
+# /api/system flag
+# ---------------------------------------------------------------------------
+
+
+def test_system_info_reports_server_mode(authed_client, monkeypatch):
+    info = authed_client.get("/api/system").json()
+    assert info["server_mode"] is False
+
+    monkeypatch.setenv("SLOWBOOKS_SERVER_MODE", "1")
+    info = authed_client.get("/api/system").json()
+    assert info["server_mode"] is True


### PR DESCRIPTION
First increment toward **SlowBooks Pro Server Edition** — targets the `server-edition` integration branch, NOT main. Main only gets the final PR after real LAN testing on the test machines.

## What

- `--serve-lan [--bind IP]` launcher mode: headless, binds 0.0.0.0 (or one interface), prints team connect URLs + plain-HTTP warning. Desktop windowed mode untouched (loopback-only, forever).
- `enable_sqlite_tuning()`: WAL + busy_timeout=5000 + synchronous=NORMAL on SQLite engines — office-grade read concurrency while keeping the one-file-per-company model.
- `/api/system` → `server_mode`; UI shows **SERVER EDITION** sidebar header + "· Server" footer suffix when serving the LAN.
- Health check respects specific-interface binds.

## Verified

- 1072 tests green (6 new: WAL pragmas persist in-file, :memory: no-op, bind plumbing, server_mode flag)
- Live LAN check on this network: served `0.0.0.0:3013`, accessed via `192.168.68.72`, header rendered (screenshot in session), auth flow works over LAN
- `node --check` clean, black/ruff clean

## Known limitations (by design, this increment)

- Plain HTTP — trusted-LAN only, TLS story is a later increment
- Single-user auth still (principal model is PR-S2)
- No Windows service yet (PR-S4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uzF92MM21Ac6Y6Gfei4ro