### PR TITLE
Fix #52: server child dies with its launcher (macOS Cmd-Q orphaning)

### DIFF
--- a/desktop_launcher.py
+++ b/desktop_launcher.py
@@ -1037,12 +1037,50 @@ def run_headless(port: int, bind_host: str = "127.0.0.1") -> int:
     return 0
 
 
+def _watch_parent(parent_pid: int, poll_seconds: float = 2.0) -> None:
+    """Daemon thread: exit this server process when its launcher dies.
+
+    Issue #52: on macOS, Command-Q terminates the parent app process
+    without unwinding Python cleanup, orphaning the --_serve child on
+    the port (invisible server, "already running" on relaunch). The
+    child watching its parent fixes every abnormal-parent-death path —
+    including launcher crashes — with one mechanism.
+
+    Server Edition is preserved BY DESIGN, not by accident: in
+    --serve-lan / scheduled-task mode the launcher parent stays alive
+    holding proc.wait(), so the watcher never fires and the server runs
+    perpetually. POSIX only (macOS + Linux); on Windows every quit path
+    goes through the window-close cleanup that already works.
+
+    (Deliberate "keep serving after the window closes" is a designed
+    v2.6 feature — tray indicator + relaunch adoption — not an accident
+    of orphaning.)
+    """
+    import threading
+    import time as _t
+
+    def _poll():
+        while True:
+            _t.sleep(poll_seconds)
+            try:
+                os.kill(parent_pid, 0)  # signal 0 = existence check
+            except OSError:
+                os._exit(0)  # parent gone: take the port down with us
+            if os.getppid() != parent_pid:
+                os._exit(0)  # reparented (launchd/init adopted us)
+
+    threading.Thread(target=_poll, daemon=True, name="parent-watch").start()
+
+
 def _serve() -> int:
     """Internal: run the uvicorn server in this process. The frozen build
     has no child interpreter for `-m uvicorn`, so start_server() re-execs
     the bundled exe with --_serve instead; all configuration (DATABASE_URL,
     APP_PORT, SLOWBOOKS_*) arrives via the environment from _server_env()."""
     import uvicorn
+
+    if sys.platform != "win32":
+        _watch_parent(os.getppid())
 
     # Import the app OURSELVES rather than passing "app.main:app": when the
     # import fails, uvicorn's string loader reports only "Could not import

--- a/tests/test_server_mode.py
+++ b/tests/test_server_mode.py
@@ -115,3 +115,60 @@ def test_data_dir_flag_redirects_everything(tmp_path):
     )
     assert r.returncode == 0, r.stdout + r.stderr
     assert (target / "companies").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# Issue #52: the server child must die with its launcher parent
+# ---------------------------------------------------------------------------
+
+
+def test_parent_watcher_exits_when_parent_dies(tmp_path):
+    """Real process pair: a fake 'launcher' spawns a watcher child; killing
+    the launcher must take the child down within the poll interval."""
+    import subprocess
+    import sys as _sys
+    import time
+
+    child_script = tmp_path / "child.py"
+    child_script.write_text(
+        "import os, sys, time\n"
+        "sys.path.insert(0, %r)\n"
+        "import desktop_launcher\n"
+        "desktop_launcher._watch_parent(os.getppid(), poll_seconds=0.2)\n"
+        "time.sleep(30)\n"
+        % str(
+            tmp_path.parent
+            and __import__("pathlib").Path(__file__).resolve().parents[1].as_posix()
+        )
+    )
+    parent_script = tmp_path / "parent.py"
+    parent_script.write_text(
+        "import subprocess, sys, time\n"
+        f"p = subprocess.Popen([sys.executable, {str(child_script)!r}])\n"
+        "print(p.pid, flush=True)\n"
+        "time.sleep(30)\n"
+    )
+    parent = subprocess.Popen(
+        [_sys.executable, str(parent_script)], stdout=subprocess.PIPE, text=True
+    )
+    child_pid = int(parent.stdout.readline().strip())
+
+    # While the parent lives, the child survives several poll cycles
+    time.sleep(1.0)
+    import os as _os
+
+    _os.kill(child_pid, 0)  # raises if dead — it must be alive
+
+    # Kill the launcher; the watcher must take the child down
+    parent.kill()
+    parent.wait()
+    deadline = time.time() + 5
+    alive = True
+    while time.time() < deadline:
+        try:
+            _os.kill(child_pid, 0)
+            time.sleep(0.2)
+        except OSError:
+            alive = False
+            break
+    assert not alive, "server child outlived its launcher parent"


### PR DESCRIPTION
Fixes #52.

The `--_serve` child now watches its parent PID (POSIX daemon thread, 2s poll: existence + reparent check) and exits when the launcher dies — one mechanism covering Cmd-Q, launcher crashes, and every other abnormal-parent-death path. Windows is untouched (its quit paths already run the window-close cleanup).

**Server Edition unaffected by design**: `--serve-lan` / scheduled-task mode keeps its launcher parent alive in `proc.wait()`, so the watcher never fires and serving stays perpetual. The owner's call: deliberate background serving (window closes, server continues, tray icon + relaunch adoption) is a designed v2.6 feature, not an orphaning accident.

Verified with a real process-pair lifecycle test; 1130 tests green.

@ContractorKeith — hardware verification is yours when convenient: after this merges, a source run (or the next artifact) on the Mac should show Cmd-Q leaving no `SlowBooksPro --_serve` process, clean relaunch, and unchanged red-button behavior. Ships with the next release rather than an immediate re-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uzF92MM21Ac6Y6Gfei4ro