### PR TITLE
Server Edition install: startup task scripts, visible URLs, --data-dir

### DIFF
--- a/desktop_launcher.py
+++ b/desktop_launcher.py
@@ -735,6 +735,52 @@ def _show_error_box(message: str) -> None:
         pass
 
 
+def _compose_serve_banner(port: int, addresses: list[str]) -> str:
+    """The 'your team connects at ...' text — shared by the console print,
+    the connect-urls.txt drop, and the frozen build's popup."""
+    lines = ["SlowBooks Pro — SERVER EDITION mode is running.", ""]
+    lines.append("Your team connects at:")
+    for addr in addresses or ["<this machine's IP>"]:
+        lines.append(f"    http://{addr}:{port}")
+    lines += [
+        "",
+        "Traffic is plain HTTP — trusted networks only.",
+        "This server stops when this process is closed.",
+    ]
+    return "\n".join(lines)
+
+
+def _announce_serve_lan(port: int) -> None:
+    """Make the connect URLs impossible to miss.
+
+    The frozen exe has no console (field report: 'I ran the command and
+    nothing happened'), so print alone is useless there. Always write
+    connect-urls.txt next to the data, and on frozen Windows also raise a
+    non-blocking popup from a daemon thread (the server keeps serving
+    behind it)."""
+    banner = _compose_serve_banner(port, _lan_addresses())
+    print(banner)
+    try:
+        (get_data_dir() / "connect-urls.txt").write_text(banner, encoding="utf-8")
+    except OSError:
+        pass
+    if FROZEN and sys.platform == "win32":
+        import threading
+
+        def _popup():
+            try:
+                import ctypes
+
+                MB_ICONINFORMATION = 0x40
+                ctypes.windll.user32.MessageBoxW(
+                    0, banner, "SlowBooks Pro — Server Edition", MB_ICONINFORMATION
+                )
+            except Exception:
+                pass
+
+        threading.Thread(target=_popup, daemon=True).start()
+
+
 def run_window(port: int, log_fh=None) -> int:
     try:
         import webview
@@ -875,14 +921,7 @@ def run_headless(port: int, bind_host: str = "127.0.0.1") -> int:
     if bind_host == "127.0.0.1":
         print(f"SlowBooks Pro is running at http://127.0.0.1:{port}")
     else:
-        print("SlowBooks Pro — SERVER EDITION mode (LAN serving)")
-        print(f"Listening on {bind_host}:{port}. Your team connects at:")
-        for addr in _lan_addresses():
-            print(f"    http://{addr}:{port}")
-        print(
-            "NOTE: traffic is plain HTTP — use this only on a network you "
-            "trust, and make sure Windows Firewall allows the port."
-        )
+        _announce_serve_lan(port)
     print("Press Ctrl+C to stop.")
     try:
         proc.wait()
@@ -1019,7 +1058,17 @@ def main() -> int:
         metavar="IP",
         help="with --serve-lan: bind a specific interface instead of all",
     )
+    parser.add_argument(
+        "--data-dir",
+        default=None,
+        metavar="PATH",
+        help="override the data directory (sets SLOWBOOKS_DATA_DIR). Used "
+        "by the Server Edition scheduled task so books live in a "
+        "machine-wide location instead of one user's profile.",
+    )
     args = parser.parse_args()
+    if args.data_dir:
+        os.environ["SLOWBOOKS_DATA_DIR"] = str(Path(args.data_dir).resolve())
 
     # A frozen console=False exe has no console at all — always behave as
     # --hidden there so output lands in launcher.log instead of vanishing.

--- a/docs/server-edition.md
+++ b/docs/server-edition.md
@@ -1,0 +1,85 @@
+# SlowBooks Pro Server Edition — setup guide
+
+One download, two products: the same signed Windows build that runs as a
+single-user desktop app can serve your whole office. Add a second user
+and the deployment *becomes* Server Edition — no separate license, no
+separate download, free either way.
+
+## What you get
+
+- One Windows PC hosts the books; everyone else uses a **browser** —
+  nothing to install on the other computers.
+- **Users and roles**: admin (everything), bookkeeper (daily books, no
+  admin functions), read-only (reports and lookups).
+- Every change in the audit log says **who** made it.
+- The company stays **one file** — backup is copy, undo is restore.
+
+## Quick trial (no install, stops when you close it)
+
+On the machine that will host:
+
+```powershell
+cd <folder containing SlowBooksPro.exe>
+.\SlowBooksPro.exe --serve-lan
+```
+
+A popup shows the connect URLs (also written to `connect-urls.txt` in the
+data folder). Allow the Windows Firewall prompt. From any other computer
+on the network, browse to `http://<host-name>:3001`.
+
+## Permanent install (starts with Windows, no login needed)
+
+From an **elevated** PowerShell in the folder containing the exe:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File _internal\scripts\windows\serveredition-install.ps1
+```
+
+This registers a startup task (runs as SYSTEM before anyone logs in),
+opens the firewall port, moves the data home to
+`C:\ProgramData\SlowBooksPro` (machine-wide, not one user's profile),
+starts the server, and prints your team's connect URLs.
+
+Undo it any time:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File _internal\scripts\windows\serveredition-uninstall.ps1
+```
+
+Your books survive uninstall — the script never deletes data.
+
+## Adding your team
+
+1. Sign in as the admin → **Settings → Users**.
+2. Add each person with a username, password, and role. The moment a
+   second user exists, the login screen gains a username field and the
+   header reads **SERVER EDITION**.
+3. Roles are enforced server-side: a read-only user physically cannot
+   post an entry; a bookkeeper cannot touch Settings, Users, backups, or
+   migrations. The last active admin can never be locked out — the app
+   refuses to demote or deactivate them.
+
+## Honest limits (current release)
+
+- **Plain HTTP** — run this on a network you trust (an office LAN behind
+  your router). TLS support is planned; until then do not port-forward
+  it to the internet.
+- Comfortable for small teams (2–10 people). The database serializes
+  writes; hundreds of concurrent users is not the design target.
+- The update badge appears in-app as usual; updating means running the
+  new installer on the host machine.
+
+## Troubleshooting
+
+- **Downloaded a build artifact from GitHub Actions?** It's a zip inside
+  a zip — extract twice.
+- **"Nothing happened" when running the exe** — the packaged exe has no
+  console; output goes to `launcher.log` in the data folder, and
+  `--serve-lan` shows its URLs in a popup + `connect-urls.txt`.
+- **Double-clicking the exe shows a WebView2 error** — that's the
+  *desktop window* needing the WebView2 runtime (the installer sets it
+  up; the portable zip doesn't). `--serve-lan` doesn't need WebView2 at
+  all — browsers on client machines are all it takes.
+- **Other computers can't connect** — check the firewall rule (the
+  install script creates it; the quick-trial path relies on you clicking
+  Allow), and confirm host and clients are on the same network.

--- a/packaging/windows/SlowBooksPro.spec
+++ b/packaging/windows/SlowBooksPro.spec
@@ -42,6 +42,10 @@ datas += _tree("app/templates", "app/templates")
 # Alembic loads migration scripts as FILES at runtime (script_location) —
 # they must exist on disk in the bundle, not just inside the PYZ.
 datas += _tree("migrations", "migrations")
+# Server Edition helper scripts ship in the bundle so an installed or
+# portable copy can register the startup task without downloading anything:
+#   _internal\scripts\windows\serveredition-install.ps1
+datas += _tree("scripts/windows", "scripts/windows")
 
 # The WeasyPrint DLL set staged by CI (empty when building without it, so a
 # local `pyinstaller SlowBooksPro.spec` still produces a testable bundle).

--- a/scripts/windows/serveredition-install.ps1
+++ b/scripts/windows/serveredition-install.ps1
@@ -1,0 +1,61 @@
+# ============================================================================
+# SlowBooks Pro — Server Edition install (Windows)
+#
+# Registers a scheduled task that runs the server at machine startup as
+# SYSTEM (no login required), stores books machine-wide under
+# C:\ProgramData\SlowBooksPro, and opens the firewall port. Run from an
+# elevated PowerShell:
+#
+#   powershell -ExecutionPolicy Bypass -File serveredition-install.ps1
+#
+# Undo everything with serveredition-uninstall.ps1.
+# ============================================================================
+#Requires -RunAsAdministrator
+param(
+    [int]$Port = 3001,
+    [string]$ExePath = "",
+    [string]$DataDir = "$env:ProgramData\SlowBooksPro"
+)
+
+$ErrorActionPreference = "Stop"
+$TaskName = "SlowBooksProServer"
+$RuleName = "SlowBooks Pro Server Edition"
+
+# The script ships inside the bundle at _internal\scripts\windows\ —
+# the exe is three levels up. Explicit -ExePath overrides.
+if (-not $ExePath) {
+    $ExePath = Join-Path $PSScriptRoot "..\..\..\SlowBooksPro.exe"
+}
+$ExePath = (Resolve-Path $ExePath).Path
+if (-not (Test-Path $ExePath)) {
+    throw "SlowBooksPro.exe not found at $ExePath — pass -ExePath"
+}
+
+New-Item -ItemType Directory -Force -Path $DataDir | Out-Null
+
+Write-Host ">> Opening firewall port $Port (rule: $RuleName)"
+netsh advfirewall firewall delete rule name="$RuleName" | Out-Null
+netsh advfirewall firewall add rule name="$RuleName" dir=in action=allow `
+    protocol=TCP localport=$Port | Out-Null
+
+Write-Host ">> Registering startup task $TaskName (runs as SYSTEM, no login needed)"
+$TaskCmd = "`"$ExePath`" --serve-lan --port $Port --data-dir `"$DataDir`""
+schtasks /Create /TN $TaskName /SC ONSTART /RU SYSTEM /RL HIGHEST /F /TR $TaskCmd | Out-Null
+
+Write-Host ">> Starting the server now"
+schtasks /Run /TN $TaskName | Out-Null
+Start-Sleep -Seconds 8
+
+$ips = Get-NetIPAddress -AddressFamily IPv4 |
+    Where-Object { $_.IPAddress -notlike "127.*" -and $_.IPAddress -notlike "169.254.*" } |
+    Select-Object -ExpandProperty IPAddress
+
+Write-Host ""
+Write-Host "SlowBooks Pro Server Edition is installed." -ForegroundColor Green
+Write-Host "Books live in: $DataDir"
+Write-Host "Your team connects at:"
+Write-Host "    http://$($env:COMPUTERNAME):$Port"
+foreach ($ip in $ips) { Write-Host "    http://${ip}:$Port" }
+Write-Host ""
+Write-Host "It starts automatically with Windows (before anyone logs in)."
+Write-Host "Plain HTTP - trusted networks only."

--- a/scripts/windows/serveredition-uninstall.ps1
+++ b/scripts/windows/serveredition-uninstall.ps1
@@ -1,0 +1,16 @@
+# ============================================================================
+# SlowBooks Pro — Server Edition uninstall (Windows)
+#
+# Removes the startup task and firewall rule. Books under
+# C:\ProgramData\SlowBooksPro are deliberately left in place — delete
+# that folder yourself if you're sure.
+# ============================================================================
+#Requires -RunAsAdministrator
+$ErrorActionPreference = "SilentlyContinue"
+
+schtasks /End /TN "SlowBooksProServer" | Out-Null
+schtasks /Delete /TN "SlowBooksProServer" /F | Out-Null
+netsh advfirewall firewall delete rule name="SlowBooks Pro Server Edition" | Out-Null
+
+Write-Host "Server Edition task + firewall rule removed." -ForegroundColor Green
+Write-Host "Your books are untouched at $env:ProgramData\SlowBooksPro."

--- a/tests/test_server_mode.py
+++ b/tests/test_server_mode.py
@@ -78,3 +78,40 @@ def test_system_info_reports_server_mode(authed_client, monkeypatch):
     monkeypatch.setenv("SLOWBOOKS_SERVER_MODE", "1")
     info = authed_client.get("/api/system").json()
     assert info["server_mode"] is True
+
+
+# ---------------------------------------------------------------------------
+# PR-S4: banner composition + --data-dir override
+# ---------------------------------------------------------------------------
+
+
+def test_serve_banner_lists_all_addresses():
+    text = desktop_launcher._compose_serve_banner(3001, ["OFFICE-PC", "192.168.68.50"])
+    assert "http://OFFICE-PC:3001" in text
+    assert "http://192.168.68.50:3001" in text
+    assert "plain HTTP" in text
+    # No addresses discovered: still renders something actionable
+    fallback = desktop_launcher._compose_serve_banner(3001, [])
+    assert "3001" in fallback
+
+
+def test_data_dir_flag_redirects_everything(tmp_path):
+    import subprocess
+    import sys as _sys
+
+    target = tmp_path / "server-data"
+    r = subprocess.run(
+        [
+            _sys.executable,
+            "desktop_launcher.py",
+            "--setup-only",
+            "--data-dir",
+            str(target),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={**__import__("os").environ, "SLOWBOOKS_DATA_DIR": ""},
+    )
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert (target / "companies").is_dir()


### PR DESCRIPTION
PR-S4, the last piece of the Server Edition stack (base: `server-edition`).

## What

- **Silent-exe fix**: frozen `--serve-lan` now raises a non-blocking connect-URLs popup (daemon thread; server keeps serving) + writes `connect-urls.txt`. Direct response to the field test.
- **`--data-dir`**: machine-wide books location for the startup task (SYSTEM's LOCALAPPDATA would otherwise swallow them).
- **`serveredition-install.ps1` / `-uninstall.ps1`**: startup task (ONSTART, SYSTEM, highest), firewall rule, immediate start, team-URL printout. Shipped inside the bundle via the PyInstaller spec. Uninstall never deletes books.
- **`docs/server-edition.md`**: setup guide + troubleshooting distilled from today's real skytech/vonholten308 session.

## Verified

- 1094 tests green (banner composition; `--data-dir` proven end-to-end via `--setup-only` subprocess creating the tree in the override location)
- PS1 scripts are the piece that needs the physical skytech pass — that's the final LAN test before `server-edition` → `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uzF92MM21Ac6Y6Gfei4ro