### PR TITLE
SlowBooks Pro Server Edition

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,7 @@
+# GitGuardian/ggshield configuration.
+# tests/ contains deliberately fake credentials (fixture passwords like
+# "test-password-123") — secrets in tests are test data, not leaks.
+version: 2
+secret:
+  ignored_paths:
+    - "tests/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, "claude/**"]
+    branches: [main, server-edition, "claude/**", "se/**"]
   pull_request:
-    branches: [main]
+    branches: [main, server-edition]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, server-edition]
   schedule:
     - cron: "0 6 * * 1"  # Weekly on Monday at 6am UTC
 

--- a/app/database.py
+++ b/app/database.py
@@ -5,6 +5,7 @@
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
+from starlette.requests import HTTPConnection
 
 from app.config import DATABASE_URL
 
@@ -54,8 +55,22 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 
 
-def get_db():
+def get_db(request: HTTPConnection = None):
+    """Request-scoped DB session (FastAPI dependency).
+
+    When FastAPI injects the request, the acting username is stamped onto
+    the Session's own info dict — the audit hooks receive this exact
+    object at flush time, so attribution travels WITH the session instead
+    of relying on contextvar propagation (which proved unreliable on the
+    frozen Windows runtime; the contextvar remains as a fallback for
+    sessions created outside the request cycle)."""
     db = SessionLocal()
+    try:
+        session = getattr(request, "session", None) if request is not None else None
+        if isinstance(session, dict) and session.get("authenticated") is True:
+            db.info["acting_username"] = session.get("username") or "operator"
+    except Exception:
+        pass  # attribution must never break a request
     try:
         yield db
     except Exception:

--- a/app/database.py
+++ b/app/database.py
@@ -25,6 +25,31 @@ if not _is_sqlite:
         pool_use_lifo=True,
     )
 engine = create_engine(DATABASE_URL, **_engine_kwargs)
+
+
+def enable_sqlite_tuning(target_engine) -> None:
+    """Concurrency PRAGMAs for SQLite engines (Server Edition groundwork).
+
+    WAL lets readers proceed while one writer commits — the difference
+    between "works for an office" and "database is locked" the moment a
+    second person opens a report mid-save. busy_timeout makes brief lock
+    contention wait instead of erroring; NORMAL sync is the recommended
+    pairing with WAL. Harmless no-ops on :memory: databases.
+    """
+    from sqlalchemy import event
+
+    @event.listens_for(target_engine, "connect")
+    def _tune(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA journal_mode=WAL")
+        cur.execute("PRAGMA busy_timeout=5000")
+        cur.execute("PRAGMA synchronous=NORMAL")
+        cur.close()
+
+
+if _is_sqlite:
+    enable_sqlite_tuning(engine)
+
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 

--- a/app/main.py
+++ b/app/main.py
@@ -341,7 +341,10 @@ def _role_allows(role: str, method: str, path: str) -> bool:
         return True
     is_read = method in _READ_METHODS
     if role == "readonly":
-        return is_read
+        # Field finding: audit payloads snapshot full record contents
+        # (tax ids, addresses) — "read the books" shouldn't mean "read
+        # every historical value of every field".
+        return is_read and not path.startswith("/api/audit")
     # bookkeeper: full read, all daily-books writes, no admin writes
     if is_read:
         return True

--- a/app/main.py
+++ b/app/main.py
@@ -57,6 +57,7 @@ from app.routes import uploads
 
 # Phase 5: Advanced Integration
 from app.routes import bank_import, simplefin, tax, backups
+from app.routes import users as users_routes
 from app.routes import classes as classes_routes
 from app.routes import fx as fx_routes
 from app.routes import fixed_assets as fixed_assets_routes
@@ -111,6 +112,7 @@ from app.config import (
 )
 from app.database import SessionLocal, Base, engine
 from app.services.audit import register_audit_hooks
+from app.services.request_context import acting_username as _acting_username
 
 
 def _run_startup_security_checks():
@@ -313,6 +315,39 @@ _AUTH_EXEMPT_RE = _re.compile(
 )
 
 
+# ---------------------------------------------------------------------------
+# Server Edition RBAC — coarse route-group policy, enforced centrally.
+#
+#   admin       everything
+#   bookkeeper  everything except administrative writes (users, settings,
+#               backups, companies, migration imports)
+#   readonly    GET/HEAD/OPTIONS only
+#
+# Legacy sessions (issued before the principal model) carry no role and
+# are treated as admin — they belong to the operator by definition.
+# ---------------------------------------------------------------------------
+_ADMIN_WRITE_PREFIXES = (
+    "/api/users",
+    "/api/settings",
+    "/api/backups",
+    "/api/companies",
+    "/api/migration",
+)
+_READ_METHODS = ("GET", "HEAD", "OPTIONS")
+
+
+def _role_allows(role: str, method: str, path: str) -> bool:
+    if role == "admin":
+        return True
+    is_read = method in _READ_METHODS
+    if role == "readonly":
+        return is_read
+    # bookkeeper: full read, all daily-books writes, no admin writes
+    if is_read:
+        return True
+    return not path.startswith(_ADMIN_WRITE_PREFIXES)
+
+
 @app.middleware("http")
 async def require_session(request: Request, call_next):
     path = request.url.path
@@ -326,6 +361,13 @@ async def require_session(request: Request, call_next):
         return JSONResponse(
             status_code=401,
             content={"detail": "Not authenticated"},
+        )
+
+    role = request.session.get("role") or "admin"
+    if not _role_allows(role, request.method, path):
+        return JSONResponse(
+            status_code=403,
+            content={"detail": "Your role doesn't allow this action"},
         )
 
     # Idle session cap. Sliding window — every authenticated hit refreshes
@@ -342,7 +384,13 @@ async def require_session(request: Request, call_next):
             )
         request.session["last_activity"] = now
 
-    return await call_next(request)
+    # Attribute this request's DB writes to the acting user (audit hooks
+    # read the contextvar — they have no access to the request).
+    token = _acting_username.set(request.session.get("username") or "operator")
+    try:
+        return await call_next(request)
+    finally:
+        _acting_username.reset(token)
 
 
 # ---- Session cookie (Phase 9.7) ----
@@ -400,6 +448,7 @@ app.include_router(uploads.router)
 # Phase 5: Advanced Integration
 app.include_router(bank_import.router)
 app.include_router(simplefin.router)
+app.include_router(users_routes.router)
 app.include_router(tax.router)
 app.include_router(backups.router)
 app.include_router(system_routes.router)

--- a/app/main.py
+++ b/app/main.py
@@ -384,16 +384,45 @@ async def require_session(request: Request, call_next):
             )
         request.session["last_activity"] = now
 
-    # Attribute this request's DB writes to the acting user (audit hooks
-    # read the contextvar — they have no access to the request).
-    token = _acting_username.set(request.session.get("username") or "operator")
-    try:
-        return await call_next(request)
-    finally:
-        _acting_username.reset(token)
+    return await call_next(request)
+
+
+class ActingUserContextMiddleware:
+    """Pure-ASGI middleware: stamp the acting username into a contextvar
+    for the audit hooks (which live at the SQLAlchemy layer and can't see
+    the request).
+
+    Deliberately NOT a BaseHTTPMiddleware — those run the downstream app
+    in a separate task, and contextvar propagation across that hop proved
+    unreliable on the frozen Windows build (field report: every audit row
+    showed no user despite the middleware setting the var). Pure ASGI
+    runs in the same task; the value is visible to everything downstream
+    unconditionally.
+
+    Must be registered BEFORE SessionMiddleware's add_middleware call so
+    SessionMiddleware wraps outside us and scope["session"] is populated.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+        session = scope.get("session") or {}
+        acting = None
+        if session.get("authenticated") is True:
+            acting = session.get("username") or "operator"
+        token = _acting_username.set(acting)
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            _acting_username.reset(token)
 
 
 # ---- Session cookie (Phase 9.7) ----
+app.add_middleware(ActingUserContextMiddleware)
+
 # Added AFTER require_session so SessionMiddleware becomes the outer
 # layer (Starlette: last added = outermost). That way request.session
 # is populated by the time require_session dispatches.

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -13,6 +13,9 @@ from app.models.fixed_assets import FixedAsset, FixedAssetType  # noqa: F401
 # Phase 1: Foundation
 from app.models.audit import AuditLog
 
+# Server Edition: user principals
+from app.models.users import User  # noqa: F401 — registers the table
+
 # Phase 2: Accounts Payable
 from app.models.purchase_orders import PurchaseOrder, PurchaseOrderLine
 from app.models.bills import Bill, BillLine, BillPayment, BillPaymentAllocation

--- a/app/models/audit.py
+++ b/app/models/audit.py
@@ -21,3 +21,6 @@ class AuditLog(Base):
     changed_fields = Column(JSON, nullable=True)
     timestamp = Column(DateTime(timezone=True), server_default=func.now(), index=True)
     source = Column(String(100), nullable=True)  # e.g. "api", "system"
+    # Server Edition: which user made the change (NULL on pre-multi-user
+    # rows and system-originated writes)
+    username = Column(String(100), nullable=True, index=True)

--- a/app/models/users.py
+++ b/app/models/users.py
@@ -1,0 +1,38 @@
+# ============================================================================
+# Users — the principal model (Server Edition).
+#
+# One row per person who can sign in. Single-operator installs have
+# exactly one admin row (backfilled from the legacy settings-table
+# password hash on first login after upgrade) and never see a username
+# field. Roles are stored now, enforced by the RBAC layer.
+# ============================================================================
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, Column, DateTime, Integer, String
+
+from app.database import Base
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+ROLE_ADMIN = "admin"
+ROLE_BOOKKEEPER = "bookkeeper"
+ROLE_READONLY = "readonly"
+VALID_ROLES = (ROLE_ADMIN, ROLE_BOOKKEEPER, ROLE_READONLY)
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    # Stored lowercase; lookups lowercase their input.
+    username = Column(String(100), unique=True, nullable=False, index=True)
+    display_name = Column(String(200), nullable=False, default="")
+    password_hash = Column(String(512), nullable=False)
+    role = Column(String(20), nullable=False, default=ROLE_ADMIN)
+    is_active = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime, default=_utcnow, nullable=False)
+    last_login_at = Column(DateTime, nullable=True)

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,10 +1,9 @@
 # ============================================================================
-# Slowbooks Pro 2026 — Auth routes (Phase 9.7)
+# Slowbooks Pro 2026 — Auth routes
 #
-# Single-operator password flow. No user model — just:
-#   GET  /api/auth/status  → {setup_needed, authenticated}
+#   GET  /api/auth/status  → {setup_needed, authenticated, multi_user, user?}
 #   POST /api/auth/setup   → first-time password set (409 if already set)
-#   POST /api/auth/login   → verify password, issue session cookie
+#   POST /api/auth/login   → password (+ username once 2+ users exist)
 #   POST /api/auth/logout  → clear session
 #
 # These routes are deliberately NOT protected by require_auth — they're
@@ -20,7 +19,9 @@ from sqlalchemy.orm import Session
 from app.database import get_db
 from app.models.auth import LoginAttempt
 from app.services.auth import (
-    check_password,
+    authenticate,
+    ensure_admin_user,
+    is_multi_user,
     password_is_set,
     set_password,
 )
@@ -49,6 +50,8 @@ def _record_login_attempt(db: Session, request: Request, success: bool) -> None:
 
 class PasswordPayload(BaseModel):
     password: str = Field(..., min_length=1, max_length=512)
+    # Server Edition: required only when more than one user exists.
+    username: Optional[str] = Field(None, max_length=100)
 
 
 class SetupPayload(BaseModel):
@@ -101,10 +104,20 @@ _SETUP_SETTINGS_KEYS = (
 def auth_status(request: Request, db: Session = Depends(get_db)):
     """Tell the SPA whether first-run setup is needed and whether the
     current session is authenticated."""
-    return {
+    authenticated = request.session.get("authenticated") is True
+    out = {
         "setup_needed": not password_is_set(db),
-        "authenticated": request.session.get("authenticated") is True,
+        "authenticated": authenticated,
+        # Login UI shows a username field only when this is true.
+        "multi_user": is_multi_user(db),
     }
+    if authenticated and request.session.get("username"):
+        out["user"] = {
+            "username": request.session.get("username"),
+            "display_name": request.session.get("display_name") or "",
+            "role": request.session.get("role") or "admin",
+        }
+    return out
 
 
 @router.post("/setup")
@@ -131,13 +144,27 @@ def setup(
             set_setting(db, key, value)
 
     set_password(db, payload.password)
+    # Materialize the operator as the admin user row right away (Server
+    # Edition principal model) — same password, zero extra questions.
+    admin = ensure_admin_user(db)
     # Rotate session before issuing — clears anything an attacker might have
     # planted via a fixation attempt. Starlette's signed-cookie session is
     # already fixation-resistant (signature changes with payload) but this
     # is defence in depth and intent-revealing.
     request.session.clear()
     request.session["authenticated"] = True
+    _stash_user(request, admin)
     return {"status": "ok", "authenticated": True}
+
+
+def _stash_user(request: Request, user) -> None:
+    """Record the acting principal in the session (None = legacy no-row)."""
+    if user is None:
+        return
+    request.session["user_id"] = user.id
+    request.session["username"] = user.username
+    request.session["display_name"] = user.display_name
+    request.session["role"] = user.role
 
 
 @router.post("/login")
@@ -159,16 +186,27 @@ def login(
             status_code=status.HTTP_409_CONFLICT,
             detail="Setup required — set a password first",
         )
-    if not check_password(db, payload.password):
+    if is_multi_user(db) and not (payload.username or "").strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Username required",
+        )
+    user = authenticate(db, payload.password, username=payload.username)
+    if user is None:
         _record_login_attempt(db, request, success=False)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect password",
+            detail=(
+                "Incorrect username or password"
+                if is_multi_user(db)
+                else "Incorrect password"
+            ),
         )
     _record_login_attempt(db, request, success=True)
     # Same rotation rationale as /setup.
     request.session.clear()
     request.session["authenticated"] = True
+    _stash_user(request, user)
     return {"status": "ok", "authenticated": True}
 
 

--- a/app/routes/system.py
+++ b/app/routes/system.py
@@ -16,9 +16,11 @@ import os
 import time
 
 import httpx
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Request
+from sqlalchemy.orm import Session
 
 from app import __version__
+from app.database import get_db
 
 router = APIRouter(prefix="/api/system", tags=["system"])
 
@@ -65,6 +67,22 @@ async def system_info():
         "version": __version__,
         "desktop": _is_desktop(),
         "server_mode": _is_server_mode(),
+    }
+
+
+@router.get("/attribution-debug")
+def attribution_debug(request: Request, db: Session = Depends(get_db)):
+    """TEMPORARY (server-edition branch only): pinpoint which attribution
+    link fails on the frozen Windows build. Reports what every layer sees
+    for the current authenticated request."""
+    from app.services.request_context import acting_username
+
+    return {
+        "app_version": __version__,
+        "http_session_keys": sorted(request.session.keys()),
+        "http_session_username": request.session.get("username"),
+        "db_info_username": db.info.get("acting_username"),
+        "contextvar_username": acting_username.get(),
     }
 
 

--- a/app/routes/system.py
+++ b/app/routes/system.py
@@ -36,6 +36,11 @@ def _is_desktop() -> bool:
     return os.environ.get("SLOWBOOKS_DESKTOP") == "1"
 
 
+def _is_server_mode() -> bool:
+    """True when the launcher is serving beyond loopback (--serve-lan)."""
+    return os.environ.get("SLOWBOOKS_SERVER_MODE") == "1"
+
+
 def _parse(v) -> tuple:
     """'2.1.0' (or 'v2.1.0') → (2, 1, 0) for comparison."""
     out = []
@@ -56,7 +61,11 @@ def is_newer(remote: str, local: str) -> bool:
 
 @router.get("")
 async def system_info():
-    return {"version": __version__, "desktop": _is_desktop()}
+    return {
+        "version": __version__,
+        "desktop": _is_desktop(),
+        "server_mode": _is_server_mode(),
+    }
 
 
 @router.get("/update-check")

--- a/app/routes/system.py
+++ b/app/routes/system.py
@@ -16,11 +16,9 @@ import os
 import time
 
 import httpx
-from fastapi import APIRouter, Depends, Request
-from sqlalchemy.orm import Session
+from fastapi import APIRouter
 
 from app import __version__
-from app.database import get_db
 
 router = APIRouter(prefix="/api/system", tags=["system"])
 
@@ -67,22 +65,6 @@ async def system_info():
         "version": __version__,
         "desktop": _is_desktop(),
         "server_mode": _is_server_mode(),
-    }
-
-
-@router.get("/attribution-debug")
-def attribution_debug(request: Request, db: Session = Depends(get_db)):
-    """TEMPORARY (server-edition branch only): pinpoint which attribution
-    link fails on the frozen Windows build. Reports what every layer sees
-    for the current authenticated request."""
-    from app.services.request_context import acting_username
-
-    return {
-        "app_version": __version__,
-        "http_session_keys": sorted(request.session.keys()),
-        "http_session_username": request.session.get("username"),
-        "db_info_username": db.info.get("acting_username"),
-        "contextvar_username": acting_username.get(),
     }
 
 

--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -1,0 +1,140 @@
+# ============================================================================
+# User management (Server Edition) — admin-only via the RBAC middleware
+# (/api/users is an admin write prefix; reads are role-gated in-route so
+# non-admins never enumerate accounts either).
+#
+# No DELETE on purpose: users deactivate, they don't disappear — their
+# username stays meaningful in the audit trail forever.
+# ============================================================================
+
+import re
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.users import ROLE_ADMIN, VALID_ROLES, User
+from app.services.auth import MIN_PASSWORD_LEN, hash_password
+
+router = APIRouter(prefix="/api/users", tags=["users"])
+
+_USERNAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{2,49}$")
+
+
+def _require_admin(request: Request) -> None:
+    if (request.session.get("role") or "admin") != ROLE_ADMIN:
+        raise HTTPException(status_code=403, detail="Admin role required")
+
+
+def _user_out(u: User) -> dict:
+    return {
+        "id": u.id,
+        "username": u.username,
+        "display_name": u.display_name,
+        "role": u.role,
+        "is_active": u.is_active,
+        "created_at": u.created_at.isoformat() if u.created_at else None,
+        "last_login_at": u.last_login_at.isoformat() if u.last_login_at else None,
+    }
+
+
+def _other_active_admin_exists(db: Session, user: User) -> bool:
+    return (
+        db.query(User)
+        .filter(User.role == ROLE_ADMIN, User.is_active, User.id != user.id)
+        .count()
+        > 0
+    )
+
+
+class UserCreate(BaseModel):
+    username: str = Field(..., min_length=3, max_length=50)
+    display_name: str = Field("", max_length=200)
+    password: str = Field(..., min_length=1, max_length=512)
+    role: str = Field(...)
+
+
+class UserUpdate(BaseModel):
+    display_name: Optional[str] = Field(None, max_length=200)
+    role: Optional[str] = None
+    is_active: Optional[bool] = None
+    password: Optional[str] = Field(None, max_length=512)
+
+
+@router.get("")
+def list_users(request: Request, db: Session = Depends(get_db)):
+    _require_admin(request)
+    return [_user_out(u) for u in db.query(User).order_by(User.id).all()]
+
+
+@router.post("", status_code=201)
+def create_user(payload: UserCreate, request: Request, db: Session = Depends(get_db)):
+    _require_admin(request)
+    username = payload.username.strip().lower()
+    if not _USERNAME_RE.match(username):
+        raise HTTPException(
+            status_code=400,
+            detail="Username must be 3-50 characters: letters, digits, . _ -",
+        )
+    if payload.role not in VALID_ROLES:
+        raise HTTPException(status_code=400, detail="Invalid role")
+    if len(payload.password) < MIN_PASSWORD_LEN:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Password must be at least {MIN_PASSWORD_LEN} characters",
+        )
+    if db.query(User).filter(User.username == username).first():
+        raise HTTPException(status_code=409, detail="Username already exists")
+    user = User(
+        username=username,
+        display_name=payload.display_name.strip() or username.title(),
+        password_hash=hash_password(payload.password),
+        role=payload.role,
+        is_active=True,
+    )
+    db.add(user)
+    db.commit()
+    return _user_out(user)
+
+
+@router.put("/{user_id}")
+def update_user(
+    user_id: int, payload: UserUpdate, request: Request, db: Session = Depends(get_db)
+):
+    _require_admin(request)
+    user = db.query(User).filter(User.id == user_id).first()
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    demoting = payload.role is not None and payload.role != ROLE_ADMIN
+    deactivating = payload.is_active is False
+    if (
+        user.role == ROLE_ADMIN
+        and user.is_active
+        and (demoting or deactivating)
+        and not _other_active_admin_exists(db, user)
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail="Cannot remove the last active admin",
+        )
+
+    if payload.role is not None:
+        if payload.role not in VALID_ROLES:
+            raise HTTPException(status_code=400, detail="Invalid role")
+        user.role = payload.role
+    if payload.display_name is not None:
+        user.display_name = payload.display_name.strip()
+    if payload.is_active is not None:
+        user.is_active = payload.is_active
+    if payload.password:
+        if len(payload.password) < MIN_PASSWORD_LEN:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Password must be at least {MIN_PASSWORD_LEN} characters",
+            )
+        user.password_hash = hash_password(payload.password)
+    db.commit()
+    return _user_out(user)

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -13,5 +13,9 @@ class AuditLogResponse(BaseModel):
     changed_fields: Optional[list] = None
     timestamp: Optional[datetime] = None
     source: Optional[str] = None
+    # Server Edition: who made the change. Response models STRIP undeclared
+    # fields silently — this line missing was a field-debugged display bug
+    # (the DB had the value all along; the API filtered it out).
+    username: Optional[str] = None
 
     model_config = {"from_attributes": True}

--- a/app/services/audit.py
+++ b/app/services/audit.py
@@ -12,12 +12,24 @@ from app.models.audit import AuditLog
 from app.services.request_context import acting_username
 
 
+import os as _os
+
+
 def _actor(session) -> str | None:
     """Who is acting: the Session's own info dict (stamped by get_db —
     travels with the object, immune to task/context propagation quirks),
     falling back to the request contextvar for sessions created outside
     the request cycle."""
-    return session.info.get("acting_username") or acting_username.get()
+    info_val = session.info.get("acting_username")
+    ctx_val = acting_username.get()
+    if _os.environ.get("SLOWBOOKS_ATTRIBUTION_DEBUG", "1") != "0":
+        # TEMPORARY field diagnostic (server-edition): stdout reaches
+        # launcher.log on the frozen build. Remove before merging to main.
+        print(
+            f"[attribution] info={info_val!r} ctx={ctx_val!r}",
+            flush=True,
+        )
+    return info_val or ctx_val
 
 
 # Tables to skip auditing.

--- a/app/services/audit.py
+++ b/app/services/audit.py
@@ -9,6 +9,7 @@ from sqlalchemy import event, inspect
 from sqlalchemy.orm import Session
 
 from app.models.audit import AuditLog
+from app.services.request_context import acting_username
 
 # Tables to skip auditing.
 # audit_log itself must be skipped to prevent infinite recursion (the
@@ -24,6 +25,10 @@ _SKIP_TABLES = {
     "document_audits",  # hash-chain document audit
     "email_log",  # outbound email send log
 }
+
+# Column values that must never be snapshotted into audit JSON — the users
+# table is audited (who created/changed accounts matters), its hashes are not.
+_REDACT_COLUMNS = {"password_hash"}
 
 
 def _serialize_value(val):
@@ -55,6 +60,9 @@ def _get_instance_dict(instance):
     result = {}
     for col in mapper.columns:
         key = col.key
+        if key in _REDACT_COLUMNS:
+            result[key] = "***"
+            continue
         val = getattr(instance, key, None)
         result[key] = _serialize_value(val)
     return result
@@ -79,6 +87,7 @@ def log_event(
         new_values=new_values,
         changed_fields=changed_fields,
         source=source,
+        username=acting_username.get(),
     )
     db.add(entry)
 
@@ -105,6 +114,7 @@ def _after_flush(session, flush_context):
                 new_values=new_vals,
                 changed_fields=list(new_vals.keys()),
                 source="api",
+                username=acting_username.get(),
             )
         )
 
@@ -143,6 +153,7 @@ def _after_flush(session, flush_context):
                     new_values=new_vals,
                     changed_fields=changed,
                     source="api",
+                    username=acting_username.get(),
                 )
             )
 
@@ -164,6 +175,7 @@ def _after_flush(session, flush_context):
                 new_values=None,
                 changed_fields=None,
                 source="api",
+                username=acting_username.get(),
             )
         )
 

--- a/app/services/audit.py
+++ b/app/services/audit.py
@@ -11,6 +11,15 @@ from sqlalchemy.orm import Session
 from app.models.audit import AuditLog
 from app.services.request_context import acting_username
 
+
+def _actor(session) -> str | None:
+    """Who is acting: the Session's own info dict (stamped by get_db —
+    travels with the object, immune to task/context propagation quirks),
+    falling back to the request contextvar for sessions created outside
+    the request cycle."""
+    return session.info.get("acting_username") or acting_username.get()
+
+
 # Tables to skip auditing.
 # audit_log itself must be skipped to prevent infinite recursion (the
 # audit entries we're about to write would themselves trigger writes).
@@ -87,7 +96,7 @@ def log_event(
         new_values=new_values,
         changed_fields=changed_fields,
         source=source,
-        username=acting_username.get(),
+        username=_actor(db),
     )
     db.add(entry)
 
@@ -114,7 +123,7 @@ def _after_flush(session, flush_context):
                 new_values=new_vals,
                 changed_fields=list(new_vals.keys()),
                 source="api",
-                username=acting_username.get(),
+                username=_actor(session),
             )
         )
 
@@ -153,7 +162,7 @@ def _after_flush(session, flush_context):
                     new_values=new_vals,
                     changed_fields=changed,
                     source="api",
-                    username=acting_username.get(),
+                    username=_actor(session),
                 )
             )
 
@@ -175,7 +184,7 @@ def _after_flush(session, flush_context):
                 new_values=None,
                 changed_fields=None,
                 source="api",
-                username=acting_username.get(),
+                username=_actor(session),
             )
         )
 

--- a/app/services/audit.py
+++ b/app/services/audit.py
@@ -12,24 +12,12 @@ from app.models.audit import AuditLog
 from app.services.request_context import acting_username
 
 
-import os as _os
-
-
 def _actor(session) -> str | None:
     """Who is acting: the Session's own info dict (stamped by get_db —
     travels with the object, immune to task/context propagation quirks),
     falling back to the request contextvar for sessions created outside
     the request cycle."""
-    info_val = session.info.get("acting_username")
-    ctx_val = acting_username.get()
-    if _os.environ.get("SLOWBOOKS_ATTRIBUTION_DEBUG", "1") != "0":
-        # TEMPORARY field diagnostic (server-edition): stdout reaches
-        # launcher.log on the frozen build. Remove before merging to main.
-        print(
-            f"[attribution] info={info_val!r} ctx={ctx_val!r}",
-            flush=True,
-        )
-    return info_val or ctx_val
+    return session.info.get("acting_username") or acting_username.get()
 
 
 # Tables to skip auditing.

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -1,9 +1,13 @@
 # ============================================================================
-# Slowbooks Pro 2026 — Single-user authentication (Phase 9.7)
+# Slowbooks Pro 2026 — Authentication
 #
-# Threat model: LAN deployment, one operator. No user model, no RBAC —
-# just "did you type the one password". Password hashed with argon2id,
-# session issued via Starlette SessionMiddleware (signed cookie).
+# Passwords hashed with argon2id, sessions via Starlette SessionMiddleware
+# (signed cookie). Two shapes, one code path:
+#   - Single-operator (desktop default): one password, no username asked.
+#     Backed by the settings-table hash AND a single admin user row.
+#   - Server Edition multi-user: the users table is the principal model;
+#     username+password once a second user exists. RBAC enforcement is
+#     layered separately.
 # ============================================================================
 
 import logging
@@ -124,7 +128,20 @@ def set_password(db: Session, plain: str) -> None:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Password must be at least {MIN_PASSWORD_LEN} characters",
         )
-    set_setting(db, AUTH_PASSWORD_KEY, hash_password(plain))
+    new_hash = hash_password(plain)
+    set_setting(db, AUTH_PASSWORD_KEY, new_hash)
+    # Keep the (single) admin user row in lockstep — on single-operator
+    # installs the settings hash and the admin row are the same password.
+    from app.models.users import ROLE_ADMIN, User
+
+    admin = (
+        db.query(User)
+        .filter(User.role == ROLE_ADMIN, User.is_active)
+        .order_by(User.id)
+        .first()
+    )
+    if admin is not None and db.query(User).count() == 1:
+        admin.password_hash = new_hash
     db.commit()
 
 
@@ -134,6 +151,93 @@ def check_password(db: Session, plain: str) -> bool:
     if not stored:
         return False
     return verify_password(plain, stored)
+
+
+# ---------------------------------------------------------------------------
+# Principals (Server Edition groundwork)
+#
+# The users table is the source of truth for who can sign in. Legacy
+# installs (settings-table hash, no user rows) are backfilled with an
+# "admin" row the first time the login path runs — after which the
+# settings hash is kept in sync but the user row wins.
+# ---------------------------------------------------------------------------
+
+DEFAULT_ADMIN_USERNAME = "admin"
+
+
+def _users_query(db: Session):
+    from app.models.users import User
+
+    return db.query(User)
+
+
+def count_active_users(db: Session) -> int:
+    from app.models.users import User
+
+    return _users_query(db).filter(User.is_active).count()
+
+
+def is_multi_user(db: Session) -> bool:
+    return count_active_users(db) > 1
+
+
+def ensure_admin_user(db: Session):
+    """Backfill the implicit operator as a real admin user row.
+
+    No-op when any user exists. Uses the settings-table hash verbatim
+    (argon2 hashes are portable strings), so the operator's password
+    keeps working with zero interaction on upgrade.
+    """
+    from app.models.users import ROLE_ADMIN, User
+
+    existing = _users_query(db).first()
+    if existing is not None:
+        return existing
+    stored = get_setting_raw(db, AUTH_PASSWORD_KEY) or ""
+    if not stored.strip():
+        return None
+    admin = User(
+        username=DEFAULT_ADMIN_USERNAME,
+        display_name=(get_setting_raw(db, "operator_name") or "").strip() or "Operator",
+        password_hash=stored,
+        role=ROLE_ADMIN,
+        is_active=True,
+    )
+    db.add(admin)
+    db.commit()
+    logger.info("Backfilled operator as admin user")
+    return admin
+
+
+def authenticate(db: Session, password: str, username: str | None = None):
+    """Resolve credentials to a User, or None.
+
+    Single-user installs authenticate by password alone (username, if
+    sent, is ignored) — identical UX to the legacy flow. With more than
+    one active user, the username is required and selects the account.
+    """
+    from datetime import datetime, timezone
+
+    from app.models.users import User
+
+    ensure_admin_user(db)
+
+    if is_multi_user(db):
+        if not (username or "").strip():
+            return None
+        user = (
+            _users_query(db)
+            .filter(User.username == username.strip().lower(), User.is_active)
+            .first()
+        )
+    else:
+        user = _users_query(db).filter(User.is_active).first()
+
+    if user is None or not verify_password(password, user.password_hash):
+        return None
+    user.last_login_at = datetime.now(timezone.utc)
+    db.commit()
+    return user
 
 
 def require_auth(request: Request) -> None:

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -235,6 +235,10 @@ def authenticate(db: Session, password: str, username: str | None = None):
 
     if user is None or not verify_password(password, user.password_hash):
         return None
+    # Self-attribute the login's own audit row (field finding: the session
+    # carries no username yet at this point, so without this stamp every
+    # login writes the most visible unattributed row on the audit page).
+    db.info["acting_username"] = user.username
     user.last_login_at = datetime.now(timezone.utc)
     db.commit()
     return user

--- a/app/services/request_context.py
+++ b/app/services/request_context.py
@@ -1,0 +1,14 @@
+# ============================================================================
+# Per-request context — who is acting.
+#
+# Set by the session middleware, read by the audit hooks (which live at
+# the SQLAlchemy layer and have no access to the request). A contextvar
+# survives async task switches, so concurrent Server Edition requests
+# can't bleed identities into each other's audit rows.
+# ============================================================================
+
+import contextvars
+
+acting_username: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "acting_username", default=None
+)

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -685,6 +685,23 @@ const App = {
                 document.querySelectorAll('.sidebar-edition, .splash-subtitle')
                     .forEach(el => { el.textContent = 'Server Edition'; });
             }
+
+            // Multi-user: always-visible identity chip in the topbar.
+            const auth = await fetch('/api/auth/status', { credentials: 'same-origin' });
+            if (auth.ok) {
+                const a = await auth.json();
+                if (a.multi_user && a.user) {
+                    const right = document.querySelector('.topbar-right');
+                    if (right && !document.getElementById('user-chip')) {
+                        const chip = document.createElement('span');
+                        chip.id = 'user-chip';
+                        chip.className = 'topbar-clock';
+                        chip.textContent =
+                            `${a.user.display_name || a.user.username} · ${a.user.role}`;
+                        right.prepend(chip);
+                    }
+                }
+            }
             if (!info.desktop) return;
 
             res = await fetch('/api/system/update-check', { credentials: 'same-origin' });

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -676,7 +676,14 @@ const App = {
             const info = await res.json();
             const versionEl = $('#app-version');
             if (versionEl && info.version) {
-                versionEl.textContent = `v${info.version}`;
+                versionEl.textContent = info.server_mode
+                    ? `v${info.version} · Server`
+                    : `v${info.version}`;
+            }
+            if (info.server_mode) {
+                // Serving the LAN: the deployment announces itself.
+                document.querySelectorAll('.sidebar-edition, .splash-subtitle')
+                    .forEach(el => { el.textContent = 'Server Edition'; });
             }
             if (!info.desktop) return;
 

--- a/app/static/js/audit.js
+++ b/app/static/js/audit.js
@@ -57,7 +57,7 @@ const AuditPage = {
 
         let html = `<div class="table-container"><table>
             <thead><tr>
-                <th>Time</th><th>Table</th><th>ID</th><th>Action</th><th>Changes</th>
+                <th>Time</th><th>User</th><th>Table</th><th>ID</th><th>Action</th><th>Changes</th>
             </tr></thead><tbody>`;
 
         for (const log of logs) {
@@ -81,6 +81,7 @@ const AuditPage = {
 
             html += `<tr>
                 <td style="white-space:nowrap;font-size:10px;">${ts}</td>
+                <td style="font-size:10px;">${escapeHtml(log.username || '—')}</td>
                 <td><strong>${escapeHtml(log.table_name)}</strong></td>
                 <td style="font-family:var(--font-mono);">${log.record_id}</td>
                 <td><span class="badge ${actionClass}">${log.action}</span></td>

--- a/app/static/js/audit.js
+++ b/app/static/js/audit.js
@@ -63,7 +63,12 @@ const AuditPage = {
         for (const log of logs) {
             const actionClass = log.action === 'INSERT' ? 'badge-paid' :
                                 log.action === 'DELETE' ? 'badge-void' : 'badge-sent';
-            const ts = log.timestamp ? new Date(log.timestamp).toLocaleString() : '';
+            // Timestamps arrive as naive UTC; without an explicit Z the Date
+            // parser assumes LOCAL time and the page renders hours off
+            // (field-reported: 23:45 UTC showed as 11:45 PM on the wall clock).
+            const iso = log.timestamp && !/Z|[+-]\d\d:?\d\d$/.test(log.timestamp)
+                ? log.timestamp + 'Z' : log.timestamp;
+            const ts = iso ? new Date(iso).toLocaleString() : '';
             let changes = '';
             if (log.action === 'UPDATE' && log.changed_fields) {
                 changes = log.changed_fields.map(f => {

--- a/app/static/js/auth.js
+++ b/app/static/js/auth.js
@@ -168,6 +168,11 @@
 
     // ----- login view ------------------------------------------------------
 
+    // Server Edition: set from /api/auth/status — when more than one user
+    // exists, the login form gains a username field. Single-user installs
+    // never see it.
+    let multiUser = false;
+
     function loginViewHTML() {
         return (
             '<form id="auth-form" ' +
@@ -176,8 +181,16 @@
             'box-shadow:0 20px 60px rgba(0,0,0,0.4);">' +
             '<h2 style="margin:0 0 6px;font-size:20px;">Unlock Slowbooks</h2>' +
             '<p style="margin:0 0 20px;color:#555;font-size:13px;line-height:1.5;">' +
-            "Enter your password to continue." +
+            (multiUser
+                ? "Sign in to continue."
+                : "Enter your password to continue.") +
             "</p>" +
+            (multiUser
+                ? field("auth-username", "Username", {
+                      required: true,
+                      autocomplete: "username",
+                  }) + '<div style="height:10px"></div>'
+                : "") +
             field("auth-password", "Password", {
                 type: "password",
                 required: true,
@@ -202,11 +215,12 @@
     function wireLogin(overlay, onSuccess) {
         const form = overlay.querySelector("#auth-form");
         const input = overlay.querySelector("#auth-password");
+        const userInput = overlay.querySelector("#auth-username");
         const errBox = overlay.querySelector("#auth-error");
         const btn = overlay.querySelector("#auth-submit");
         const switchBtn = overlay.querySelector("#auth-switch-setup");
 
-        input.focus();
+        (userInput || input).focus();
 
         switchBtn.addEventListener("click", function () {
             renderView("setup", onSuccess);
@@ -218,7 +232,9 @@
             btn.disabled = true;
             btn.textContent = "...";
             try {
-                await postJSON(AUTH_LOGIN_URL, { password: input.value });
+                const body = { password: input.value };
+                if (userInput) body.username = userInput.value.trim();
+                await postJSON(AUTH_LOGIN_URL, body);
                 removeOverlay();
                 if (onSuccess) onSuccess();
                 else window.location.reload();
@@ -403,6 +419,7 @@
         authPromptInFlight = true;
         try {
             const status = await checkStatus();
+            multiUser = status.multi_user === true;
             if (status.authenticated) return;
             renderView("login", onSuccess);
         } finally {

--- a/app/static/js/customers.js
+++ b/app/static/js/customers.js
@@ -348,3 +348,7 @@ const CustomersPage = {
         CustomersPage._pendingForm = null;
     },
 };
+
+// Top-level const creates no window property — the topbar's
+// data-action dispatch (bootstrap.js callByPath) needs this export.
+window.CustomersPage = CustomersPage;

--- a/app/static/js/invoices.js
+++ b/app/static/js/invoices.js
@@ -467,3 +467,7 @@ const InvoicesPage = {
         } catch (err) { toast(err.message, 'error'); }
     },
 };
+
+// Top-level const creates no window property — the topbar's
+// data-action dispatch (bootstrap.js callByPath) needs this export.
+window.InvoicesPage = InvoicesPage;

--- a/app/static/js/payments.js
+++ b/app/static/js/payments.js
@@ -248,3 +248,7 @@ const PaymentsPage = {
         } catch (err) { toast(err.message, 'error'); }
     },
 };
+
+// Top-level const creates no window property — the topbar's
+// data-action dispatch (bootstrap.js callByPath) needs this export.
+window.PaymentsPage = PaymentsPage;

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -11,6 +11,7 @@ const SettingsPage = {
             SettingsPage.loadEmailTemplates();
             SettingsPage.loadAiConfig();
             SettingsPage.loadClasses();
+            SettingsPage.loadUsers();
             SettingsPage.scrollToFocus();
         }, 0);
         return `
@@ -281,10 +282,106 @@ const SettingsPage = {
                     <div id="backup-list"></div>
                 </div>
 
+                <div class="settings-section" id="settings-users" style="display:none;">
+                    <h3>Users &mdash; Server Edition</h3>
+                    <p style="font-size:12px; color:var(--text-muted); margin-bottom:10px;">
+                        Add a second user and this deployment becomes
+                        <strong>Server Edition</strong>: everyone signs in with a
+                        username, every change is attributed in the audit log, and
+                        roles limit what each person can do.
+                    </p>
+                    <div id="users-list" style="margin-bottom:12px;"></div>
+                    <div class="form-grid" style="align-items:end;">
+                        <div class="form-group"><label>Username</label>
+                            <input id="user-new-username" autocomplete="off"></div>
+                        <div class="form-group"><label>Display name</label>
+                            <input id="user-new-display" autocomplete="off"></div>
+                        <div class="form-group"><label>Password</label>
+                            <input id="user-new-password" type="password" autocomplete="new-password"></div>
+                        <div class="form-group"><label>Role</label>
+                            <select id="user-new-role">
+                                <option value="bookkeeper">Bookkeeper — daily books, no admin</option>
+                                <option value="readonly">Read-only — reports and lookups</option>
+                                <option value="admin">Admin — everything</option>
+                            </select></div>
+                    </div>
+                    <button type="button" class="btn btn-primary" onclick="SettingsPage.createUser()">Add User</button>
+                </div>
+
                 <div class="form-actions">
                     <button type="submit" class="btn btn-primary">Save Settings</button>
                 </div>
             </form>`;
+    },
+
+    // ------------------------------------------------------------------
+    // Users (Server Edition) — section is visible to admins only; the
+    // backend enforces the same rule, this just avoids a useless 403.
+    // ------------------------------------------------------------------
+    async loadUsers() {
+        const section = $('#settings-users');
+        if (!section) return;
+        try {
+            const status = await API.get('/auth/status');
+            if (!status.user || status.user.role !== 'admin') return;
+            const users = await API.get('/users');
+            section.style.display = '';
+            const rows = users.map(u => `<tr>
+                <td>${escapeHtml(u.username)}</td>
+                <td>${escapeHtml(u.display_name)}</td>
+                <td>
+                    <select onchange="SettingsPage.updateUser(${u.id}, {role: this.value})">
+                        ${['admin', 'bookkeeper', 'readonly'].map(r =>
+                            `<option value="${r}" ${u.role === r ? 'selected' : ''}>${r}</option>`).join('')}
+                    </select>
+                </td>
+                <td>${u.last_login_at ? formatDate(u.last_login_at) : '—'}</td>
+                <td>${u.is_active
+                    ? `<button type="button" class="btn btn-sm btn-secondary" onclick="SettingsPage.updateUser(${u.id}, {is_active: false})">Deactivate</button>`
+                    : `<button type="button" class="btn btn-sm btn-secondary" onclick="SettingsPage.updateUser(${u.id}, {is_active: true})">Reactivate</button>`}
+                    <button type="button" class="btn btn-sm btn-secondary" onclick="SettingsPage.resetUserPassword(${u.id}, '${escapeHtml(u.username)}')">Reset password</button>
+                </td>
+            </tr>`).join('');
+            $('#users-list').innerHTML = `<div class="table-container"><table>
+                <thead><tr><th>Username</th><th>Name</th><th>Role</th><th>Last login</th><th></th></tr></thead>
+                <tbody>${rows}</tbody></table></div>`;
+        } catch (e) { /* non-admin or pre-upgrade server: section stays hidden */ }
+    },
+
+    async createUser() {
+        try {
+            await API.post('/users', {
+                username: $('#user-new-username').value.trim(),
+                display_name: $('#user-new-display').value.trim(),
+                password: $('#user-new-password').value,
+                role: $('#user-new-role').value,
+            });
+            toast('User added — this deployment is now Server Edition');
+            $('#user-new-username').value = '';
+            $('#user-new-display').value = '';
+            $('#user-new-password').value = '';
+            SettingsPage.loadUsers();
+        } catch (err) { toast(err.message, 'error'); }
+    },
+
+    async updateUser(id, patch) {
+        try {
+            await API.put(`/users/${id}`, patch);
+            toast('User updated');
+            SettingsPage.loadUsers();
+        } catch (err) {
+            toast(err.message, 'error');
+            SettingsPage.loadUsers(); // revert any optimistic select change
+        }
+    },
+
+    async resetUserPassword(id, username) {
+        const pw = prompt(`New password for ${username} (min 8 characters):`);
+        if (!pw) return;
+        try {
+            await API.put(`/users/${id}`, { password: pw });
+            toast('Password updated');
+        } catch (err) { toast(err.message, 'error'); }
     },
 
     async save(e) {

--- a/desktop_launcher.py
+++ b/desktop_launcher.py
@@ -18,6 +18,9 @@ anywhere Python does). What it does, in order:
 To switch companies: close the window and relaunch — the picker appears
 again. Flags:
   --no-window   start the server and print the URL (no native window)
+  --serve-lan   Server Edition mode: serve the LAN, no window (binds
+                0.0.0.0, or --bind IP for one interface). Plain HTTP —
+                trusted networks only for now.
   --setup-only  prepare .env and data directories, then exit
   --smoke-test  CI self-test: create a company, boot the server, render a
                 PDF, exit 0/1
@@ -224,14 +227,17 @@ def prepare_env() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _server_env(db_url: str, port: int) -> dict:
+def _server_env(db_url: str, port: int, bind_host: str = "127.0.0.1") -> dict:
     env = dict(os.environ)
     env.update(
         {
             "DATABASE_URL": db_url,
             "APP_DEBUG": "true",
             "FORCE_HTTPS": "false",
-            "APP_HOST": "127.0.0.1",
+            "APP_HOST": bind_host,
+            # Server Edition groundwork: anything beyond loopback flips the
+            # flag the frontend uses to show the SERVER EDITION header.
+            "SLOWBOOKS_SERVER_MODE": "0" if bind_host == "127.0.0.1" else "1",
             "APP_PORT": str(port),
             "SLOWBOOKS_DATA_DIR": str(get_data_dir()),
             # Where app/config.py loads .env from (the install dir is
@@ -282,7 +288,9 @@ def migrate(db_url: str, output=None) -> None:
     )
 
 
-def start_server(db_url: str, port: int, output=None) -> subprocess.Popen:
+def start_server(
+    db_url: str, port: int, output=None, bind_host: str = "127.0.0.1"
+) -> subprocess.Popen:
     if FROZEN:
         # Re-exec this same bundled exe; --_serve (handled at the top of
         # main()) turns the child into the uvicorn server. cwd must be
@@ -297,7 +305,7 @@ def start_server(db_url: str, port: int, output=None) -> subprocess.Popen:
             "uvicorn",
             "app.main:app",
             "--host",
-            "127.0.0.1",
+            bind_host,
             "--port",
             str(port),
             # cmd.exe consoles don't render ANSI colors by default; without
@@ -308,14 +316,19 @@ def start_server(db_url: str, port: int, output=None) -> subprocess.Popen:
     return subprocess.Popen(
         cmd,
         cwd=cwd,
-        env=_server_env(db_url, port),
+        env=_server_env(db_url, port, bind_host),
         stdout=output,
         stderr=subprocess.STDOUT if output else None,
     )
 
 
-def wait_for_health(proc: subprocess.Popen, port: int, timeout: float = 120) -> bool:
-    url = f"http://127.0.0.1:{port}/health"
+def wait_for_health(
+    proc: subprocess.Popen,
+    port: int,
+    timeout: float = 120,
+    host: str = "127.0.0.1",
+) -> bool:
+    url = f"http://{host}:{port}/health"
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if proc.poll() is not None:
@@ -350,7 +363,9 @@ def _server_already_running(port: int) -> bool:
         return False
 
 
-def launch_company(filename: str, port: int, output=None) -> subprocess.Popen:
+def launch_company(
+    filename: str, port: int, output=None, bind_host: str = "127.0.0.1"
+) -> subprocess.Popen:
     """Point the app at a company file, migrate it, and start the server."""
     from app.services import company_service
 
@@ -373,8 +388,10 @@ def launch_company(filename: str, port: int, output=None) -> subprocess.Popen:
 
     migrate(db_url, output=output)
 
-    proc = start_server(db_url, port, output=output)
-    if not wait_for_health(proc, port):
+    proc = start_server(db_url, port, output=output, bind_host=bind_host)
+    # 0.0.0.0 includes loopback; a specific interface bind does not.
+    health_host = "127.0.0.1" if bind_host in ("127.0.0.1", "0.0.0.0") else bind_host
+    if not wait_for_health(proc, port, host=health_host):
         stop_server(proc)
         raise RuntimeError(
             f"Server did not become healthy on port {port}. "
@@ -804,7 +821,35 @@ def run_window(port: int, log_fh=None) -> int:
 # ---------------------------------------------------------------------------
 
 
-def run_headless(port: int) -> int:
+def _lan_addresses() -> list[str]:
+    """Best-effort list of this machine's reachable names/IPs for the
+    'your team connects at ...' banner. Never raises."""
+    import socket
+
+    seen: list[str] = []
+    try:
+        hostname = socket.gethostname()
+        if hostname:
+            seen.append(hostname)
+    except OSError:
+        pass
+    try:
+        # UDP "connect" to a public address picks the primary interface
+        # without sending a packet.
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(("8.8.8.8", 80))
+            ip = s.getsockname()[0]
+            if ip and ip not in seen:
+                seen.append(ip)
+        finally:
+            s.close()
+    except OSError:
+        pass
+    return seen
+
+
+def run_headless(port: int, bind_host: str = "127.0.0.1") -> int:
     from app.services import company_service
 
     filename = company_service.get_last_opened()
@@ -822,12 +867,22 @@ def run_headless(port: int) -> int:
 
     print(f"Opening company file: {filename}")
     try:
-        proc = launch_company(filename, port)
+        proc = launch_company(filename, port, bind_host=bind_host)
     except (ValueError, RuntimeError, subprocess.CalledProcessError) as exc:
         print(f"ERROR: {exc}")
         return 1
 
-    print(f"SlowBooks Pro is running at http://127.0.0.1:{port}")
+    if bind_host == "127.0.0.1":
+        print(f"SlowBooks Pro is running at http://127.0.0.1:{port}")
+    else:
+        print("SlowBooks Pro — SERVER EDITION mode (LAN serving)")
+        print(f"Listening on {bind_host}:{port}. Your team connects at:")
+        for addr in _lan_addresses():
+            print(f"    http://{addr}:{port}")
+        print(
+            "NOTE: traffic is plain HTTP — use this only on a network you "
+            "trust, and make sure Windows Firewall allows the port."
+        )
     print("Press Ctrl+C to stop.")
     try:
         proc.wait()
@@ -857,7 +912,8 @@ def _serve() -> int:
         raise
 
     port = int(os.environ.get("APP_PORT", "3001"))
-    uvicorn.run(app.main.app, host="127.0.0.1", port=port, use_colors=False)
+    host = os.environ.get("APP_HOST", "127.0.0.1")
+    uvicorn.run(app.main.app, host=host, port=port, use_colors=False)
     return 0
 
 
@@ -951,6 +1007,18 @@ def main() -> int:
         ),
     )
     parser.add_argument("--port", type=int, default=None)
+    parser.add_argument(
+        "--serve-lan",
+        action="store_true",
+        help="Server Edition mode: serve to the local network (no window). "
+        "Binds 0.0.0.0 unless --bind is given.",
+    )
+    parser.add_argument(
+        "--bind",
+        default=None,
+        metavar="IP",
+        help="with --serve-lan: bind a specific interface instead of all",
+    )
     args = parser.parse_args()
 
     # A frozen console=False exe has no console at all — always behave as
@@ -1012,6 +1080,8 @@ def main() -> int:
 
         port = args.port or int(get_env_value("APP_PORT") or "3001")
 
+        if args.serve_lan:
+            return run_headless(port, bind_host=args.bind or "0.0.0.0")
         if args.no_window:
             return run_headless(port)
         return run_window(port, log_fh)

--- a/desktop_launcher.py
+++ b/desktop_launcher.py
@@ -735,6 +735,52 @@ def _show_error_box(message: str) -> None:
         pass
 
 
+def _compose_serve_banner(port: int, addresses: list[str]) -> str:
+    """The 'your team connects at ...' text — shared by the console print,
+    the connect-urls.txt drop, and the frozen build's popup."""
+    lines = ["SlowBooks Pro — SERVER EDITION mode is running.", ""]
+    lines.append("Your team connects at:")
+    for addr in addresses or ["<this machine's IP>"]:
+        lines.append(f"    http://{addr}:{port}")
+    lines += [
+        "",
+        "Traffic is plain HTTP — trusted networks only.",
+        "This server stops when this process is closed.",
+    ]
+    return "\n".join(lines)
+
+
+def _announce_serve_lan(port: int) -> None:
+    """Make the connect URLs impossible to miss.
+
+    The frozen exe has no console (field report: 'I ran the command and
+    nothing happened'), so print alone is useless there. Always write
+    connect-urls.txt next to the data, and on frozen Windows also raise a
+    non-blocking popup from a daemon thread (the server keeps serving
+    behind it)."""
+    banner = _compose_serve_banner(port, _lan_addresses())
+    print(banner)
+    try:
+        (get_data_dir() / "connect-urls.txt").write_text(banner, encoding="utf-8")
+    except OSError:
+        pass
+    if FROZEN and sys.platform == "win32":
+        import threading
+
+        def _popup():
+            try:
+                import ctypes
+
+                MB_ICONINFORMATION = 0x40
+                ctypes.windll.user32.MessageBoxW(
+                    0, banner, "SlowBooks Pro — Server Edition", MB_ICONINFORMATION
+                )
+            except Exception:
+                pass
+
+        threading.Thread(target=_popup, daemon=True).start()
+
+
 def run_window(port: int, log_fh=None) -> int:
     try:
         import webview
@@ -875,14 +921,7 @@ def run_headless(port: int, bind_host: str = "127.0.0.1") -> int:
     if bind_host == "127.0.0.1":
         print(f"SlowBooks Pro is running at http://127.0.0.1:{port}")
     else:
-        print("SlowBooks Pro — SERVER EDITION mode (LAN serving)")
-        print(f"Listening on {bind_host}:{port}. Your team connects at:")
-        for addr in _lan_addresses():
-            print(f"    http://{addr}:{port}")
-        print(
-            "NOTE: traffic is plain HTTP — use this only on a network you "
-            "trust, and make sure Windows Firewall allows the port."
-        )
+        _announce_serve_lan(port)
     print("Press Ctrl+C to stop.")
     try:
         proc.wait()
@@ -1019,7 +1058,17 @@ def main() -> int:
         metavar="IP",
         help="with --serve-lan: bind a specific interface instead of all",
     )
+    parser.add_argument(
+        "--data-dir",
+        default=None,
+        metavar="PATH",
+        help="override the data directory (sets SLOWBOOKS_DATA_DIR). Used "
+        "by the Server Edition scheduled task so books live in a "
+        "machine-wide location instead of one user's profile.",
+    )
     args = parser.parse_args()
+    if args.data_dir:
+        os.environ["SLOWBOOKS_DATA_DIR"] = str(Path(args.data_dir).resolve())
 
     # A frozen console=False exe has no console at all — always behave as
     # --hidden there so output lands in launcher.log instead of vanishing.

--- a/docs/server-edition.md
+++ b/docs/server-edition.md
@@ -1,0 +1,85 @@
+# SlowBooks Pro Server Edition — setup guide
+
+One download, two products: the same signed Windows build that runs as a
+single-user desktop app can serve your whole office. Add a second user
+and the deployment *becomes* Server Edition — no separate license, no
+separate download, free either way.
+
+## What you get
+
+- One Windows PC hosts the books; everyone else uses a **browser** —
+  nothing to install on the other computers.
+- **Users and roles**: admin (everything), bookkeeper (daily books, no
+  admin functions), read-only (reports and lookups).
+- Every change in the audit log says **who** made it.
+- The company stays **one file** — backup is copy, undo is restore.
+
+## Quick trial (no install, stops when you close it)
+
+On the machine that will host:
+
+```powershell
+cd <folder containing SlowBooksPro.exe>
+.\SlowBooksPro.exe --serve-lan
+```
+
+A popup shows the connect URLs (also written to `connect-urls.txt` in the
+data folder). Allow the Windows Firewall prompt. From any other computer
+on the network, browse to `http://<host-name>:3001`.
+
+## Permanent install (starts with Windows, no login needed)
+
+From an **elevated** PowerShell in the folder containing the exe:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File _internal\scripts\windows\serveredition-install.ps1
+```
+
+This registers a startup task (runs as SYSTEM before anyone logs in),
+opens the firewall port, moves the data home to
+`C:\ProgramData\SlowBooksPro` (machine-wide, not one user's profile),
+starts the server, and prints your team's connect URLs.
+
+Undo it any time:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File _internal\scripts\windows\serveredition-uninstall.ps1
+```
+
+Your books survive uninstall — the script never deletes data.
+
+## Adding your team
+
+1. Sign in as the admin → **Settings → Users**.
+2. Add each person with a username, password, and role. The moment a
+   second user exists, the login screen gains a username field and the
+   header reads **SERVER EDITION**.
+3. Roles are enforced server-side: a read-only user physically cannot
+   post an entry; a bookkeeper cannot touch Settings, Users, backups, or
+   migrations. The last active admin can never be locked out — the app
+   refuses to demote or deactivate them.
+
+## Honest limits (current release)
+
+- **Plain HTTP** — run this on a network you trust (an office LAN behind
+  your router). TLS support is planned; until then do not port-forward
+  it to the internet.
+- Comfortable for small teams (2–10 people). The database serializes
+  writes; hundreds of concurrent users is not the design target.
+- The update badge appears in-app as usual; updating means running the
+  new installer on the host machine.
+
+## Troubleshooting
+
+- **Downloaded a build artifact from GitHub Actions?** It's a zip inside
+  a zip — extract twice.
+- **"Nothing happened" when running the exe** — the packaged exe has no
+  console; output goes to `launcher.log` in the data folder, and
+  `--serve-lan` shows its URLs in a popup + `connect-urls.txt`.
+- **Double-clicking the exe shows a WebView2 error** — that's the
+  *desktop window* needing the WebView2 runtime (the installer sets it
+  up; the portable zip doesn't). `--serve-lan` doesn't need WebView2 at
+  all — browsers on client machines are all it takes.
+- **Other computers can't connect** — check the firewall rule (the
+  install script creates it; the quick-trial path relies on you clicking
+  Allow), and confirm host and clients are on the same network.

--- a/migrations/versions/b6c7d8e9f0a1_audit_username.py
+++ b/migrations/versions/b6c7d8e9f0a1_audit_username.py
@@ -1,0 +1,27 @@
+"""Server Edition: per-user audit attribution — username column on audit_log
+
+Revision ID: b6c7d8e9f0a1
+Revises: a5b6c7d8e9f0
+Create Date: 2026-08-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "b6c7d8e9f0a1"
+down_revision = "a5b6c7d8e9f0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Batch mode for SQLite compatibility (desktop company files)
+    with op.batch_alter_table("audit_log") as batch_op:
+        batch_op.add_column(sa.Column("username", sa.String(100), nullable=True))
+        batch_op.create_index("ix_audit_log_username", ["username"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("audit_log") as batch_op:
+        batch_op.drop_index("ix_audit_log_username")
+        batch_op.drop_column("username")

--- a/packaging/windows/SlowBooksPro.spec
+++ b/packaging/windows/SlowBooksPro.spec
@@ -42,6 +42,10 @@ datas += _tree("app/templates", "app/templates")
 # Alembic loads migration scripts as FILES at runtime (script_location) —
 # they must exist on disk in the bundle, not just inside the PYZ.
 datas += _tree("migrations", "migrations")
+# Server Edition helper scripts ship in the bundle so an installed or
+# portable copy can register the startup task without downloading anything:
+#   _internal\scripts\windows\serveredition-install.ps1
+datas += _tree("scripts/windows", "scripts/windows")
 
 # The WeasyPrint DLL set staged by CI (empty when building without it, so a
 # local `pyinstaller SlowBooksPro.spec` still produces a testable bundle).

--- a/scripts/windows/serveredition-install.ps1
+++ b/scripts/windows/serveredition-install.ps1
@@ -1,0 +1,61 @@
+# ============================================================================
+# SlowBooks Pro — Server Edition install (Windows)
+#
+# Registers a scheduled task that runs the server at machine startup as
+# SYSTEM (no login required), stores books machine-wide under
+# C:\ProgramData\SlowBooksPro, and opens the firewall port. Run from an
+# elevated PowerShell:
+#
+#   powershell -ExecutionPolicy Bypass -File serveredition-install.ps1
+#
+# Undo everything with serveredition-uninstall.ps1.
+# ============================================================================
+#Requires -RunAsAdministrator
+param(
+    [int]$Port = 3001,
+    [string]$ExePath = "",
+    [string]$DataDir = "$env:ProgramData\SlowBooksPro"
+)
+
+$ErrorActionPreference = "Stop"
+$TaskName = "SlowBooksProServer"
+$RuleName = "SlowBooks Pro Server Edition"
+
+# The script ships inside the bundle at _internal\scripts\windows\ —
+# the exe is three levels up. Explicit -ExePath overrides.
+if (-not $ExePath) {
+    $ExePath = Join-Path $PSScriptRoot "..\..\..\SlowBooksPro.exe"
+}
+$ExePath = (Resolve-Path $ExePath).Path
+if (-not (Test-Path $ExePath)) {
+    throw "SlowBooksPro.exe not found at $ExePath — pass -ExePath"
+}
+
+New-Item -ItemType Directory -Force -Path $DataDir | Out-Null
+
+Write-Host ">> Opening firewall port $Port (rule: $RuleName)"
+netsh advfirewall firewall delete rule name="$RuleName" | Out-Null
+netsh advfirewall firewall add rule name="$RuleName" dir=in action=allow `
+    protocol=TCP localport=$Port | Out-Null
+
+Write-Host ">> Registering startup task $TaskName (runs as SYSTEM, no login needed)"
+$TaskCmd = "`"$ExePath`" --serve-lan --port $Port --data-dir `"$DataDir`""
+schtasks /Create /TN $TaskName /SC ONSTART /RU SYSTEM /RL HIGHEST /F /TR $TaskCmd | Out-Null
+
+Write-Host ">> Starting the server now"
+schtasks /Run /TN $TaskName | Out-Null
+Start-Sleep -Seconds 8
+
+$ips = Get-NetIPAddress -AddressFamily IPv4 |
+    Where-Object { $_.IPAddress -notlike "127.*" -and $_.IPAddress -notlike "169.254.*" } |
+    Select-Object -ExpandProperty IPAddress
+
+Write-Host ""
+Write-Host "SlowBooks Pro Server Edition is installed." -ForegroundColor Green
+Write-Host "Books live in: $DataDir"
+Write-Host "Your team connects at:"
+Write-Host "    http://$($env:COMPUTERNAME):$Port"
+foreach ($ip in $ips) { Write-Host "    http://${ip}:$Port" }
+Write-Host ""
+Write-Host "It starts automatically with Windows (before anyone logs in)."
+Write-Host "Plain HTTP - trusted networks only."

--- a/scripts/windows/serveredition-install.ps1
+++ b/scripts/windows/serveredition-install.ps1
@@ -1,5 +1,5 @@
 # ============================================================================
-# SlowBooks Pro — Server Edition install (Windows)
+# SlowBooks Pro - Server Edition install (Windows)
 #
 # Registers a scheduled task that runs the server at machine startup as
 # SYSTEM (no login required), stores books machine-wide under
@@ -21,14 +21,14 @@ $ErrorActionPreference = "Stop"
 $TaskName = "SlowBooksProServer"
 $RuleName = "SlowBooks Pro Server Edition"
 
-# The script ships inside the bundle at _internal\scripts\windows\ —
+# The script ships inside the bundle at _internal\scripts\windows\ -
 # the exe is three levels up. Explicit -ExePath overrides.
 if (-not $ExePath) {
     $ExePath = Join-Path $PSScriptRoot "..\..\..\SlowBooksPro.exe"
 }
 $ExePath = (Resolve-Path $ExePath).Path
 if (-not (Test-Path $ExePath)) {
-    throw "SlowBooksPro.exe not found at $ExePath — pass -ExePath"
+    throw "SlowBooksPro.exe not found at $ExePath - pass -ExePath"
 }
 
 New-Item -ItemType Directory -Force -Path $DataDir | Out-Null

--- a/scripts/windows/serveredition-uninstall.ps1
+++ b/scripts/windows/serveredition-uninstall.ps1
@@ -1,8 +1,8 @@
 # ============================================================================
-# SlowBooks Pro — Server Edition uninstall (Windows)
+# SlowBooks Pro - Server Edition uninstall (Windows)
 #
 # Removes the startup task and firewall rule. Books under
-# C:\ProgramData\SlowBooksPro are deliberately left in place — delete
+# C:\ProgramData\SlowBooksPro are deliberately left in place - delete
 # that folder yourself if you're sure.
 # ============================================================================
 #Requires -RunAsAdministrator

--- a/scripts/windows/serveredition-uninstall.ps1
+++ b/scripts/windows/serveredition-uninstall.ps1
@@ -1,0 +1,16 @@
+# ============================================================================
+# SlowBooks Pro — Server Edition uninstall (Windows)
+#
+# Removes the startup task and firewall rule. Books under
+# C:\ProgramData\SlowBooksPro are deliberately left in place — delete
+# that folder yourself if you're sure.
+# ============================================================================
+#Requires -RunAsAdministrator
+$ErrorActionPreference = "SilentlyContinue"
+
+schtasks /End /TN "SlowBooksProServer" | Out-Null
+schtasks /Delete /TN "SlowBooksProServer" /F | Out-Null
+netsh advfirewall firewall delete rule name="SlowBooks Pro Server Edition" | Out-Null
+
+Write-Host "Server Edition task + firewall rule removed." -ForegroundColor Green
+Write-Host "Your books are untouched at $env:ProgramData\SlowBooksPro."

--- a/scripts/windows/update-server-edition.ps1
+++ b/scripts/windows/update-server-edition.ps1
@@ -1,0 +1,98 @@
+# ============================================================================
+# SlowBooks Pro - Server Edition in-place updater (Windows)
+#
+# One command to swap the server's program files from a GitHub Actions
+# artifact and restart the scheduled task. Data is never touched.
+#
+#   # with GitHub CLI available (recommended):
+#   powershell -ExecutionPolicy Bypass -File update-server-edition.ps1 -RunId 31651056187
+#
+#   # or with a manually downloaded artifact zip:
+#   powershell -ExecutionPolicy Bypass -File update-server-edition.ps1 -ZipPath "$env:USERPROFILE\Downloads\SlowBooksPro-windows-x64.zip"
+#
+# ASCII only in this file - Windows PowerShell 5.1 parses BOM-less
+# scripts as ANSI and em-dashes break the parser.
+# ============================================================================
+param(
+    [string]$RunId = "",
+    [string]$ZipPath = "",
+    [string]$InstallDir = "C:\SlowBooksServer\SlowBooksPro-windows-x64",
+    [string]$Repo = "VonHoltenCodes/SlowBooks-Pro-2026",
+    [int]$Port = 3001
+)
+
+$ErrorActionPreference = "Stop"
+$stage = Join-Path $env:TEMP ("sb-update-" + [guid]::NewGuid().ToString("N").Substring(0, 8))
+New-Item -ItemType Directory -Path $stage | Out-Null
+
+try {
+    # ---- Acquire the build ------------------------------------------------
+    if ($RunId) {
+        if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+            throw "GitHub CLI (gh) not found - download the artifact manually and use -ZipPath"
+        }
+        Write-Host ">> Downloading artifact from run $RunId"
+        gh run download $RunId -R $Repo -n SlowBooksPro-windows-x64 -D $stage
+        if ($LASTEXITCODE -ne 0) { throw "gh run download failed" }
+    }
+    elseif ($ZipPath) {
+        Write-Host ">> Extracting $ZipPath"
+        Expand-Archive $ZipPath $stage -Force
+    }
+    else {
+        throw "Pass -RunId <actions run id> or -ZipPath <downloaded zip>"
+    }
+
+    # Artifacts arrive as zip-in-zip; keep extracting until an exe appears.
+    foreach ($round in 1..3) {
+        $exe = Get-ChildItem $stage -Recurse -Filter SlowBooksPro.exe -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if ($exe) { break }
+        $inner = Get-ChildItem $stage -Recurse -Filter *.zip | Select-Object -First 1
+        if (-not $inner) { break }
+        Expand-Archive $inner.FullName (Join-Path $stage "x$round") -Force
+    }
+    if (-not $exe) { throw "SlowBooksPro.exe not found in the artifact" }
+
+    $srcDir = Split-Path $exe.FullName
+    if (-not (Test-Path (Join-Path $srcDir "_internal"))) {
+        throw "Extracted layout is wrong: no _internal beside the exe at $srcDir"
+    }
+
+    # ---- Swap -------------------------------------------------------------
+    Write-Host ">> Stopping server"
+    taskkill /IM SlowBooksPro.exe /F 2>$null | Out-Null
+    Start-Sleep -Seconds 2
+
+    Write-Host ">> Swapping program files in $InstallDir"
+    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+    Remove-Item "$InstallDir\*" -Recurse -Force -ErrorAction SilentlyContinue
+    Copy-Item "$srcDir\*" $InstallDir -Recurse
+
+    $check = Get-ChildItem $InstallDir
+    if (-not (Test-Path "$InstallDir\SlowBooksPro.exe") -or -not (Test-Path "$InstallDir\_internal")) {
+        throw "Post-swap layout check failed - expected SlowBooksPro.exe + _internal"
+    }
+
+    Write-Host ">> Restarting server task"
+    schtasks /Run /TN SlowBooksProServer | Out-Null
+
+    # ---- Verify -----------------------------------------------------------
+    Write-Host ">> Waiting for /health"
+    $ok = $false
+    foreach ($i in 1..30) {
+        Start-Sleep -Seconds 2
+        try {
+            $h = Invoke-RestMethod "http://127.0.0.1:$Port/health" -TimeoutSec 3
+            Write-Host ("UPDATED OK - server healthy, version " + $h.version) -ForegroundColor Green
+            $ok = $true
+            break
+        } catch { }
+    }
+    if (-not $ok) {
+        throw "Server did not become healthy within 60s - check C:\ProgramData\SlowBooksPro\launcher.log"
+    }
+}
+finally {
+    Remove-Item $stage -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/windows/update-server-edition.ps1
+++ b/scripts/windows/update-server-edition.ps1
@@ -13,6 +13,7 @@
 # ASCII only in this file - Windows PowerShell 5.1 parses BOM-less
 # scripts as ANSI and em-dashes break the parser.
 # ============================================================================
+#Requires -RunAsAdministrator
 param(
     [string]$RunId = "",
     [string]$ZipPath = "",
@@ -61,7 +62,7 @@ try {
 
     # ---- Swap -------------------------------------------------------------
     Write-Host ">> Stopping server"
-    taskkill /IM SlowBooksPro.exe /F 2>$null | Out-Null
+    Get-Process -Name SlowBooksPro -ErrorAction SilentlyContinue | Stop-Process -Force
     Start-Sleep -Seconds 2
 
     Write-Host ">> Swapping program files in $InstallDir"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import pytest  # noqa: E402
+from starlette.requests import HTTPConnection  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 from sqlalchemy import create_engine  # noqa: E402
 from sqlalchemy.orm import sessionmaker  # noqa: E402
@@ -165,8 +166,14 @@ def seed_customer(db_session):
 def _wire_app(TestSession):
     """Override app's get_db dependency to use the per-test session factory."""
 
-    def override_get_db():
+    def override_get_db(request: HTTPConnection = None):
         session = TestSession()
+        # Mirror production's attribution stamping so tests exercise the
+        # session.info path (the mechanism that works on frozen Windows),
+        # not just the contextvar fallback.
+        http_session = getattr(request, "session", None) if request else None
+        if isinstance(http_session, dict) and http_session.get("authenticated") is True:
+            session.info["acting_username"] = http_session.get("username") or "operator"
         try:
             yield session
         finally:

--- a/tests/test_rbac_users.py
+++ b/tests/test_rbac_users.py
@@ -187,3 +187,19 @@ def test_audit_never_stores_password_hashes(client, db_session):
     assert row.username == "admin"
     assert row.new_values.get("password_hash") == "***"
     assert "argon2" not in str(row.new_values)
+
+
+def test_audit_api_returns_username_field(client, db_session):
+    """Regression: the /api/audit response model must expose `username`.
+
+    The write path was verified against the DB while the response model
+    silently stripped the field — every layer looked healthy except the
+    one users see. Read THROUGH THE API, like the UI does."""
+    _mk_user(db_session, "keeper", "keeper-password-1", ROLE_BOOKKEEPER)
+    _login_as(client, "keeper", "keeper-password-1")
+    client.post("/api/customers", json={"name": "API Visibility Inc"})
+
+    rows = client.get("/api/audit", params={"table_name": "customers"}).json()
+    assert rows, "expected at least one customers audit row"
+    assert "username" in rows[0], "response model is stripping username"
+    assert rows[0]["username"] == "keeper"

--- a/tests/test_rbac_users.py
+++ b/tests/test_rbac_users.py
@@ -203,3 +203,28 @@ def test_audit_api_returns_username_field(client, db_session):
     assert rows, "expected at least one customers audit row"
     assert "username" in rows[0], "response model is stripping username"
     assert rows[0]["username"] == "keeper"
+
+
+def test_login_audit_row_is_self_attributed(client, db_session):
+    """Field finding: every login wrote the most visible unattributed row
+    (last_login_at UPDATE flushes before the session carries a username)."""
+    _mk_user(db_session, "keeper", "keeper-password-1", ROLE_BOOKKEEPER)
+    _login_as(client, "keeper", "keeper-password-1")
+    row = (
+        db_session.query(AuditLog)
+        .filter(AuditLog.table_name == "users", AuditLog.action == "UPDATE")
+        .order_by(AuditLog.id.desc())
+        .first()
+    )
+    assert row is not None
+    assert row.username == "keeper"
+
+
+def test_readonly_cannot_read_audit_payloads(client, db_session):
+    """Field finding: audit snapshots carry full historical PII — readonly
+    means read the books, not read every value any field ever held."""
+    _mk_user(db_session, "viewer", "viewer-password-1", ROLE_READONLY)
+    _login_as(client, "viewer", "viewer-password-1")
+    assert client.get("/api/audit").status_code == 403
+    assert client.get("/api/audit/tables").status_code == 403
+    assert client.get("/api/customers").status_code == 200  # books stay readable

--- a/tests/test_rbac_users.py
+++ b/tests/test_rbac_users.py
@@ -1,0 +1,189 @@
+"""Server Edition RBAC (PR-S3): role policy enforcement, /api/users
+management, last-admin protection, and per-user audit attribution."""
+
+from app.models.audit import AuditLog
+from app.models.users import ROLE_BOOKKEEPER, ROLE_READONLY, User
+from app.services import auth as auth_service
+
+FIXTURE_PW = "test-password-123"
+
+
+def _mk_user(db, username, password, role):
+    u = User(
+        username=username,
+        display_name=username.title(),
+        password_hash=auth_service.hash_password(password),
+        role=role,
+        is_active=True,
+    )
+    db.add(u)
+    db.commit()
+    return u
+
+
+def _login_as(client, username, password):
+    client.post("/api/auth/logout")
+    r = client.post(
+        "/api/auth/login", json={"username": username, "password": password}
+    )
+    assert r.status_code == 200, r.text
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Role policy
+# ---------------------------------------------------------------------------
+
+
+def test_readonly_can_read_but_not_write(client, db_session):
+    _mk_user(db_session, "viewer", "viewer-password-1", ROLE_READONLY)
+    _login_as(client, "viewer", "viewer-password-1")
+
+    assert client.get("/api/customers").status_code == 200
+    assert client.get("/api/reports/profit-loss").status_code == 200
+    r = client.post("/api/customers", json={"name": "Blocked Corp"})
+    assert r.status_code == 403
+
+
+def test_bookkeeper_daily_writes_ok_admin_writes_blocked(client, db_session):
+    _mk_user(db_session, "keeper", "keeper-password-1", ROLE_BOOKKEEPER)
+    _login_as(client, "keeper", "keeper-password-1")
+
+    r = client.post("/api/customers", json={"name": "Daily Books LLC"})
+    assert r.status_code in (200, 201)
+
+    assert client.put("/api/settings", json={"invoice_prefix": "X-"}).status_code == 403
+    assert client.get("/api/settings").status_code == 200  # reads stay open
+    assert (
+        client.post(
+            "/api/users",
+            json={
+                "username": "sneaky",
+                "password": "sneaky-password-1",
+                "role": "admin",
+            },
+        ).status_code
+        == 403
+    )
+    # Reads of the user list are role-gated in-route too
+    assert client.get("/api/users").status_code == 403
+
+
+def test_admin_unrestricted_and_legacy_session_is_admin(client):
+    # The fixture session predates any explicit role handling in older
+    # cookies; ours carries role=admin from setup — both must pass.
+    assert client.put("/api/settings", json={"invoice_prefix": "A-"}).status_code == 200
+    assert client.get("/api/users").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# /api/users management
+# ---------------------------------------------------------------------------
+
+
+def test_create_list_update_user(client):
+    r = client.post(
+        "/api/users",
+        json={
+            "username": "Renita",
+            "display_name": "Renita",
+            "password": "renita-password-1",
+            "role": "bookkeeper",
+        },
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["username"] == "renita"  # normalized lowercase
+    assert "password" not in str(body) or "password_hash" not in body
+
+    users = client.get("/api/users").json()
+    assert [u["username"] for u in users] == ["admin", "renita"]
+
+    r = client.put(f"/api/users/{body['id']}", json={"role": "readonly"})
+    assert r.status_code == 200
+    assert r.json()["role"] == "readonly"
+
+
+def test_user_validation(client):
+    bad = [
+        ({"username": "x", "password": "long-enough-pw", "role": "admin"}, 422),
+        ({"username": "has space", "password": "long-enough-pw", "role": "admin"}, 400),
+        ({"username": "goodname", "password": "short", "role": "admin"}, 400),
+        ({"username": "goodname", "password": "long-enough-pw", "role": "boss"}, 400),
+    ]
+    for payload, expected in bad:
+        r = client.post("/api/users", json=payload)
+        assert r.status_code == expected, (payload, r.status_code)
+
+    client.post(
+        "/api/users",
+        json={"username": "dupe", "password": "long-enough-pw", "role": "readonly"},
+    )
+    r = client.post(
+        "/api/users",
+        json={"username": "DUPE", "password": "long-enough-pw", "role": "readonly"},
+    )
+    assert r.status_code == 409
+
+
+def test_last_admin_protected(client, db_session):
+    admin_id = db_session.query(User).filter(User.username == "admin").one().id
+    assert (
+        client.put(f"/api/users/{admin_id}", json={"role": "readonly"}).status_code
+        == 409
+    )
+    assert (
+        client.put(f"/api/users/{admin_id}", json={"is_active": False}).status_code
+        == 409
+    )
+    # With a second admin present, demotion is allowed
+    client.post(
+        "/api/users",
+        json={"username": "admin2", "password": "admin2-password-1", "role": "admin"},
+    )
+    assert (
+        client.put(f"/api/users/{admin_id}", json={"role": "bookkeeper"}).status_code
+        == 200
+    )
+
+
+# ---------------------------------------------------------------------------
+# Audit attribution
+# ---------------------------------------------------------------------------
+
+
+def test_audit_rows_attributed_to_acting_user(client, db_session):
+    _mk_user(db_session, "keeper", "keeper-password-1", ROLE_BOOKKEEPER)
+    _login_as(client, "keeper", "keeper-password-1")
+    r = client.post("/api/customers", json={"name": "Attributed Inc"})
+    assert r.status_code in (200, 201)
+
+    row = (
+        db_session.query(AuditLog)
+        .filter(AuditLog.table_name == "customers")
+        .order_by(AuditLog.id.desc())
+        .first()
+    )
+    assert row is not None
+    assert row.username == "keeper"
+
+
+def test_audit_never_stores_password_hashes(client, db_session):
+    client.post(
+        "/api/users",
+        json={
+            "username": "hashcheck",
+            "password": "hash-password-11",
+            "role": "readonly",
+        },
+    )
+    row = (
+        db_session.query(AuditLog)
+        .filter(AuditLog.table_name == "users")
+        .order_by(AuditLog.id.desc())
+        .first()
+    )
+    assert row is not None
+    assert row.username == "admin"
+    assert row.new_values.get("password_hash") == "***"
+    assert "argon2" not in str(row.new_values)

--- a/tests/test_server_mode.py
+++ b/tests/test_server_mode.py
@@ -78,3 +78,40 @@ def test_system_info_reports_server_mode(authed_client, monkeypatch):
     monkeypatch.setenv("SLOWBOOKS_SERVER_MODE", "1")
     info = authed_client.get("/api/system").json()
     assert info["server_mode"] is True
+
+
+# ---------------------------------------------------------------------------
+# PR-S4: banner composition + --data-dir override
+# ---------------------------------------------------------------------------
+
+
+def test_serve_banner_lists_all_addresses():
+    text = desktop_launcher._compose_serve_banner(3001, ["OFFICE-PC", "192.168.68.50"])
+    assert "http://OFFICE-PC:3001" in text
+    assert "http://192.168.68.50:3001" in text
+    assert "plain HTTP" in text
+    # No addresses discovered: still renders something actionable
+    fallback = desktop_launcher._compose_serve_banner(3001, [])
+    assert "3001" in fallback
+
+
+def test_data_dir_flag_redirects_everything(tmp_path):
+    import subprocess
+    import sys as _sys
+
+    target = tmp_path / "server-data"
+    r = subprocess.run(
+        [
+            _sys.executable,
+            "desktop_launcher.py",
+            "--setup-only",
+            "--data-dir",
+            str(target),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={**__import__("os").environ, "SLOWBOOKS_DATA_DIR": ""},
+    )
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert (target / "companies").is_dir()

--- a/tests/test_server_mode.py
+++ b/tests/test_server_mode.py
@@ -1,0 +1,80 @@
+"""Server Edition groundwork (PR-S1): LAN bind plumbing, SQLite WAL
+tuning, and the /api/system server_mode flag the UI keys its header off."""
+
+import sqlite3
+
+from sqlalchemy import create_engine, text
+
+import desktop_launcher
+from app.database import enable_sqlite_tuning
+
+# ---------------------------------------------------------------------------
+# SQLite concurrency tuning
+# ---------------------------------------------------------------------------
+
+
+def test_sqlite_tuning_enables_wal(tmp_path):
+    db = tmp_path / "tuned.db"
+    engine = create_engine(f"sqlite:///{db}")
+    enable_sqlite_tuning(engine)
+    with engine.connect() as conn:
+        mode = conn.execute(text("PRAGMA journal_mode")).scalar()
+        busy = conn.execute(text("PRAGMA busy_timeout")).scalar()
+        sync = conn.execute(text("PRAGMA synchronous")).scalar()
+    assert str(mode).lower() == "wal"
+    assert int(busy) == 5000
+    assert int(sync) == 1  # NORMAL
+
+    # WAL is persistent in the file: a plain sqlite3 connection sees it too
+    raw = sqlite3.connect(db)
+    assert raw.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+    raw.close()
+
+
+def test_sqlite_tuning_harmless_on_memory_db():
+    engine = create_engine("sqlite:///:memory:")
+    enable_sqlite_tuning(engine)
+    with engine.connect() as conn:
+        mode = conn.execute(text("PRAGMA journal_mode")).scalar()
+    assert str(mode).lower() == "memory"  # no-op, no error
+
+
+# ---------------------------------------------------------------------------
+# Launcher bind plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_server_env_default_is_loopback():
+    env = desktop_launcher._server_env("sqlite:///x.db", 3001)
+    assert env["APP_HOST"] == "127.0.0.1"
+    assert env["SLOWBOOKS_SERVER_MODE"] == "0"
+
+
+def test_server_env_lan_bind_sets_server_mode():
+    env = desktop_launcher._server_env("sqlite:///x.db", 3001, bind_host="0.0.0.0")
+    assert env["APP_HOST"] == "0.0.0.0"
+    assert env["SLOWBOOKS_SERVER_MODE"] == "1"
+    env = desktop_launcher._server_env(
+        "sqlite:///x.db", 3001, bind_host="192.168.68.50"
+    )
+    assert env["SLOWBOOKS_SERVER_MODE"] == "1"
+
+
+def test_lan_addresses_never_raises():
+    addrs = desktop_launcher._lan_addresses()
+    assert isinstance(addrs, list)
+    assert all(isinstance(a, str) and a for a in addrs)
+
+
+# ---------------------------------------------------------------------------
+# /api/system flag
+# ---------------------------------------------------------------------------
+
+
+def test_system_info_reports_server_mode(authed_client, monkeypatch):
+    info = authed_client.get("/api/system").json()
+    assert info["server_mode"] is False
+
+    monkeypatch.setenv("SLOWBOOKS_SERVER_MODE", "1")
+    info = authed_client.get("/api/system").json()
+    assert info["server_mode"] is True

--- a/tests/test_users_principal.py
+++ b/tests/test_users_principal.py
@@ -1,0 +1,152 @@
+"""Server Edition principal model (PR-S2): users table, legacy backfill,
+single-user password-only login preserved, username login at 2+ users.
+
+The `client` fixture arrives already set up (password "test-password-123")
+and authenticated — which now also means the admin user row exists.
+"""
+
+from app.models.users import ROLE_ADMIN, ROLE_BOOKKEEPER, User
+from app.services import auth as auth_service
+from app.services.settings_service import get_setting_raw
+
+FIXTURE_PW = "test-password-123"
+
+
+def _mk_user(db, username, password, role=ROLE_BOOKKEEPER, active=True, name=""):
+    u = User(
+        username=username,
+        display_name=name or username.title(),
+        password_hash=auth_service.hash_password(password),
+        role=role,
+        is_active=active,
+    )
+    db.add(u)
+    db.commit()
+    return u
+
+
+# ---------------------------------------------------------------------------
+# Setup + backfill
+# ---------------------------------------------------------------------------
+
+
+def test_setup_creates_admin_user_row(client, db_session):
+    users = db_session.query(User).all()
+    assert len(users) == 1
+    assert users[0].username == "admin"
+    assert users[0].role == ROLE_ADMIN
+    assert users[0].is_active
+    # Same hash both places: the user row is the settings hash, verbatim
+    assert users[0].password_hash == get_setting_raw(db_session, "auth_password_hash")
+
+
+def test_legacy_install_backfills_on_first_login(client, db_session):
+    # Simulate a pre-Server-Edition install: settings hash present, user
+    # rows absent (they didn't exist before this feature).
+    db_session.query(User).delete()
+    db_session.commit()
+    client.post("/api/auth/logout")
+
+    r = client.post("/api/auth/login", json={"password": FIXTURE_PW})
+    assert r.status_code == 200
+    admin = db_session.query(User).one()
+    assert admin.username == "admin"
+    assert admin.role == ROLE_ADMIN
+    assert admin.last_login_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Single-user flow: identical UX to today
+# ---------------------------------------------------------------------------
+
+
+def test_single_user_login_ignores_username(client):
+    client.post("/api/auth/logout")
+    # Password-only works; a stray username is harmless
+    r = client.post(
+        "/api/auth/login",
+        json={"password": FIXTURE_PW, "username": "whatever"},
+    )
+    assert r.status_code == 200
+    status = client.get("/api/auth/status").json()
+    assert status["multi_user"] is False
+    assert status["user"]["username"] == "admin"
+    assert status["user"]["role"] == ROLE_ADMIN
+
+
+def test_set_password_keeps_admin_row_in_sync(client, db_session):
+    auth_service.set_password(db_session, "new-password-22")
+    client.post("/api/auth/logout")
+    r = client.post("/api/auth/login", json={"password": "new-password-22"})
+    assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Multi-user flow
+# ---------------------------------------------------------------------------
+
+
+def _add_renita_and_logout(client, db_session):
+    _mk_user(db_session, "renita", "renita-password-1", name="Renita")
+    client.post("/api/auth/logout")
+
+
+def test_multi_user_requires_username(client, db_session):
+    _add_renita_and_logout(client, db_session)
+    status = client.get("/api/auth/status").json()
+    assert status["multi_user"] is True
+
+    r = client.post("/api/auth/login", json={"password": FIXTURE_PW})
+    assert r.status_code == 400  # username now required
+
+    r = client.post(
+        "/api/auth/login", json={"username": "admin", "password": FIXTURE_PW}
+    )
+    assert r.status_code == 200
+    assert client.get("/api/auth/status").json()["user"]["username"] == "admin"
+
+
+def test_multi_user_second_account_and_role_in_session(client, db_session):
+    _add_renita_and_logout(client, db_session)
+    r = client.post(
+        "/api/auth/login",
+        json={"username": "RENITA", "password": "renita-password-1"},
+    )
+    # Case-insensitive username lookup
+    assert r.status_code == 200
+    user = client.get("/api/auth/status").json()["user"]
+    assert user["username"] == "renita"
+    assert user["display_name"] == "Renita"
+    assert user["role"] == ROLE_BOOKKEEPER
+
+
+def test_multi_user_rejects_wrong_password_and_unknown_user(client, db_session):
+    _add_renita_and_logout(client, db_session)
+    r = client.post(
+        "/api/auth/login", json={"username": "renita", "password": "wrong-password"}
+    )
+    assert r.status_code == 401
+    r = client.post(
+        "/api/auth/login", json={"username": "ghost", "password": "renita-password-1"}
+    )
+    assert r.status_code == 401
+    # Error message must not reveal which part was wrong
+    assert "username or password" in r.json()["detail"].lower()
+
+
+def test_inactive_user_cannot_log_in(client, db_session):
+    _add_renita_and_logout(client, db_session)
+    _mk_user(db_session, "gone", "gone-password-11", active=False)
+    r = client.post(
+        "/api/auth/login", json={"username": "gone", "password": "gone-password-11"}
+    )
+    assert r.status_code == 401
+
+
+def test_cross_user_password_rejected(client, db_session):
+    """renita's password must not unlock admin's account."""
+    _add_renita_and_logout(client, db_session)
+    r = client.post(
+        "/api/auth/login", json={"username": "admin", "password": "renita-password-1"}
+    )
+    assert r.status_code == 401

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -263,9 +263,6 @@ def test_collector_finds_something():
 # - One-shot seeds run once during setup, not from the running SPA
 # - Legacy paths superseded by newer endpoints (kept for backwards compat)
 _INTENTIONAL_BACKEND_ONLY: set[tuple[str, str]] = {
-    # TEMPORARY diagnostic for the Server Edition attribution field bug —
-    # remove with the endpoint before server-edition merges to main.
-    ("GET", "/api/system/attribution-debug"),
     ("POST", "/api/stripe/webhook"),  # legacy alias for provider webhook
     # Provider payment routes without SPA callers: webhooks fire from the
     # provider's servers; create-checkout-session is called from the

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -263,6 +263,9 @@ def test_collector_finds_something():
 # - One-shot seeds run once during setup, not from the running SPA
 # - Legacy paths superseded by newer endpoints (kept for backwards compat)
 _INTENTIONAL_BACKEND_ONLY: set[tuple[str, str]] = {
+    # TEMPORARY diagnostic for the Server Edition attribution field bug —
+    # remove with the endpoint before server-edition merges to main.
+    ("GET", "/api/system/attribution-debug"),
     ("POST", "/api/stripe/webhook"),  # legacy alias for provider webhook
     # Provider payment routes without SPA callers: webhooks fire from the
     # provider's servers; create-checkout-session is called from the


### PR DESCRIPTION
The complete Server Edition program — 17 commits, four stacked features, every one field-verified on real hardware (skytech serving, vonholten308 as client, including cold-boot SYSTEM start).

## What ships

- **LAN serving** (`--serve-lan [--bind IP]`): headless server mode with visible connect URLs (popup + connect-urls.txt on frozen builds), SQLite WAL tuning for office concurrency, SERVER EDITION UI identity
- **Users & principals**: users table, invisible legacy upgrade (operator backfilled as admin), password-only UX preserved for single user, username login at 2+ users
- **RBAC**: admin/bookkeeper/readonly enforced centrally; Users management in Settings; last-admin protection; readonly excluded from audit payloads (historical PII)
- **Per-user audit attribution**: every row names its actor (session-object stamping + contextvar fallback; alembic revision `b6c7d8e9f0a1`); self-attributed logins; UTC-correct display
- **Operations**: `serveredition-install.ps1` (startup task as SYSTEM + firewall + ProgramData books), uninstall, one-command `update-server-edition.ps1` — all shipped inside the bundle
- Fixes discovered along the way: topbar buttons dead in all environments (missing window exports), audit response model stripping `username`

## Field verification (2026-08-12, skytech + vonholten308)

Install script, multi-user login with username field, role enforcement, audit attribution through the API and UI, one-file upgrade-in-place, and the reboot finale: cold boot → serving as SYSTEM in 9–17 seconds with nobody logged in. Verified cooperatively with a Claude Code session on the server reading the live database and authenticated API.

1097 tests green. Same codebase, same installer — an edition is a state, not a SKU. Free forever, per the standing decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uzF92MM21Ac6Y6Gfei4ro