### PR TITLE
Encrypt credential settings at rest

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -180,6 +180,20 @@ async def lifespan(app: FastAPI):
     fail-hard production guard — keep them on the startup side of the yield
     so a misconfigured deploy never serves a single request."""
     _run_startup_security_checks()
+    # At-rest upgrade: encrypt any legacy plaintext credential rows (SMTP,
+    # payment, QBO, SimpleFIN secrets) on first boot after upgrading.
+    try:
+        from app.services.settings_service import upgrade_plaintext_secrets
+
+        _db = SessionLocal()
+        try:
+            n = upgrade_plaintext_secrets(_db)
+            if n:
+                print(f"Encrypted {n} legacy plaintext secret setting(s) at rest")
+        finally:
+            _db.close()
+    except Exception:
+        pass  # never block boot on the upgrader
     yield
 
 

--- a/app/services/closing_date.py
+++ b/app/services/closing_date.py
@@ -4,6 +4,8 @@
 # ============================================================================
 
 import hmac
+
+from app.services.crypto import decrypt_value
 from datetime import date
 
 from fastapi import HTTPException
@@ -39,7 +41,7 @@ def check_closing_date(db: Session, txn_date: date, password: str = None):
             pw_row
             and pw_row.value
             and password
-            and hmac.compare_digest(password, pw_row.value)
+            and hmac.compare_digest(password, decrypt_value(pw_row.value))
         ):
             return  # Password override accepted
         raise HTTPException(

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -30,8 +30,10 @@ def _get_smtp_settings(db: Session) -> dict:
         "smtp_from_name",
         "smtp_use_tls",
     ]
+    from app.services.settings_service import _maybe_decrypt
+
     rows = db.query(Settings).filter(Settings.key.in_(keys)).all()
-    settings = {r.key: r.value for r in rows}
+    settings = {r.key: _maybe_decrypt(r.key, r.value) for r in rows}
     return settings
 
 

--- a/app/services/payments/__init__.py
+++ b/app/services/payments/__init__.py
@@ -49,10 +49,12 @@ def all_providers() -> list[PaymentProvider]:
 def provider_settings(db: Session, provider: PaymentProvider) -> dict:
     """Load this provider's settings rows as a plain dict ('' when unset)."""
     keys = list(provider.settings_keys)
+    from app.services.settings_service import _maybe_decrypt
+
     rows = db.query(Settings).filter(Settings.key.in_(keys)).all()
     result = {k: "" for k in keys}
     for r in rows:
-        result[r.key] = r.value
+        result[r.key] = _maybe_decrypt(r.key, r.value)
     return result
 
 

--- a/app/services/qbo_service.py
+++ b/app/services/qbo_service.py
@@ -27,14 +27,21 @@ from app.models.settings import Settings, DEFAULT_SETTINGS
 
 def _get_setting(db: Session, key: str) -> str:
     """Get a single setting value, falling back to DEFAULT_SETTINGS."""
+    from app.services.settings_service import _maybe_decrypt
+
     row = db.query(Settings).filter(Settings.key == key).first()
     if row:
-        return row.value or ""
+        return _maybe_decrypt(key, row.value) or ""
     return DEFAULT_SETTINGS.get(key, "")
 
 
 def _set_setting(db: Session, key: str, value: str):
-    """Upsert a single setting."""
+    """Upsert a single setting (encrypting credential keys at rest)."""
+    from app.services.crypto import encrypt_value, is_encrypted
+    from app.services.settings_service import ENCRYPTED_SETTINGS_KEYS
+
+    if key in ENCRYPTED_SETTINGS_KEYS and value and not is_encrypted(value):
+        value = encrypt_value(value)
     row = db.query(Settings).filter(Settings.key == key).first()
     if row:
         row.value = value

--- a/app/services/settings_service.py
+++ b/app/services/settings_service.py
@@ -8,6 +8,7 @@ from other modules" convention.
 from sqlalchemy.orm import Session
 
 from app.models.settings import Settings, DEFAULT_SETTINGS
+from app.services.crypto import decrypt_value, encrypt_value, is_encrypted
 
 _SENSITIVE_KEYS = frozenset(
     {
@@ -15,6 +16,33 @@ _SENSITIVE_KEYS = frozenset(
         "session_secret",
     }
 )
+
+# Credentials that must be Fernet-encrypted at rest (fernet:v1: prefix).
+# Redaction-on-read (routes/settings SECRET_KEYS) hides these from the
+# API; this set hides them from the database file itself. AI provider
+# keys are handled by analytics.py with the same crypto primitives;
+# auth_password_hash is argon2 (already non-reversible).
+ENCRYPTED_SETTINGS_KEYS = frozenset(
+    {
+        "closing_date_password",
+        "smtp_password",
+        "stripe_secret_key",
+        "stripe_webhook_secret",
+        "paypal_client_secret",
+        "square_access_token",
+        "square_webhook_signature_key",
+        "qbo_client_secret",
+        "qbo_access_token",
+        "qbo_refresh_token",
+        "simplefin_access_url",
+    }
+)
+
+
+def _maybe_decrypt(key: str, value):
+    if key in ENCRYPTED_SETTINGS_KEYS and value:
+        return decrypt_value(value)
+    return value
 
 
 def get_all_settings(db: Session) -> dict:
@@ -26,21 +54,48 @@ def get_all_settings(db: Session) -> dict:
     result = dict(DEFAULT_SETTINGS)
     for row in rows:
         if row.key not in _SENSITIVE_KEYS:
-            result[row.key] = row.value
+            result[row.key] = _maybe_decrypt(row.key, row.value)
     return result
 
 
 def get_setting_raw(db: Session, key: str) -> str | None:
     """Return a single setting value by key (including sensitive keys)."""
     row = db.query(Settings).filter(Settings.key == key).first()
-    return row.value if row else None
+    return _maybe_decrypt(key, row.value) if row else None
 
 
 def set_setting(db: Session, key: str, value: str) -> None:
     """Upsert a single setting row (caller must db.commit())."""
+    if key in ENCRYPTED_SETTINGS_KEYS and value and not is_encrypted(value):
+        value = encrypt_value(value)
     row = db.query(Settings).filter(Settings.key == key).first()
     if row:
         row.value = value
     else:
         row = Settings(key=key, value=value)
         db.add(row)
+
+
+def upgrade_plaintext_secrets(db: Session) -> int:
+    """One-shot at-rest upgrade: encrypt any legacy plaintext secret rows.
+
+    Called at startup so existing installs close the gap on their first
+    boot after upgrading. Returns how many rows were upgraded. Never
+    raises — a failed upgrade must not block the app from serving.
+    """
+    upgraded = 0
+    try:
+        rows = (
+            db.query(Settings)
+            .filter(Settings.key.in_(list(ENCRYPTED_SETTINGS_KEYS)))
+            .all()
+        )
+        for row in rows:
+            if row.value and not is_encrypted(row.value):
+                row.value = encrypt_value(row.value)
+                upgraded += 1
+        if upgraded:
+            db.commit()
+    except Exception:
+        db.rollback()
+    return upgraded

--- a/tests/test_settings_encryption.py
+++ b/tests/test_settings_encryption.py
@@ -1,0 +1,117 @@
+"""At-rest encryption for credential settings: SMTP, payments, QBO,
+SimpleFIN, closing-date password. Redaction hides them from the API;
+this layer hides them from the database file itself."""
+
+from app.models.settings import Settings
+from app.services.crypto import CIPHERTEXT_PREFIX, encrypt_value
+from app.services.settings_service import (
+    get_all_settings,
+    get_setting_raw,
+    set_setting,
+    upgrade_plaintext_secrets,
+)
+
+
+def _raw_row(db, key):
+    return db.query(Settings).filter(Settings.key == key).first()
+
+
+def test_secret_settings_are_ciphertext_at_rest(client, db_session):
+    r = client.put("/api/settings", json={"smtp_password": "hunter2-smtp"})
+    assert r.status_code == 200
+    row = _raw_row(db_session, "smtp_password")
+    assert row.value.startswith(CIPHERTEXT_PREFIX)
+    assert "hunter2-smtp" not in row.value
+    # Service reads decrypt transparently
+    assert get_setting_raw(db_session, "smtp_password") == "hunter2-smtp"
+    assert get_all_settings(db_session)["smtp_password"] == "hunter2-smtp"
+    # API still redacts
+    assert client.get("/api/settings").json()["smtp_password"] == "********"
+
+
+def test_non_secret_settings_stay_plaintext(client, db_session):
+    client.put("/api/settings", json={"company_name": "Plain Co"})
+    assert _raw_row(db_session, "company_name").value == "Plain Co"
+
+
+def test_no_double_encryption(db_session):
+    already = encrypt_value("once-only")
+    set_setting(db_session, "stripe_secret_key", already)
+    db_session.commit()
+    stored = _raw_row(db_session, "stripe_secret_key").value
+    assert stored == already  # not wrapped a second time
+    assert get_setting_raw(db_session, "stripe_secret_key") == "once-only"
+
+
+def test_legacy_plaintext_upgrades_at_boot(db_session):
+    # Simulate a pre-upgrade install: plaintext secret in the table
+    db_session.add(Settings(key="paypal_client_secret", value="legacy-plain"))
+    db_session.add(Settings(key="company_phone", value="555-0100"))
+    db_session.commit()
+
+    n = upgrade_plaintext_secrets(db_session)
+    assert n == 1  # only the secret row
+    row = _raw_row(db_session, "paypal_client_secret")
+    assert row.value.startswith(CIPHERTEXT_PREFIX)
+    assert get_setting_raw(db_session, "paypal_client_secret") == "legacy-plain"
+    assert _raw_row(db_session, "company_phone").value == "555-0100"
+    # Idempotent
+    assert upgrade_plaintext_secrets(db_session) == 0
+
+
+def test_smtp_consumer_receives_plaintext(db_session):
+    from app.services.email_service import _get_smtp_settings
+
+    set_setting(db_session, "smtp_password", "smtp-secret-99")
+    db_session.commit()
+    assert _get_smtp_settings(db_session)["smtp_password"] == "smtp-secret-99"
+
+
+def test_payments_loader_receives_plaintext(db_session):
+    from app.services.payments import provider_settings, get_provider
+
+    set_setting(db_session, "stripe_secret_key", "sk_test_abc123")
+    db_session.commit()
+    cfg = provider_settings(db_session, get_provider("stripe"))
+    assert cfg["stripe_secret_key"] == "sk_test_abc123"
+
+
+def test_qbo_roundtrip_encrypted(db_session):
+    from app.services import qbo_service
+
+    qbo_service._set_setting(db_session, "qbo_access_token", "qbo-tok-1")
+    db_session.commit()
+    assert _raw_row(db_session, "qbo_access_token").value.startswith(CIPHERTEXT_PREFIX)
+    assert qbo_service._get_setting(db_session, "qbo_access_token") == "qbo-tok-1"
+
+
+def test_closing_date_password_override_works_encrypted(db_session):
+    from datetime import date, timedelta
+
+    from app.services.closing_date import check_closing_date
+
+    set_setting(db_session, "closing_date", date.today().isoformat())
+    set_setting(db_session, "closing_date_password", "override-pw-1")
+    db_session.commit()
+    import pytest
+    from fastapi import HTTPException
+
+    locked_day = date.today() - timedelta(days=1)
+    # Wrong/absent password: locked (raises)
+    with pytest.raises(HTTPException):
+        check_closing_date(db_session, locked_day)
+    with pytest.raises(HTTPException):
+        check_closing_date(db_session, locked_day, password="wrong")
+    # Correct password decrypts and compares — no raise
+    check_closing_date(db_session, locked_day, password="override-pw-1")
+
+
+def test_simplefin_access_url_encrypted_via_existing_flow(client, db_session):
+    set_setting(db_session, "simplefin_access_url", "https://u:p@bridge.example/x")
+    db_session.commit()
+    row = _raw_row(db_session, "simplefin_access_url")
+    assert row.value.startswith(CIPHERTEXT_PREFIX)
+    assert (
+        get_setting_raw(db_session, "simplefin_access_url")
+        == "https://u:p@bridge.example/x"
+    )


### PR DESCRIPTION
Field-reported gap: `smtp_password` (and, on inspection, every credential in the settings table except AI keys) was redacted from API reads but **plaintext at rest**. Now the full family — SMTP, Stripe, PayPal, Square, QBO tokens, SimpleFIN access URL, closing-date password — is Fernet-encrypted (`fernet:v1:` versioned ciphertext, same primitives as the AI keys).

- Encrypt-on-write / decrypt-on-read centralized in `settings_service`; four direct-table consumers taught to decrypt
- Boot-time idempotent upgrader closes the gap for existing installs on first start
- Wrong-key decrypts raise loudly — no silent garbage
- 1139 tests green (9 new)

Ships with the next release (owner is holding tags for upcoming ideas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uzF92MM21Ac6Y6Gfei4ro