### PR TITLE
Close out the sweep findings and prep v2.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
+### v2.5.3 — API hardening, from a full-surface sweep
+
+Every one of the API's 357 operations was driven end-to-end on Windows
+(installer) and Linux (source, PostgreSQL 17); everything that surfaced is
+fixed here. No schema migrations; drop-in upgrade from 2.5.x.
+
+**Data-integrity fixes**
+
+- An invalid `pay_type` or `role` on an employee was written as-is and then
+  made the row permanently unreadable — one bad `PUT` returned 500 for the
+  record *and* for `GET /api/employees` company-wide, with no API-level
+  recovery. Both fields are now validated as enums (422 at the edge), the
+  same treatment `pay_frequency` and `filing_status` already had. For rows
+  corrupted before the fix, `scripts/repair_employee_enums.py` repairs in
+  raw SQL (dry-run by default; `--apply` to write).
+- The migration dry-run tolerated a one-cent journal imbalance the importer
+  then refused, so `ok=true` could precede a mid-import 500. The gate now
+  applies the importer's exact-balance rule, including to synthesized
+  opening-balance journals.
+- Customer and vendor names: blank/whitespace-only names rejected, lengths
+  capped to the column width (was: opaque 500 on PostgreSQL, silent
+  overflow on SQLite), obviously malformed emails rejected. The CSV and
+  IIF importers honor the same rules — an IIF transaction with a blank
+  NAME no longer auto-creates an unnamed customer.
+
+**Correctness / API behavior**
+
+- Emailing an invoice (and Settings → "send test email") called
+  `send_email()` with a stale signature and could never succeed; both now
+  work, report 502 with a pointer to the email log when SMTP fails, and no
+  longer double-log.
+- Account endpoints return 409 with a real message instead of leaking
+  database errors as 500s (delete-with-history, duplicate account number);
+  an account can no longer be made its own parent.
+- `/openapi.json` no longer requires auth, so the documented agent flow
+  ("discover from the spec") works; the spec now declares its bearer
+  security scheme, with genuinely public routes exempted.
+- API tokens can no longer clear or roll back the closing date, nor set
+  the closing-date override password; moving the date forward (tightening)
+  is still allowed, and signed-in users are unaffected.
+- Machine-originated audit rows (e.g. the token `last_used_at` stamp) are
+  attributed to an explicit `system` principal instead of NULL.
+- `SlowBooksPro.exe --help` with piped/redirected output hung the frozen
+  Windows build forever on an invisible error dialog (UnicodeEncodeError
+  under cp1252 inside argparse). Launcher stdio is now total; verified on
+  Windows before/after.
+
+**Docs**
+
+- INSTALL.md's native Linux path works as written on PEP 668 distros
+  (venv steps, `.env` honored by alembic, APP_DEBUG guidance);
+  `.env.example` no longer recommends a FORCE_HTTPS setting the app
+  refuses to boot with; README operation count corrected.
+
+17 new regression tests (1159 total).
+
 ### Native macOS desktop
 
 - Added a signed and Apple-notarized native app for Apple Silicon Macs running

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 # Single source of truth for the application version: app/main.py reports
 # it on the FastAPI app and /health, /api/system serves it to the frontend
 # footer, and the Windows release workflow parses it for the installer.
-__version__ = "2.5.2"
+__version__ = "2.5.3"

--- a/app/services/audit.py
+++ b/app/services/audit.py
@@ -17,7 +17,13 @@ def _actor(session) -> str | None:
     travels with the object, immune to task/context propagation quirks),
     falling back to the request contextvar for sessions created outside
     the request cycle."""
-    return session.info.get("acting_username") or acting_username.get()
+    # Fall back to an explicit "system" principal rather than NULL. A
+    # tamper-evident trail with anonymous rows is weaker than it looks:
+    # NULL is ambiguous between "the system did it" (token last_used_at
+    # stamps, startup writes) and "attribution failed". Naming the machine
+    # principal makes the distinction auditable — a NULL username is now
+    # always a bug, never a normal state.
+    return session.info.get("acting_username") or acting_username.get() or "system"
 
 
 # Tables to skip auditing.

--- a/app/services/csv_import.py
+++ b/app/services/csv_import.py
@@ -29,7 +29,7 @@ def import_customers(db: Session, csv_text: str) -> dict:
 
     for i, row in enumerate(reader, start=2):
         try:
-            name = row.get("Name", "").strip()
+            name = row.get("Name", "").strip()[:200]
             if not name:
                 errors.append(f"Row {i}: Missing name")
                 continue
@@ -69,7 +69,7 @@ def import_vendors(db: Session, csv_text: str) -> dict:
 
     for i, row in enumerate(reader, start=2):
         try:
-            name = row.get("Name", "").strip()
+            name = row.get("Name", "").strip()[:200]
             if not name:
                 errors.append(f"Row {i}: Missing name")
                 continue
@@ -116,7 +116,7 @@ def import_items(db: Session, csv_text: str) -> dict:
 
     for i, row in enumerate(reader, start=2):
         try:
-            name = row.get("Name", "").strip()
+            name = row.get("Name", "").strip()[:200]
             if not name:
                 errors.append(f"Row {i}: Missing name")
                 continue

--- a/app/services/iif_import.py
+++ b/app/services/iif_import.py
@@ -439,7 +439,7 @@ def import_customers(db: Session, rows: list) -> dict:
     for i, row in enumerate(rows):
         sp = db.begin_nested()
         try:
-            name = row.get("NAME", "").strip()
+            name = row.get("NAME", "").strip()[:200]
             if not name:
                 errors.append({"row": i + 1, "message": "Missing customer NAME"})
                 sp.rollback()
@@ -492,7 +492,7 @@ def import_vendors(db: Session, rows: list) -> dict:
     for i, row in enumerate(rows):
         sp = db.begin_nested()
         try:
-            name = row.get("NAME", "").strip()
+            name = row.get("NAME", "").strip()[:200]
             if not name:
                 errors.append({"row": i + 1, "message": "Missing vendor NAME"})
                 sp.rollback()
@@ -977,7 +977,13 @@ def _import_invoice(db: Session, trns: dict, spls: list) -> Invoice:
             return None
 
     # Resolve customer
-    cust_name = trns.get("NAME", "").strip()
+    cust_name = trns.get("NAME", "").strip()[:200]
+    if not cust_name:
+        # A TRNS row with no NAME cannot anchor an AR document, and auto-
+        # creating a Customer(name="") plants a record that is invisible in
+        # list views and unsearchable — the API refuses blank names since
+        # 6c82e9a, so the importer must not sneak them in the back door.
+        return None
     customer = db.query(Customer).filter(Customer.name == cust_name).first()
     if not customer:
         # Auto-create customer
@@ -1254,7 +1260,13 @@ def _import_estimate(db: Session, trns: dict, spls: list) -> Estimate:
         if existing:
             return None
 
-    cust_name = trns.get("NAME", "").strip()
+    cust_name = trns.get("NAME", "").strip()[:200]
+    if not cust_name:
+        # A TRNS row with no NAME cannot anchor an AR document, and auto-
+        # creating a Customer(name="") plants a record that is invisible in
+        # list views and unsearchable — the API refuses blank names since
+        # 6c82e9a, so the importer must not sneak them in the back door.
+        return None
     customer = db.query(Customer).filter(Customer.name == cust_name).first()
     if not customer:
         customer = Customer(name=cust_name, is_active=True)

--- a/desktop_launcher.py
+++ b/desktop_launcher.py
@@ -1159,6 +1159,23 @@ def run_smoke_test(port: int = 3999) -> int:
 
 
 def main() -> int:
+    # Make every stdio write total BEFORE argparse can print anything.
+    # A frozen console=False build launched with redirected stdio (any
+    # pipe: `SlowBooksPro.exe --help | ...`, CI, an agent) gets whatever
+    # encoding the handle reports — cp1252 on US Windows — and this
+    # module docstring, which argparse prints for --help, contains
+    # characters cp1252 cannot encode. print_help() then raised
+    # UnicodeEncodeError; unhandled in a windowed build, the bootloader
+    # parked the process on an error dialog nobody can see. Field
+    # report: one such process survived ~7 hours. With errors="replace"
+    # the worst case is a "?" instead of an arrow.
+    for _stream in (sys.stdout, sys.stderr):
+        if _stream is not None:
+            try:
+                _stream.reconfigure(errors="replace")
+            except (AttributeError, OSError):
+                pass  # not a TextIOWrapper (test harness, log redirect)
+
     # Not a user flag — the frozen server child (see start_server) and
     # argparse must never meet, so handle it before parsing.
     if "--_serve" in sys.argv:

--- a/tests/test_api_defect_regressions.py
+++ b/tests/test_api_defect_regressions.py
@@ -248,3 +248,72 @@ def test_repair_script_is_a_noop_on_healthy_data(client, db_session):
 
     _make_employee(client, pay_type="salary", role="manager")
     assert scan(db_session) == []
+
+
+# ---------------------------------------------------------------------------
+# Importers could create records the API itself refuses: an IIF TRNS row with
+# a blank NAME auto-created Customer(name=""), and oversized names bypassed
+# the schema length caps entirely (ORM objects are built directly).
+# ---------------------------------------------------------------------------
+
+BLANK_NAME_INVOICE_IIF = (
+    "!TRNS\tTRNSID\tTRNSTYPE\tDATE\tACCNT\tNAME\tAMOUNT\tDOCNUM\tTERMS\n"
+    "!SPL\tSPLID\tTRNSTYPE\tDATE\tACCNT\tNAME\tAMOUNT\tINVITEM\tQNTY\tPRICE\n"
+    "!ENDTRNS\n"
+    "TRNS\t1\tINVOICE\t2026-04-01\tAccounts Receivable\t\t50.00\tINV-BLANK\tNet 30\n"
+    "SPL\t2\tINVOICE\t2026-04-01\tService Income\t\t-50.00\t\t1\t50.00\n"
+    "ENDTRNS\n"
+)
+
+
+def test_iif_blank_name_does_not_create_blank_customer(db_session, seed_accounts):
+    from app.models.contacts import Customer
+    from app.services.iif_import import import_transactions, parse_iif
+
+    parsed = parse_iif(BLANK_NAME_INVOICE_IIF)
+    import_transactions(db_session, parsed["TRNS"])  # must not raise
+    db_session.commit()
+
+    blanks = db_session.query(Customer).filter(Customer.name == "").count()
+    assert blanks == 0
+
+
+def test_csv_import_clamps_oversized_customer_name(db_session):
+    from app.models.contacts import Customer
+    from app.services.csv_import import import_customers
+
+    csv_text = "Name,Email\n" + ("X" * 300) + ",big@example.com\n"
+    result = import_customers(db_session, csv_text)
+    assert result["created"] == 1, result
+
+    row = db_session.query(Customer).filter(Customer.name.like("X%")).one()
+    assert len(row.name) == 200
+
+
+# ---------------------------------------------------------------------------
+# Audit rows written outside a request principal (e.g. the api_tokens
+# last_used_at stamp) carried username=NULL — ambiguous between "the system
+# did it" and "attribution failed". They are now attributed to `system`.
+# ---------------------------------------------------------------------------
+
+
+def test_machine_writes_are_attributed_to_system(client, db_session):
+    from app.models.audit import AuditLog
+
+    token = _mint(client, label="attrib-probe", role="readonly")
+    tc = _bearer(token)
+    assert tc.get("/api/customers").status_code == 200
+
+    rows = (
+        db_session.query(AuditLog)
+        .filter(AuditLog.table_name == "api_tokens")
+        .order_by(AuditLog.id.desc())
+        .all()
+    )
+    assert rows, "expected audit rows for the token lifecycle"
+    assert all(r.username for r in rows), [(r.action, r.username) for r in rows]
+    # the last_used_at stamp specifically — previously NULL
+    upd = [r for r in rows if (r.action or "").upper() == "UPDATE"]
+    assert upd and all(r.username == "system" for r in upd), [
+        (r.action, r.username) for r in upd
+    ]


### PR DESCRIPTION
The remaining items from the full-surface API sweep, plus release prep. Five commits, reviewable independently.

## Fixes

**Importers no longer create records the API refuses** (`e3c0b78`)
An IIF `TRNS` row with a blank `NAME` auto-created `Customer(name=\"\")` while resolving invoices/estimates — the back door around the blank-name validation on `main`. Such rows are now skipped (same convention as the duplicate-DOCNUM skip). All CSV and IIF importers also clamp names to the `VARCHAR(200)` column; every affected model declares `String(200)`. The IIF *list* importers already validated correctly — only the transaction-side auto-create lacked the guard.

**Audit rows always name their principal** (`7e29f7c`)
8 of 195 sweep audit rows had `username=NULL` — mostly the `api_tokens.last_used_at` stamp written during bearer resolution, before any principal exists. `_actor()` now falls back to `system`, so NULL is always a bug, never a normal state. Regression test proves the token-stamp rows now read `system`.

**`--help` can no longer hang the frozen Windows build** (`0ab2303`)
Root-caused empirically on the installed 2.5.2 (SkyTech) and reproduced unfrozen (VonHolten308, Python 3.13.14):
1. the module docstring argparse prints contains `→`/`—`;
2. piped/redirected stdio gets cp1252, which can't encode them → `UnicodeEncodeError` *inside* `print_help()` (argparse only guards `AttributeError`/`OSError`);
3. unhandled in a `console=False` build, the PyInstaller bootloader parks the process on an error dialog nobody can see — the ~7-hour orphan.

Bare launches were never affected (stdout is `None` → argparse swallows → exit 0), which is why only scripts/agents/CI ever hit it. Fix: `reconfigure(errors=\"replace\")` on stdout/stderr before argparse — every stdio write becomes total; worst case a `?` instead of an arrow. Verified before/after on Windows: exit 1 + 0 help bytes → exit 0 + full help text. Frozen-build verification is running on VonHolten308; results will land as a PR comment.

## Release prep (`4885a17`)

- `__version__` → **2.5.3**
- CHANGELOG entry covering everything since 2.5.2 (both PRs)
- **No tag is created** — windows.yml/macos.yml fire on `tags: v*`, so nothing ships until you tag `v2.5.3`

## Verification

1159 tests pass (3 new), `black --check` + `ruff` clean — the exact CI lint commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AkYRaEb6yQsvmXDwnUiStw