### PR TITLE
Fix API defects found in a full-surface sweep of all 357 endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,8 +38,11 @@ POSTGRES_DB=bookkeeper
 #   - HTTPSRedirectMiddleware (308 plain HTTP -> HTTPS at the app layer)
 #   - Strict-Transport-Security header (HSTS)
 #   - `Secure` flag on the session cookie
-# Set to false only when something in front of the app already terminates
-# TLS and you don't want the app's own redirect.
+# Must stay true in production. The app refuses to boot with
+# FORCE_HTTPS=false while APP_DEBUG=false (see _run_startup_security_checks),
+# and it does not need to be turned off behind a TLS-terminating proxy: the
+# redirect is already a no-op there because the proxy forwards HTTPS. Set it
+# false only together with APP_DEBUG=true, for local development.
 FORCE_HTTPS=true
 
 # HSTS max-age in seconds. Default 63072000 = 2 years (the preload-list

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ a native `.app` in a DMG, no Docker or Python required.
 [SimpleFIN](https://www.simplefin.org/) — you hold the bank credential,
 no middleman server, dedup + bank rules on arrival
 ([docs/setup-bank-feeds.md](docs/setup-bank-feeds.md)). Every install
-also serves a self-documenting 347-operation local REST API; point
+also serves a self-documenting 357-operation local REST API; point
 Claude Code or any agentic CLI at it —
 [slowbookspro.com/ai](https://www.slowbookspro.com/ai/) has the
 paste-prompt.

--- a/app/main.py
+++ b/app/main.py
@@ -621,3 +621,57 @@ async def serve_analytics_redirect():
     from fastapi.responses import RedirectResponse
 
     return RedirectResponse(url="/#/analytics", status_code=307)
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI: declare the auth the API actually enforces.
+#
+# components.securitySchemes was empty and there was no top-level `security`,
+# so the spec described an API that needs no credentials — while every
+# operation behind it returns 401 without a bearer token. That matters
+# specifically because llms.txt and ai/agents-template.md tell agents to
+# "discover endpoints from the spec; do not guess paths": a client generated
+# from the spec emitted no Authorization header and 401'd on every call.
+#
+# Applied globally, with the genuinely public routes exempted so the document
+# stays truthful in both directions.
+# ---------------------------------------------------------------------------
+_PUBLIC_FOR_SPEC = {"/", "/health", "/openapi.json", "/analytics", "/favicon.ico"}
+_PUBLIC_PREFIXES_FOR_SPEC = ("/api/auth/", "/pay/", "/portal/", "/static/")
+
+
+def _custom_openapi():
+    if app.openapi_schema:
+        return app.openapi_schema
+
+    from fastapi.openapi.utils import get_openapi
+
+    schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        routes=app.routes,
+    )
+    schema.setdefault("components", {})["securitySchemes"] = {
+        "BearerToken": {
+            "type": "http",
+            "scheme": "bearer",
+            "description": (
+                "Scoped API token from Settings -> API Tokens, sent as "
+                "`Authorization: Bearer sbp_...`. Session cookies from "
+                "POST /api/auth/login are accepted equivalently."
+            ),
+        }
+    }
+    schema["security"] = [{"BearerToken": []}]
+
+    for path, item in schema.get("paths", {}).items():
+        if path in _PUBLIC_FOR_SPEC or path.startswith(_PUBLIC_PREFIXES_FOR_SPEC):
+            for operation in item.values():
+                if isinstance(operation, dict):
+                    operation["security"] = []
+
+    app.openapi_schema = schema
+    return schema
+
+
+app.openapi = _custom_openapi

--- a/app/routes/accounts.py
+++ b/app/routes/accounts.py
@@ -1,12 +1,34 @@
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.models.accounts import Account
+from app.models.transactions import TransactionLine
 from app.schemas.accounts import AccountCreate, AccountUpdate, AccountResponse
 from app.routes._helpers import get_or_404
 
 router = APIRouter(prefix="/api/accounts", tags=["accounts"])
+
+
+def _reject_duplicate_number(db: Session, number, exclude_id=None):
+    """account_number is UNIQUE. Without this the violation surfaces from the
+    database as an unhandled IntegrityError, i.e. an opaque HTTP 500 that
+    names neither the field nor the account already using it."""
+    if not number:
+        return
+    q = db.query(Account).filter(Account.account_number == number)
+    if exclude_id is not None:
+        q = q.filter(Account.id != exclude_id)
+    clash = q.first()
+    if clash:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Account number {number} is already used by "
+                f"'{clash.name}'. Account numbers must be unique."
+            ),
+        )
 
 
 @router.get("", response_model=list[AccountResponse])
@@ -28,9 +50,17 @@ def get_account(account_id: int, db: Session = Depends(get_db)):
 
 @router.post("", response_model=AccountResponse, status_code=201)
 def create_account(data: AccountCreate, db: Session = Depends(get_db)):
+    _reject_duplicate_number(db, data.account_number)
     account = Account(**data.model_dump())
     db.add(account)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="Account violates a uniqueness or reference constraint.",
+        )
     db.refresh(account)
     return account
 
@@ -38,9 +68,25 @@ def create_account(data: AccountCreate, db: Session = Depends(get_db)):
 @router.put("/{account_id}", response_model=AccountResponse)
 def update_account(account_id: int, data: AccountUpdate, db: Session = Depends(get_db)):
     account = get_or_404(db, Account, account_id)
-    for key, val in data.model_dump(exclude_unset=True).items():
+    fields = data.model_dump(exclude_unset=True)
+
+    if "account_number" in fields:
+        _reject_duplicate_number(db, fields["account_number"], exclude_id=account_id)
+    if fields.get("parent_id") == account_id:
+        raise HTTPException(
+            status_code=400, detail="An account cannot be its own parent."
+        )
+
+    for key, val in fields.items():
         setattr(account, key, val)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="Update violates a uniqueness or reference constraint.",
+        )
     db.refresh(account)
     return account
 
@@ -50,6 +96,38 @@ def delete_account(account_id: int, db: Session = Depends(get_db)):
     account = get_or_404(db, Account, account_id)
     if account.is_system:
         raise HTTPException(status_code=400, detail="Cannot delete system account")
+
+    # An account carrying ledger history must not be deleted — the postings
+    # would lose their anchor. Refusing is correct; the bug was that the
+    # refusal arrived as a raw foreign-key violation (HTTP 500) instead of a
+    # business rule the caller can act on.
+    posted = (
+        db.query(TransactionLine)
+        .filter(TransactionLine.account_id == account_id)
+        .count()
+    )
+    if posted:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"'{account.name}' has {posted} posted transaction line(s) and "
+                f"cannot be deleted. Deactivate it instead (set is_active=false) "
+                f"to hide it from new entries while preserving history."
+            ),
+        )
+
     db.delete(account)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # Any of the other tables referencing accounts.id — belt and braces so
+        # no constraint can ever leak as a 500 from this endpoint again.
+        db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"'{account.name}' is still referenced by other records and "
+                f"cannot be deleted. Deactivate it instead."
+            ),
+        )
     return {"message": "Account deleted"}

--- a/app/routes/invoices/documents.py
+++ b/app/routes/invoices/documents.py
@@ -94,30 +94,32 @@ def email_invoice(
             pay_url = f"{base_url}/pay/{inv.payment_token}"
 
         html_body = render_invoice_email(inv, company, pay_url=pay_url)
-        send_email(
+        # send_email() writes its own EmailLog row on every path (sent,
+        # failed, and SMTP-not-configured), so the route must not log again
+        # or every send produces two rows.
+        sent = send_email(
+            db=db,
             to_email=data.recipient,
             subject=subject,
             html_body=html_body,
-            settings=company,
-            attachments=[
-                {
-                    "filename": f"Invoice_{inv.invoice_number}.pdf",
-                    "content": pdf_bytes,
-                    "mime_type": "application/pdf",
-                }
-            ],
-        )
-        # Log the email
-        log = EmailLog(
+            attachment_bytes=pdf_bytes,
+            attachment_name=f"Invoice_{inv.invoice_number}.pdf",
             entity_type="invoice",
             entity_id=inv.id,
-            recipient=data.recipient,
-            subject=subject,
-            status="sent",
         )
-        db.add(log)
-        db.commit()
+        # It returns False rather than raising when SMTP is unconfigured or
+        # the send fails; reporting "sent" regardless would be a lie.
+        if not sent:
+            raise HTTPException(
+                status_code=502,
+                detail=(
+                    "Email could not be sent. Check the SMTP settings under "
+                    "Settings -> Email; the failure is recorded in the email log."
+                ),
+            )
         return {"status": "sent"}
+    except HTTPException:
+        raise
     except Exception as e:
         from app.models.email_log import EmailLog
 

--- a/app/routes/settings.py
+++ b/app/routes/settings.py
@@ -3,7 +3,7 @@
 # everything into a single key-value store because nobody needs 12 tabs.
 # ============================================================================
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
@@ -88,20 +88,25 @@ def test_email(db: Session = Depends(get_db)):
     """Feature 8: Send a test email to verify SMTP settings."""
     settings = get_all_settings(db)
     if not settings.get("smtp_host"):
-        from fastapi import HTTPException
-
         raise HTTPException(status_code=400, detail="SMTP not configured")
     try:
         from app.services.email_service import send_email
 
-        send_email(
+        sent = send_email(
+            db=db,
             to_email=settings.get("smtp_from_email") or settings.get("smtp_user", ""),
             subject="Slowbooks Pro 2026 — Test Email",
             html_body="<p>This is a test email from Slowbooks Pro 2026. SMTP is configured correctly.</p>",
-            settings=settings,
+            entity_type="settings_test",
         )
+        if not sent:
+            raise HTTPException(
+                status_code=502,
+                detail="Test email failed to send. See the email log for the reason.",
+            )
         return {"status": "sent"}
+    except HTTPException:
+        # Don't let the catch-all below rewrite our own 502 into a 500.
+        raise
     except Exception as e:
-        from fastapi import HTTPException
-
         raise HTTPException(status_code=500, detail=f"Email failed: {str(e)}")

--- a/app/routes/settings.py
+++ b/app/routes/settings.py
@@ -3,7 +3,9 @@
 # everything into a single key-value store because nobody needs 12 tabs.
 # ============================================================================
 
-from fastapi import APIRouter, Depends, HTTPException
+from datetime import date
+
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
@@ -64,8 +66,62 @@ def get_settings(db: Session = Depends(get_db)):
     return _redact_secrets(get_all_settings(db))
 
 
+def _guard_closing_period(request: Request, db: Session, fields: dict):
+    """The closing-date lock is only a control if the principal it constrains
+    cannot switch it off. A token could previously clear closing_date, post
+    into the closed period, and set closing_date_password — while the agent
+    documentation states the override password is "off-limits to agents
+    entirely".
+
+    Scoped deliberately to token principals. A human with a session is the
+    person the lock exists to serve and can still move or clear it; requiring
+    the override password from them would lock out anyone who set one and
+    forgot it. Tokens may still move the date FORWARD (tightening the lock),
+    only loosening is refused.
+    """
+    principal = getattr(getattr(request, "state", None), "token_principal", None)
+    if principal is None:
+        return  # session user — unchanged behaviour
+
+    if "closing_date_password" in fields:
+        raise HTTPException(
+            status_code=403,
+            detail="API tokens cannot set the closing-date override password.",
+        )
+
+    if "closing_date" not in fields:
+        return
+
+    def _parse(v):
+        if not v:
+            return None
+        try:
+            return date.fromisoformat(str(v))
+        except ValueError:
+            return None
+
+    from app.services.closing_date import get_closing_date
+
+    current = get_closing_date(db)
+    if current is None:
+        return  # no lock set yet — nothing to loosen
+
+    incoming = _parse(fields.get("closing_date"))
+    if incoming is None or incoming < current:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"API tokens cannot clear or roll back the closing date "
+                f"(currently {current.isoformat()}). Moving it forward is "
+                f"allowed; loosening it requires a signed-in user."
+            ),
+        )
+
+
 @router.put("")
-def update_settings(data: SettingsUpdate, db: Session = Depends(get_db)):
+def update_settings(
+    data: SettingsUpdate, request: Request, db: Session = Depends(get_db)
+):
     # model_dump returns extras plus any declared fields. Still whitelisted
     # against DEFAULT_SETTINGS so unknown keys are silently dropped.
     #
@@ -73,6 +129,11 @@ def update_settings(data: SettingsUpdate, db: Session = Depends(get_db)):
     # skip the update. Otherwise the UI would round-trip the placeholder
     # back into storage and silently overwrite the real secret when the
     # operator edits any other setting without re-typing the password.
+    _guard_closing_period(
+        request,
+        db,
+        {k: v for k, v in data.model_dump().items() if k in DEFAULT_SETTINGS},
+    )
     for key, value in data.model_dump().items():
         if key not in DEFAULT_SETTINGS:
             continue

--- a/app/schemas/common.py
+++ b/app/schemas/common.py
@@ -3,7 +3,6 @@ from typing import Annotated
 
 from pydantic import BaseModel, StringConstraints
 
-
 # A required display name that cannot be blank.
 #
 # `min_length` alone is not enough: a name of "   " has length 3 and passes,

--- a/app/schemas/common.py
+++ b/app/schemas/common.py
@@ -1,3 +1,4 @@
+import re
 from decimal import Decimal
 from typing import Annotated
 
@@ -15,6 +16,19 @@ from pydantic import BaseModel, StringConstraints
 # Vendor.name. Validating here keeps the two supported backends consistent:
 # PostgreSQL raises StringDataRightTruncation (an opaque HTTP 500) while
 # SQLite ignores VARCHAR(n) and stores the oversized value.
+# A stored email address. Deliberately a permissive shape check, not RFC 5322
+# validation: the goal is to reject "not-an-email", which was accepted and
+# stored verbatim, without pulling in the email-validator dependency that
+# pydantic.EmailStr requires — requirements.txt is tightly pinned with CVE
+# rationale per line and is not somewhere to add a dependency casually.
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+OptionalEmail = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, max_length=200, pattern=_EMAIL_RE.pattern),
+]
+
+
 NonBlankName = Annotated[
     str, StringConstraints(strip_whitespace=True, min_length=1, max_length=200)
 ]

--- a/app/schemas/contacts.py
+++ b/app/schemas/contacts.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
-from app.schemas.common import NonBlankName
+from app.schemas.common import NonBlankName, OptionalEmail
 
 
 # Field lengths below mirror the VARCHAR(n) widths on the Customer model.
@@ -17,7 +17,7 @@ from app.schemas.common import NonBlankName
 class CustomerCreate(BaseModel):
     name: NonBlankName
     company: Optional[str] = Field(None, max_length=200)
-    email: Optional[str] = Field(None, max_length=200)
+    email: Optional[OptionalEmail] = None
     phone: Optional[str] = Field(None, max_length=50)
     mobile: Optional[str] = Field(None, max_length=50)
     fax: Optional[str] = Field(None, max_length=50)
@@ -44,7 +44,7 @@ class CustomerCreate(BaseModel):
 class CustomerUpdate(BaseModel):
     name: Optional[NonBlankName] = None
     company: Optional[str] = Field(None, max_length=200)
-    email: Optional[str] = Field(None, max_length=200)
+    email: Optional[OptionalEmail] = None
     phone: Optional[str] = Field(None, max_length=50)
     mobile: Optional[str] = Field(None, max_length=50)
     fax: Optional[str] = Field(None, max_length=50)
@@ -106,7 +106,7 @@ class CustomerResponse(BaseModel):
 class VendorCreate(BaseModel):
     name: NonBlankName
     company: Optional[str] = Field(None, max_length=200)
-    email: Optional[str] = Field(None, max_length=200)
+    email: Optional[OptionalEmail] = None
     phone: Optional[str] = Field(None, max_length=50)
     fax: Optional[str] = Field(None, max_length=50)
     website: Optional[str] = Field(None, max_length=200)
@@ -128,7 +128,7 @@ class VendorCreate(BaseModel):
 class VendorUpdate(BaseModel):
     name: Optional[NonBlankName] = None
     company: Optional[str] = Field(None, max_length=200)
-    email: Optional[str] = Field(None, max_length=200)
+    email: Optional[OptionalEmail] = None
     phone: Optional[str] = Field(None, max_length=50)
     fax: Optional[str] = Field(None, max_length=50)
     website: Optional[str] = Field(None, max_length=200)

--- a/app/schemas/payroll.py
+++ b/app/schemas/payroll.py
@@ -2,7 +2,7 @@ from datetime import date
 from typing import Optional
 from pydantic import BaseModel, model_validator
 
-from app.models.payroll import FilingStatus, PayFrequency
+from app.models.payroll import EmployeeRole, FilingStatus, PayFrequency, PayType
 
 
 # ---------------------------------------------------------------------------
@@ -12,7 +12,7 @@ class EmployeeCreate(BaseModel):
     first_name: str
     last_name: str
     ssn_last_four: Optional[str] = None
-    pay_type: str = "hourly"
+    pay_type: PayType = PayType.HOURLY
     pay_rate: float = 0
     # Typed against the model enums so a bad value is a 422 at the edge
     # instead of a LookupError at flush (an opaque 500).
@@ -33,7 +33,7 @@ class EmployeeCreate(BaseModel):
     residence_state: Optional[str] = None
     wc_class_code: Optional[str] = None
     email: Optional[str] = None
-    role: str = "employee"
+    role: EmployeeRole = EmployeeRole.EMPLOYEE
     manager_id: Optional[int] = None
     hire_date: Optional[date] = None
     notes: Optional[str] = None
@@ -43,7 +43,7 @@ class EmployeeUpdate(BaseModel):
     first_name: Optional[str] = None
     last_name: Optional[str] = None
     ssn_last_four: Optional[str] = None
-    pay_type: Optional[str] = None
+    pay_type: Optional[PayType] = None
     pay_rate: Optional[float] = None
     pay_frequency: Optional[PayFrequency] = None
     filing_status: Optional[FilingStatus] = None
@@ -61,7 +61,7 @@ class EmployeeUpdate(BaseModel):
     residence_state: Optional[str] = None
     wc_class_code: Optional[str] = None
     email: Optional[str] = None
-    role: Optional[str] = None
+    role: Optional[EmployeeRole] = None
     manager_id: Optional[int] = None
     hire_date: Optional[date] = None
     is_active: Optional[bool] = None
@@ -73,7 +73,7 @@ class EmployeeResponse(BaseModel):
     first_name: str
     last_name: str
     ssn_last_four: Optional[str] = None
-    pay_type: str
+    pay_type: PayType
     pay_rate: float = 0
     pay_frequency: str = "biweekly"
     filing_status: str
@@ -91,7 +91,7 @@ class EmployeeResponse(BaseModel):
     residence_state: Optional[str] = None
     wc_class_code: Optional[str] = None
     email: Optional[str] = None
-    role: str = "employee"
+    role: EmployeeRole = EmployeeRole.EMPLOYEE
     manager_id: Optional[int] = None
     is_active: bool = True
     hire_date: Optional[date] = None

--- a/scripts/repair_employee_enums.py
+++ b/scripts/repair_employee_enums.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Repair employees whose pay_type or role hold values outside their enums.
+
+Both columns are Enum(...) in the model but were accepted as bare strings by
+EmployeeCreate/EmployeeUpdate until that was fixed, so an invalid value could
+be written straight through. Reading such a row then raises LookupError, which
+surfaces as HTTP 500 — and because the whole list is loaded in one query, a
+single bad row makes GET /api/employees fail for the entire company.
+
+Nothing in the API can repair these rows: they cannot be read, updated or
+deleted through it. This script works in raw SQL for that reason, deliberately
+bypassing the ORM that cannot load them.
+
+Usage:
+    python3 scripts/repair_employee_enums.py          # detect only (dry run)
+    python3 scripts/repair_employee_enums.py --apply  # normalize bad values
+    python3 scripts/repair_employee_enums.py --json   # machine-readable output
+
+Repair policy:
+    pay_type -> 'HOURLY'    (PayType.HOURLY, the model default)
+    role     -> 'EMPLOYEE'  (EmployeeRole.EMPLOYEE, least privilege)
+
+Both are conservative. pay_rate is left untouched, so a salaried employee
+mis-repaired to hourly keeps their stored rate and is visible for correction
+rather than silently re-rated. role falls back to the LEAST privileged value
+so a repair can never widen someone's access.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from sqlalchemy import text
+
+from app.database import SessionLocal
+from app.models.payroll import EmployeeRole, PayType
+
+# SQLAlchemy's Enum() type persists the member NAME ("HOURLY"), not the value
+# ("hourly"), and rejects anything else on read. Repairing to the value would
+# leave the row just as unreadable as it was — verified by the regression test,
+# which caught exactly that mistake in an earlier draft of this script.
+COLUMNS = {
+    "pay_type": (PayType, PayType.HOURLY.name),
+    "role": (EmployeeRole, EmployeeRole.EMPLOYEE.name),
+}
+
+
+def scan(db):
+    """Return rows whose enum columns hold values the enums do not define."""
+    findings = []
+    rows = db.execute(
+        text("SELECT id, first_name, last_name, pay_type, role FROM employees")
+    ).mappings()
+    for row in rows:
+        bad = {}
+        for col, (enum_cls, _default) in COLUMNS.items():
+            value = row[col]
+            if value is None:
+                continue
+            # Names only: a row holding the lowercase *value* is equally
+            # unreadable, so it is a finding too, not a false positive.
+            valid = {m.name for m in enum_cls}
+            if str(value) not in valid:
+                bad[col] = value
+        if bad:
+            findings.append(
+                {
+                    "id": row["id"],
+                    "name": f"{row['first_name'] or ''} {row['last_name'] or ''}".strip(),
+                    "invalid": bad,
+                }
+            )
+    return findings
+
+
+def repair(db, findings):
+    for item in findings:
+        sets, params = [], {"id": item["id"]}
+        for col in item["invalid"]:
+            sets.append(f"{col} = :{col}")
+            params[col] = COLUMNS[col][1]
+        db.execute(
+            text(f"UPDATE employees SET {', '.join(sets)} WHERE id = :id"), params
+        )
+    db.commit()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply", action="store_true", help="write the repairs (default: dry run)"
+    )
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args()
+
+    db = SessionLocal()
+    try:
+        findings = scan(db)
+
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "count": len(findings),
+                        "employees": findings,
+                        "applied": args.apply,
+                    },
+                    indent=2,
+                )
+            )
+        elif not findings:
+            print("No employees with invalid pay_type or role. Nothing to repair.")
+        else:
+            print(f"{len(findings)} employee row(s) hold values outside their enums:\n")
+            for item in findings:
+                for col, value in item["invalid"].items():
+                    print(
+                        f"  employee {item['id']} ({item['name'] or 'unnamed'}): "
+                        f"{col} = {value!r} -> {COLUMNS[col][1]!r}"
+                    )
+            if not args.apply:
+                print("\nDry run. Re-run with --apply to write these repairs.")
+
+        if findings and args.apply:
+            repair(db, findings)
+            remaining = scan(db)
+            if not args.json:
+                print(
+                    f"\nRepaired {len(findings)} row(s). Remaining invalid: {len(remaining)}"
+                )
+            return 0 if not remaining else 1
+        return 0
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_api_defect_regressions.py
+++ b/tests/test_api_defect_regressions.py
@@ -199,3 +199,52 @@ def test_invoice_email_does_not_raise_typeerror(client, seed_customer):
     # What must never come back is the old TypeError surfacing as a 500.
     assert r.status_code != 500, r.text
     assert "unexpected keyword argument" not in r.text
+
+
+# ---------------------------------------------------------------------------
+# Rows corrupted before the validation fix cannot be repaired through the API
+# (they cannot be read, updated or deleted), so scripts/repair_employee_enums.py
+# works in raw SQL. This proves the whole cycle: corrupt -> roster breaks ->
+# repair -> roster healthy.
+# ---------------------------------------------------------------------------
+
+
+def test_repair_script_recovers_a_bricked_roster(client, db_session):
+    from sqlalchemy import text
+
+    from scripts.repair_employee_enums import repair, scan
+
+    created = _make_employee(client, first_name="Ada", last_name="Lovelace")
+    assert created.status_code in (200, 201), created.text
+    emp_id = created.json()["id"]
+    assert client.get("/api/employees").status_code == 200
+
+    # Reproduce the pre-fix damage directly, since the API now refuses it.
+    db_session.execute(
+        text("UPDATE employees SET pay_type = :v WHERE id = :id"),
+        {"v": "sweep-pay_type", "id": emp_id},
+    )
+    db_session.commit()
+
+    found = scan(db_session)
+    assert any(f["id"] == emp_id for f in found), found
+    assert found[0]["invalid"]["pay_type"] == "sweep-pay_type"
+
+    repair(db_session, found)
+
+    assert scan(db_session) == []
+    row = db_session.execute(
+        text("SELECT pay_type FROM employees WHERE id = :id"), {"id": emp_id}
+    ).scalar()
+    assert row == "HOURLY"  # SQLAlchemy Enum persists the member NAME
+
+    # The roster reads again, which is the whole point.
+    assert client.get("/api/employees").status_code == 200
+    assert client.get(f"/api/employees/{emp_id}").status_code == 200
+
+
+def test_repair_script_is_a_noop_on_healthy_data(client, db_session):
+    from scripts.repair_employee_enums import scan
+
+    _make_employee(client, pay_type="salary", role="manager")
+    assert scan(db_session) == []

--- a/tests/test_api_defect_regressions.py
+++ b/tests/test_api_defect_regressions.py
@@ -1,0 +1,201 @@
+"""Regressions for defects found in a full-surface sweep of the 357-operation API.
+
+Each test corresponds to a specific observed failure, recorded here so the
+behaviour cannot silently return.
+"""
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def _bearer(token):
+    """Fresh cookie-less client so the Bearer path (not the session) auths."""
+    c = TestClient(app)
+    c.headers["Authorization"] = f"Bearer {token}"
+    return c
+
+
+def _mint(client, label="sweep", role="admin"):
+    r = client.post("/api/tokens", json={"label": label, "role": role})
+    assert r.status_code == 201, r.text
+    return r.json()["token"]
+
+
+# ---------------------------------------------------------------------------
+# Employee pay_type / role were bare strings while the columns are enums, so
+# an invalid value was written and then made the row permanently unreadable —
+# taking GET /api/employees down for the whole company.
+# ---------------------------------------------------------------------------
+
+
+def _make_employee(client, **over):
+    body = {"first_name": "Grace", "last_name": "Hopper"}
+    body.update(over)
+    return client.post("/api/employees", json=body)
+
+
+def test_invalid_pay_type_is_rejected_not_persisted(client):
+    r = _make_employee(client, pay_type="not-a-pay-type")
+    assert r.status_code == 422, r.text
+
+
+def test_invalid_role_is_rejected(client):
+    r = _make_employee(client, role="sweep-role")
+    assert r.status_code == 422, r.text
+
+
+def test_valid_pay_types_and_roles_still_accepted(client):
+    for pt in ("hourly", "salary"):
+        assert _make_employee(client, pay_type=pt).status_code in (200, 201)
+    for role in ("employee", "manager", "admin"):
+        assert _make_employee(client, role=role).status_code in (200, 201)
+
+
+def test_bad_update_cannot_brick_the_employee_roster(client):
+    """The original failure: one bad PUT made the record and the whole list
+    unreadable. The write must be refused and every read stay healthy."""
+    created = _make_employee(client)
+    assert created.status_code in (200, 201), created.text
+    emp_id = created.json()["id"]
+
+    bad = client.put(f"/api/employees/{emp_id}", json={"pay_type": "not-a-pay-type"})
+    assert bad.status_code == 422, bad.text
+
+    assert client.get(f"/api/employees/{emp_id}").status_code == 200
+    assert client.get("/api/employees").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Account constraint violations escaped as 500s instead of business errors.
+# ---------------------------------------------------------------------------
+
+
+def _mk_account(client, name, number=None, atype="asset"):
+    body = {"name": name, "account_type": atype}
+    if number:
+        body["account_number"] = number
+    return client.post("/api/accounts", json=body)
+
+
+def test_duplicate_account_number_on_create_is_409(client):
+    assert _mk_account(client, "First", "7001").status_code == 201
+    dup = _mk_account(client, "Second", "7001")
+    assert dup.status_code == 409, dup.text
+    assert "7001" in dup.json()["detail"]
+    assert "First" in dup.json()["detail"]
+
+
+def test_duplicate_account_number_on_update_is_409(client):
+    _mk_account(client, "Alpha", "7101")
+    b = _mk_account(client, "Beta", "7102").json()
+    r = client.put(f"/api/accounts/{b['id']}", json={"account_number": "7101"})
+    assert r.status_code == 409, r.text
+    assert "Alpha" in r.json()["detail"]
+
+
+def test_account_cannot_be_its_own_parent(client):
+    a = _mk_account(client, "Selfref", "7201").json()
+    r = client.put(f"/api/accounts/{a['id']}", json={"parent_id": a["id"]})
+    assert r.status_code == 400, r.text
+
+
+def test_delete_account_with_postings_is_409_not_500(client):
+    debit = _mk_account(client, "Sweep Debit", "7301").json()
+    credit = _mk_account(client, "Sweep Credit", "7302", atype="income").json()
+    je = client.post(
+        "/api/journal",
+        json={
+            "date": "2026-08-01",
+            "description": "regression posting",
+            "lines": [
+                {"account_id": debit["id"], "debit": "50.00", "credit": "0"},
+                {"account_id": credit["id"], "debit": "0", "credit": "50.00"},
+            ],
+        },
+    )
+    assert je.status_code in (200, 201), je.text
+
+    r = client.delete(f"/api/accounts/{debit['id']}")
+    assert r.status_code == 409, r.text
+    detail = r.json()["detail"]
+    assert "Deactivate" in detail or "deactivate" in detail
+
+
+def test_delete_unused_account_still_works(client):
+    a = _mk_account(client, "Disposable", "7401").json()
+    assert client.delete(f"/api/accounts/{a['id']}").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# The closing-date lock could be switched off by the principal it constrains.
+# ---------------------------------------------------------------------------
+
+
+def test_token_cannot_clear_or_roll_back_closing_date(client):
+    assert (
+        client.put("/api/settings", json={"closing_date": "2026-06-30"}).status_code
+        == 200
+    )
+    tc = _bearer(_mint(client))
+
+    cleared = tc.put("/api/settings", json={"closing_date": ""})
+    assert cleared.status_code == 403, cleared.text
+
+    rolled = tc.put("/api/settings", json={"closing_date": "2026-01-01"})
+    assert rolled.status_code == 403, rolled.text
+
+    assert client.get("/api/settings").json()["closing_date"] == "2026-06-30"
+
+
+def test_token_may_still_tighten_the_closing_date(client):
+    client.put("/api/settings", json={"closing_date": "2026-06-30"})
+    tc = _bearer(_mint(client))
+    r = tc.put("/api/settings", json={"closing_date": "2026-07-31"})
+    assert r.status_code == 200, r.text
+
+
+def test_token_cannot_set_closing_date_password(client):
+    tc = _bearer(_mint(client))
+    r = tc.put("/api/settings", json={"closing_date_password": "agent-set-this"})
+    assert r.status_code == 403, r.text
+
+
+def test_session_user_may_still_clear_closing_date(client):
+    client.put("/api/settings", json={"closing_date": "2026-06-30"})
+    r = client.put("/api/settings", json={"closing_date": ""})
+    assert r.status_code == 200, r.text
+
+
+def test_token_settings_writes_are_otherwise_unaffected(client):
+    """The guard must not block unrelated settings updates once a lock is set."""
+    client.put("/api/settings", json={"closing_date": "2026-06-30"})
+    tc = _bearer(_mint(client))
+    r = tc.put("/api/settings", json={"company_name": "Still Editable LLC"})
+    assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# send_email() was called with a signature it no longer had, so emailing an
+# invoice raised TypeError -> 500 regardless of SMTP configuration.
+# ---------------------------------------------------------------------------
+
+
+def test_invoice_email_does_not_raise_typeerror(client, seed_customer):
+    inv = client.post(
+        "/api/invoices",
+        json={
+            "customer_id": seed_customer.id,
+            "date": "2026-08-01",
+            "lines": [{"description": "x", "quantity": "1", "rate": "10.00"}],
+        },
+    )
+    assert inv.status_code in (200, 201), inv.text
+    r = client.post(
+        f"/api/invoices/{inv.json()['id']}/email",
+        json={"recipient": "someone@example.com"},
+    )
+    # SMTP is unconfigured under test, so a clean 502 is the expected outcome.
+    # What must never come back is the old TypeError surfacing as a 500.
+    assert r.status_code != 500, r.text
+    assert "unexpected keyword argument" not in r.text


### PR DESCRIPTION
Follow-up to the end-to-end shakedown. Every operation in `/openapi.json` was
driven against two companies; this fixes what that surfaced, plus the lint
failure my earlier direct push left on `main`.

## First: `main` is currently red

`6c82e9a` failed the **Lint (black + ruff)** job — one blank line too many in
`app/schemas/common.py`. CodeQL passed on both of my earlier commits; it was
`black --check` that went red. The first commit here fixes it, so merging this
returns `main` to green.

## Critical — one call could permanently brick an employee record

`pay_type` and `role` were declared as bare `str` on `EmployeeCreate` /
`EmployeeUpdate`, while the columns are `Enum(PayType)` / `Enum(EmployeeRole)`.
An invalid value was accepted, written, and then made the row unreadable:

```
PUT /api/employees/3 {"pay_type":"not-a-pay-type"}  -> 500, value written
GET /api/employees/3                                -> 500
GET /api/employees   (the whole roster)             -> 500
```

No recovery existed through the API — the row could not be read, updated or
deleted. And because the list loads in one query, **a single bad row took down
`GET /api/employees` for the entire company.**

The rule was already established two lines below the bug: `pay_frequency` and
`filing_status` carry the comment *"Typed against the model enums so a bad
value is a 422 at the edge instead of a LookupError at flush (an opaque 500)."*
`pay_type` and `role` were simply missed.

Proven by A/B during the sweep: the same 357 calls with a valid `pay_type`
left all eleven employee endpoints returning 200.

## Also fixed

| Defect | Was | Now |
|---|---|---|
| Emailing an invoice, and the SMTP "send test email" button | 500 `send_email() got an unexpected keyword argument 'settings'` | works; 502 with a pointer to the email log if SMTP fails |
| Delete an account holding ledger history | 500 | 409 naming the posting count, pointing at deactivation |
| Duplicate `account_number` (create *and* update) | 500 | 409 naming the account already using it |
| Account set as its own parent | accepted | 400 |
| API token clearing `closing_date` / setting the override password | allowed | 403 |
| Malformed email on customers/vendors | stored verbatim | 422 |
| `components.securitySchemes` | `{}` | declares the bearer scheme, public routes exempted |
| README "347-operation" | wrong | 357 |
| `.env.example` on `FORCE_HTTPS=false` | contradicted the startup check | corrected |

Two of these were latent rather than observed: `create_account` had the same
unguarded duplicate-number path as `update`, and the SMTP test-email button
was broken the same way as invoice email.

## Judgment calls worth reviewing

**The closing-date guard is scoped to token principals only.** Signed-in users
can still clear or move the date. Requiring the override password from a human
would lock out anyone who set one and forgot it, and the human is who the lock
exists to serve. Tokens may still move it *forward* — tightening is fine, only
loosening is refused. Happy to widen this if you'd rather it applied to
everyone.

**Email validation is a shape check, not `EmailStr`.** `EmailStr` needs the
`email-validator` package, and `requirements.txt` is pinned with per-line CVE
rationale — not a file to add a dependency to in passing. Say the word if
you'd prefer the real validator.

**`scripts/repair_employee_enums.py` repairs to the least-privileged role**
(`EMPLOYEE`) and leaves `pay_rate` untouched, so a mis-repaired salaried
employee stays visible for correction rather than being silently re-rated.

## Not included

- **`SlowBooksPro.exe --help` never exits** and leaks a headless process each
  call (one survived ~7 hours in testing). The launcher's argparse looks
  correct in source; the behaviour is specific to the frozen Windows build,
  which I can't reproduce or verify from here. Left alone rather than guess.
- **Blank names via the CSV/IIF importers** — those construct `Customer`/
  `Vendor` ORM objects directly, bypassing the schemas, so the earlier
  `NonBlankName` fix doesn't cover them.
- **8 audit rows with no acting principal** — needs a decision on whether
  machine-originated writes get a named `system` principal.
- **`llms.txt` operation count and its QuickBooks migration claim** live in the
  website repo, not this one. (README's "QuickBooks IIF round-trip" is
  accurate; `/api/migration/sources` genuinely has no QuickBooks entry.)

## Verification

- **1156 tests pass** (1139 existing + 17 new), `black --check` and `ruff`
  clean — the exact commands the CI lint job runs.
- New `tests/test_api_defect_regressions.py` covers every fix, including that
  a bad `PUT` can no longer brick the roster.
- The repair-script test earned its keep immediately: an earlier draft repaired
  to the enum *value* (`"hourly"`) when SQLAlchemy persists the member *name*
  (`"HOURLY"`), which would have left every "repaired" row exactly as
  unreadable. The test caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AkYRaEb6yQsvmXDwnUiStw