### PR TITLE
Scoped API tokens (v2.5.1)

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -69,6 +69,12 @@ def get_db(request: HTTPConnection = None):
         session = getattr(request, "session", None) if request is not None else None
         if isinstance(session, dict) and session.get("authenticated") is True:
             db.info["acting_username"] = session.get("username") or "operator"
+        elif request is not None:
+            # Scoped API tokens: the middleware stashes the principal on
+            # request.state — audit rows attribute to "token:<label>".
+            tp = getattr(getattr(request, "state", None), "token_principal", None)
+            if isinstance(tp, dict) and tp.get("username"):
+                db.info["acting_username"] = tp["username"]
     except Exception:
         pass  # attribution must never break a request
     try:

--- a/app/main.py
+++ b/app/main.py
@@ -58,6 +58,7 @@ from app.routes import uploads
 # Phase 5: Advanced Integration
 from app.routes import bank_import, simplefin, tax, backups
 from app.routes import users as users_routes
+from app.routes import api_tokens as api_tokens_routes
 from app.routes import classes as classes_routes
 from app.routes import fx as fx_routes
 from app.routes import fixed_assets as fixed_assets_routes
@@ -113,6 +114,7 @@ from app.config import (
 from app.database import SessionLocal, Base, engine
 from app.services.audit import register_audit_hooks
 from app.services.request_context import acting_username as _acting_username
+from app.services.api_token_service import resolve as _resolve_api_token
 
 
 def _run_startup_security_checks():
@@ -328,6 +330,7 @@ _AUTH_EXEMPT_RE = _re.compile(
 # ---------------------------------------------------------------------------
 _ADMIN_WRITE_PREFIXES = (
     "/api/users",
+    "/api/tokens",
     "/api/settings",
     "/api/backups",
     "/api/companies",
@@ -360,13 +363,35 @@ async def require_session(request: Request, call_next):
         or _AUTH_EXEMPT_RE.match(path)
     ):
         return await call_next(request)
-    if request.session.get("authenticated") is not True:
-        return JSONResponse(
-            status_code=401,
-            content={"detail": "Not authenticated"},
-        )
+    token_principal = None
+    if request.session.get("authenticated") is True:
+        role = request.session.get("role") or "admin"
+    else:
+        # Scoped API tokens: non-human principals (agents, integrations)
+        # authenticate with `Authorization: Bearer sbp_...` and wear a role
+        # exactly like a user. Session auth always wins when present.
+        auth_header = request.headers.get("authorization") or ""
+        if auth_header.startswith("Bearer "):
+            token_principal = _resolve_api_token(auth_header[7:].strip())
+        if token_principal is None:
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Not authenticated"},
+            )
+        # Tokens cannot manage identities — a leaked bookkeeper token must
+        # not be able to mint itself an admin token or a user account.
+        if path.startswith(("/api/users", "/api/tokens")):
+            return JSONResponse(
+                status_code=403,
+                content={"detail": "API tokens cannot manage users or tokens"},
+            )
+        role = token_principal["role"]
+        # get_db reads this to stamp audit attribution ("token:<label>")
+        request.state.token_principal = {
+            "username": "token:" + token_principal["label"],
+            "role": role,
+        }
 
-    role = request.session.get("role") or "admin"
     if not _role_allows(role, request.method, path):
         return JSONResponse(
             status_code=403,
@@ -376,7 +401,7 @@ async def require_session(request: Request, call_next):
     # Idle session cap. Sliding window — every authenticated hit refreshes
     # `last_activity`, so a session that's actively in use never trips this.
     # Disabled when SESSION_IDLE_TIMEOUT_SECONDS = 0 (test harness, dev).
-    if SESSION_IDLE_TIMEOUT_SECONDS > 0:
+    if SESSION_IDLE_TIMEOUT_SECONDS > 0 and token_principal is None:
         now = int(_time.time())
         last = request.session.get("last_activity")
         if isinstance(last, int) and (now - last) > SESSION_IDLE_TIMEOUT_SECONDS:
@@ -481,6 +506,7 @@ app.include_router(uploads.router)
 app.include_router(bank_import.router)
 app.include_router(simplefin.router)
 app.include_router(users_routes.router)
+app.include_router(api_tokens_routes.router)
 app.include_router(tax.router)
 app.include_router(backups.router)
 app.include_router(system_routes.router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -15,6 +15,7 @@ from app.models.audit import AuditLog
 
 # Server Edition: user principals
 from app.models.users import User  # noqa: F401 — registers the table
+from app.models.api_tokens import ApiToken  # noqa: F401 — registers the table
 
 # Phase 2: Accounts Payable
 from app.models.purchase_orders import PurchaseOrder, PurchaseOrderLine

--- a/app/models/api_tokens.py
+++ b/app/models/api_tokens.py
@@ -1,0 +1,39 @@
+# ============================================================================
+# API tokens — non-human principals (agents, integrations, the receipt
+# service). A token wears a role exactly like a user does; the RBAC
+# middleware can't tell the difference, which is the point.
+#
+# Storage: SHA-256 of the secret (tokens are 256-bit random — deterministic
+# hashing enables indexed lookup and offline brute force is meaningless).
+# The full secret is shown exactly once at creation. No DELETE — tokens
+# deactivate, so their label stays meaningful in the audit trail forever.
+# ============================================================================
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, Column, DateTime, Integer, String
+
+from app.database import Base
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+TOKEN_PREFIX = "sbp_"
+
+
+class ApiToken(Base):
+    __tablename__ = "api_tokens"
+
+    id = Column(Integer, primary_key=True, index=True)
+    label = Column(String(100), unique=True, nullable=False)
+    token_hash = Column(String(64), unique=True, nullable=False, index=True)
+    # First characters of the secret ("sbp_ab12…") so the operator can
+    # match a token in a config file to a row here without exposing it.
+    token_hint = Column(String(12), nullable=False)
+    role = Column(String(20), nullable=False)  # same values as users.role
+    is_active = Column(Boolean, nullable=False, default=True)
+    created_by = Column(String(100), nullable=False, default="")
+    created_at = Column(DateTime, default=_utcnow, nullable=False)
+    last_used_at = Column(DateTime, nullable=True)

--- a/app/routes/api_tokens.py
+++ b/app/routes/api_tokens.py
@@ -1,0 +1,104 @@
+# ============================================================================
+# API token management — admin sessions only. The middleware additionally
+# blocks token principals from this whole prefix (no self-escalation), so
+# only a human admin in a browser can mint or revoke tokens.
+#
+# The full secret appears exactly once, in the create response. No DELETE:
+# tokens deactivate, keeping their label meaningful in the audit trail.
+# ============================================================================
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.api_tokens import ApiToken
+from app.models.users import ROLE_ADMIN, VALID_ROLES
+from app.services.api_token_service import generate_token, hash_token
+
+router = APIRouter(prefix="/api/tokens", tags=["api_tokens"])
+
+
+def _require_admin(request: Request) -> None:
+    if (request.session.get("role") or "admin") != ROLE_ADMIN:
+        raise HTTPException(status_code=403, detail="Admin role required")
+
+
+def _out(t: ApiToken) -> dict:
+    return {
+        "id": t.id,
+        "label": t.label,
+        "token_hint": t.token_hint,
+        "role": t.role,
+        "is_active": t.is_active,
+        "created_by": t.created_by,
+        "created_at": t.created_at.isoformat() if t.created_at else None,
+        "last_used_at": t.last_used_at.isoformat() if t.last_used_at else None,
+    }
+
+
+class TokenCreate(BaseModel):
+    label: str = Field(..., min_length=1, max_length=100)
+    role: str = Field(...)
+
+
+class TokenUpdate(BaseModel):
+    is_active: Optional[bool] = None
+    label: Optional[str] = Field(None, min_length=1, max_length=100)
+
+
+@router.get("")
+def list_tokens(request: Request, db: Session = Depends(get_db)):
+    _require_admin(request)
+    return [_out(t) for t in db.query(ApiToken).order_by(ApiToken.id).all()]
+
+
+@router.post("", status_code=201)
+def create_token(payload: TokenCreate, request: Request, db: Session = Depends(get_db)):
+    _require_admin(request)
+    label = payload.label.strip()
+    if payload.role not in VALID_ROLES:
+        raise HTTPException(status_code=400, detail="Invalid role")
+    if db.query(ApiToken).filter(ApiToken.label == label).first():
+        raise HTTPException(status_code=409, detail="Label already exists")
+    secret = generate_token()
+    row = ApiToken(
+        label=label,
+        token_hash=hash_token(secret),
+        token_hint=secret[:10],
+        role=payload.role,
+        is_active=True,
+        created_by=request.session.get("username") or "operator",
+    )
+    db.add(row)
+    db.commit()
+    out = _out(row)
+    # The one and only time the secret leaves the server.
+    out["token"] = secret
+    return out
+
+
+@router.put("/{token_id}")
+def update_token(
+    token_id: int, payload: TokenUpdate, request: Request, db: Session = Depends(get_db)
+):
+    _require_admin(request)
+    row = db.query(ApiToken).filter(ApiToken.id == token_id).first()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Token not found")
+    if payload.label is not None:
+        label = payload.label.strip()
+        clash = (
+            db.query(ApiToken)
+            .filter(ApiToken.label == label, ApiToken.id != token_id)
+            .first()
+        )
+        if clash:
+            raise HTTPException(status_code=409, detail="Label already exists")
+        row.label = label
+    if payload.is_active is not None:
+        row.is_active = payload.is_active
+    db.commit()
+    return _out(row)

--- a/app/services/api_token_service.py
+++ b/app/services/api_token_service.py
@@ -1,0 +1,53 @@
+# ============================================================================
+# API token service — issue, resolve, and revoke bearer tokens.
+#
+# resolve() is called from the session middleware for requests carrying
+# `Authorization: Bearer sbp_...` and no authenticated session. It opens
+# its own short-lived DB session (middleware runs before dependencies).
+# ============================================================================
+
+import hashlib
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from app.models.api_tokens import TOKEN_PREFIX, ApiToken
+from app.models.users import VALID_ROLES  # noqa: F401 — re-exported for routes
+
+# last_used_at is best-effort telemetry; throttle writes so a chatty agent
+# doesn't turn every GET into a DB write.
+_LAST_USED_RESOLUTION = timedelta(minutes=5)
+
+
+def generate_token() -> str:
+    return TOKEN_PREFIX + secrets.token_urlsafe(32)
+
+
+def hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def resolve(bearer: str) -> dict | None:
+    """Bearer secret → {"label", "role"} for an active token, else None."""
+    if not bearer or not bearer.startswith(TOKEN_PREFIX):
+        return None
+    from app.database import SessionLocal
+
+    db = SessionLocal()
+    try:
+        row = (
+            db.query(ApiToken)
+            .filter(ApiToken.token_hash == hash_token(bearer), ApiToken.is_active)
+            .first()
+        )
+        if row is None:
+            return None
+        now = datetime.now(timezone.utc)
+        last = row.last_used_at
+        if last is not None and last.tzinfo is None:
+            last = last.replace(tzinfo=timezone.utc)
+        if last is None or (now - last) > _LAST_USED_RESOLUTION:
+            row.last_used_at = now
+            db.commit()
+        return {"label": row.label, "role": row.role}
+    finally:
+        db.close()

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -12,6 +12,7 @@ const SettingsPage = {
             SettingsPage.loadAiConfig();
             SettingsPage.loadClasses();
             SettingsPage.loadUsers();
+            SettingsPage.loadApiTokens();
             SettingsPage.scrollToFocus();
         }, 0);
         return `
@@ -308,6 +309,34 @@ const SettingsPage = {
                     <button type="button" class="btn btn-primary" onclick="SettingsPage.createUser()">Add User</button>
                 </div>
 
+                <div class="settings-section" id="settings-api-tokens" style="display:none;">
+                    <h3>API Tokens &mdash; agents &amp; integrations</h3>
+                    <p style="font-size:12px; color:var(--text-muted); margin-bottom:10px;">
+                        Scoped credentials for non-humans: AI agents, the receipt
+                        service, scripts. A token wears a role just like a user —
+                        give read-only to anything that only reports, and every
+                        change it makes is attributed in the audit log as
+                        <code>token:&lt;label&gt;</code>. Tokens can never manage
+                        users or other tokens, whatever their role.
+                    </p>
+                    <div id="api-token-reveal" style="display:none; margin-bottom:12px; padding:10px; border:1px solid var(--qb-gold); border-radius:4px; background:rgba(224,158,36,0.08); font-size:12px;">
+                        <strong>Copy this token now — it will never be shown again:</strong>
+                        <div style="font-family:var(--font-mono); margin-top:6px; word-break:break-all;" id="api-token-secret"></div>
+                    </div>
+                    <div id="api-token-list" style="margin-bottom:12px;"></div>
+                    <div class="form-grid" style="align-items:end;">
+                        <div class="form-group"><label>Label</label>
+                            <input id="token-new-label" autocomplete="off" placeholder="e.g. claude-code, receipt-service"></div>
+                        <div class="form-group"><label>Role</label>
+                            <select id="token-new-role">
+                                <option value="readonly">Read-only — reports and lookups</option>
+                                <option value="bookkeeper">Bookkeeper — daily books, no admin</option>
+                                <option value="admin">Admin — everything except identity management</option>
+                            </select></div>
+                    </div>
+                    <button type="button" class="btn btn-primary" onclick="SettingsPage.createApiToken()">Create Token</button>
+                </div>
+
                 <div class="form-actions">
                     <button type="submit" class="btn btn-primary">Save Settings</button>
                 </div>
@@ -346,6 +375,60 @@ const SettingsPage = {
                 <thead><tr><th>Username</th><th>Name</th><th>Role</th><th>Last login</th><th></th></tr></thead>
                 <tbody>${rows}</tbody></table></div>`;
         } catch (e) { /* non-admin or pre-upgrade server: section stays hidden */ }
+    },
+
+    // ------------------------------------------------------------------
+    // API tokens — admin-only, mirrors the Users section
+    // ------------------------------------------------------------------
+    async loadApiTokens() {
+        const section = $('#settings-api-tokens');
+        if (!section) return;
+        try {
+            const status = await API.get('/auth/status');
+            if (!status.user || status.user.role !== 'admin') return;
+            const tokens = await API.get('/tokens');
+            section.style.display = '';
+            if (!tokens.length) {
+                $('#api-token-list').innerHTML =
+                    '<div style="font-size:11px; color:var(--text-muted);">No tokens yet.</div>';
+                return;
+            }
+            const rows = tokens.map(t => `<tr>
+                <td>${escapeHtml(t.label)}</td>
+                <td style="font-family:var(--font-mono); font-size:10px;">${escapeHtml(t.token_hint)}&hellip;</td>
+                <td>${escapeHtml(t.role)}</td>
+                <td>${t.last_used_at ? formatDate(t.last_used_at) : '—'}</td>
+                <td>${t.is_active
+                    ? `<button type="button" class="btn btn-sm btn-secondary" onclick="SettingsPage.updateApiToken(${t.id}, {is_active: false})">Revoke</button>`
+                    : `<button type="button" class="btn btn-sm btn-secondary" onclick="SettingsPage.updateApiToken(${t.id}, {is_active: true})">Reactivate</button>`}
+                </td>
+            </tr>`).join('');
+            $('#api-token-list').innerHTML = `<div class="table-container"><table>
+                <thead><tr><th>Label</th><th>Token</th><th>Role</th><th>Last used</th><th></th></tr></thead>
+                <tbody>${rows}</tbody></table></div>`;
+        } catch (e) { /* non-admin or pre-upgrade server: section stays hidden */ }
+    },
+
+    async createApiToken() {
+        try {
+            const created = await API.post('/tokens', {
+                label: $('#token-new-label').value.trim(),
+                role: $('#token-new-role').value,
+            });
+            $('#api-token-secret').textContent = created.token;
+            $('#api-token-reveal').style.display = '';
+            $('#token-new-label').value = '';
+            toast('Token created — copy it now, it will not be shown again');
+            SettingsPage.loadApiTokens();
+        } catch (err) { toast(err.message, 'error'); }
+    },
+
+    async updateApiToken(id, patch) {
+        try {
+            await API.put(`/tokens/${id}`, patch);
+            toast('Token updated');
+            SettingsPage.loadApiTokens();
+        } catch (err) { toast(err.message, 'error'); }
     },
 
     async createUser() {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,6 +174,10 @@ def _wire_app(TestSession):
         http_session = getattr(request, "session", None) if request else None
         if isinstance(http_session, dict) and http_session.get("authenticated") is True:
             session.info["acting_username"] = http_session.get("username") or "operator"
+        elif request is not None:
+            tp = getattr(getattr(request, "state", None), "token_principal", None)
+            if isinstance(tp, dict) and tp.get("username"):
+                session.info["acting_username"] = tp["username"]
         try:
             yield session
         finally:

--- a/tests/test_api_tokens.py
+++ b/tests/test_api_tokens.py
@@ -1,0 +1,150 @@
+"""Scoped API tokens (v2.5.1): issuance, bearer auth, role enforcement,
+no-self-escalation, revocation, and audit attribution."""
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.models.api_tokens import ApiToken
+from app.models.audit import AuditLog
+
+
+def _mint(client, label="agent", role="readonly"):
+    r = client.post("/api/tokens", json={"label": label, "role": role})
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _bearer(token):
+    """Fresh cookie-less client so the Bearer path (not the session) auths."""
+    c = TestClient(app)
+    c.headers["Authorization"] = f"Bearer {token}"
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Issuance + management (admin sessions only)
+# ---------------------------------------------------------------------------
+
+
+def test_create_returns_secret_once(client, db_session):
+    created = _mint(client, "claude-code", "readonly")
+    assert created["token"].startswith("sbp_")
+    assert created["token_hint"] == created["token"][:10]
+
+    listed = client.get("/api/tokens").json()
+    assert len(listed) == 1
+    assert "token" not in listed[0]  # never again
+    row = db_session.query(ApiToken).one()
+    assert created["token"] not in (row.token_hash, row.token_hint)  # hashed at rest
+
+
+def test_validation_and_dupes(client):
+    r = client.post("/api/tokens", json={"label": "x1", "role": "boss"})
+    assert r.status_code == 400
+    _mint(client, "dupe", "readonly")
+    r = client.post("/api/tokens", json={"label": "dupe", "role": "readonly"})
+    assert r.status_code == 409
+
+
+def test_non_admin_sessions_cannot_manage(client, db_session):
+    from app.models.users import ROLE_BOOKKEEPER, User
+    from app.services import auth as auth_service
+
+    db_session.add(
+        User(
+            username="keeper",
+            display_name="Keeper",
+            password_hash=auth_service.hash_password("keeper-password-1"),
+            role=ROLE_BOOKKEEPER,
+            is_active=True,
+        )
+    )
+    db_session.commit()
+    client.post("/api/auth/logout")
+    client.post(
+        "/api/auth/login", json={"username": "keeper", "password": "keeper-password-1"}
+    )
+    assert client.get("/api/tokens").status_code == 403
+    assert (
+        client.post("/api/tokens", json={"label": "sneak", "role": "admin"}).status_code
+        == 403
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bearer authentication + role enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_readonly_token_reads_but_never_writes(client):
+    tok = _mint(client, "reporter", "readonly")["token"]
+    api = _bearer(tok)
+    assert api.get("/api/customers").status_code == 200
+    assert api.post("/api/customers", json={"name": "Nope"}).status_code == 403
+
+
+def test_bookkeeper_token_daily_writes_only(client):
+    tok = _mint(client, "keeper-bot", "bookkeeper")["token"]
+    api = _bearer(tok)
+    assert api.post("/api/customers", json={"name": "Bot Corp"}).status_code in (
+        200,
+        201,
+    )
+    assert api.put("/api/settings", json={"invoice_prefix": "T-"}).status_code == 403
+
+
+def test_tokens_cannot_manage_identities_even_as_admin(client):
+    tok = _mint(client, "root-bot", "admin")["token"]
+    api = _bearer(tok)
+    assert api.put("/api/settings", json={"invoice_prefix": "A-"}).status_code == 200
+    # The no-self-escalation wall
+    assert api.get("/api/users").status_code == 403
+    assert api.get("/api/tokens").status_code == 403
+    assert (
+        api.post("/api/tokens", json={"label": "evil", "role": "admin"}).status_code
+        == 403
+    )
+
+
+def test_bad_and_revoked_tokens_rejected(client):
+    assert _bearer("sbp_totally-fake").get("/api/customers").status_code == 401
+    created = _mint(client, "shortlived", "readonly")
+    api = _bearer(created["token"])
+    assert api.get("/api/customers").status_code == 200
+    client.put(f"/api/tokens/{created['id']}", json={"is_active": False})
+    assert api.get("/api/customers").status_code == 401
+
+
+def test_no_credentials_still_401(client):
+    assert TestClient(app).get("/api/customers").status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Attribution + telemetry
+# ---------------------------------------------------------------------------
+
+
+def test_token_writes_attributed_in_audit(client, db_session):
+    tok = _mint(client, "receipt-service", "bookkeeper")["token"]
+    _bearer(tok).post("/api/customers", json={"name": "Attributed Bot Inc"})
+    row = (
+        db_session.query(AuditLog)
+        .filter(AuditLog.table_name == "customers")
+        .order_by(AuditLog.id.desc())
+        .first()
+    )
+    assert row is not None
+    assert row.username == "token:receipt-service"
+
+
+def test_last_used_recorded(client, db_session):
+    created = _mint(client, "tracked", "readonly")
+    assert (
+        db_session.query(ApiToken).filter_by(label="tracked").one().last_used_at is None
+    )
+    _bearer(created["token"]).get("/api/customers")
+    db_session.expire_all()
+    assert (
+        db_session.query(ApiToken).filter_by(label="tracked").one().last_used_at
+        is not None
+    )


### PR DESCRIPTION
Delivers the /ai page's roadmap promise on the Server Edition principal foundation. Tokens are non-human principals: same roles, same RBAC chokepoint, same audit attribution — plus a no-self-escalation wall (tokens can never manage users or tokens, whatever their role).

- SHA-256-at-rest secrets, shown once, `sbp_` prefix, hint column
- Bearer path in the middleware; session always wins; token requests never set cookies
- Settings → API Tokens card (admin sessions only)
- Audit rows attribute as `token:<label>`
- 1129 tests green (10 new: issuance/validation, role matrix per token, revocation, no-self-escalation, attribution, last-used)

First customer: the receipt-intake service. Second: every agent following slowbookspro.com/ai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uzF92MM21Ac6Y6Gfei4ro