### PR TITLE
Sales receipts: one-screen POS entry + QuickBooks import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
+### Sales receipts — one-screen POS sales + QuickBooks import
+
+For businesses that ring up sales at a counter instead of invoicing:
+a QuickBooks sales receipt is an invoice paid at the moment of sale,
+and SlowBooks now models it exactly that way — an Invoice flagged
+`is_sales_receipt` plus a Payment for the full total, so every
+existing report, PDF, export, and void path works unchanged. Schema
+migration `c7d8e9f0a1b2` adds the flag (drop-in; new databases need
+nothing).
+
+- **Enter Sales Receipts screen** — new sidebar page with a
+  one-screen form: customer (with quick-add), payment method,
+  check #/reference, deposit-to account (defaults to Undeposited
+  Funds), tax, class, currency, and line items. `POST
+  /api/sales-receipts` composes the existing invoice and payment
+  routes, so numbering, closing-date enforcement, FX, and
+  inventory/COGS behave identically to documents entered separately;
+  if the payment half fails the invoice half is voided rather than
+  left as a stray open balance. Receipts list on their own page and
+  no longer clutter the Invoices list (`GET
+  /api/invoices?is_sales_receipt=...` filters either way; omitting
+  the param returns everything, as before).
+- **IIF import: `CASH SALE` blocks** — QuickBooks Desktop's sales
+  receipts previously fell into the silently-skipped bucket. They now
+  import as paid invoice + payment with balanced journals (deposit
+  account from the TRNS header, Undeposited Funds fallback).
+  Counter sales with a blank Customer:Job land on an auto-created
+  "Walk-In Customer" (reported as a warning); unnumbered receipts get
+  the next invoice number, and re-imports dedup by document number or
+  customer + date + total.
+- **QBO import: SalesReceipt entity** — the QuickBooks Online
+  importer pulls sales receipts alongside invoices and payments, with
+  the same id-mapping dedup; the QBO page gets a Sales Receipts
+  import checkbox (import-only — there is no matching export entity).
+- **docs/migrate-from-quickbooks.md** — new guide covering both
+  paths, including the fact that Desktop's built-in IIF export is
+  lists-only and the clean Transaction Detail report recipe for
+  getting sales history out.
+
 ### v2.5.3 — API hardening, from a full-surface sweep
 
 Every one of the API's 357 operations was driven end-to-end on Windows

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Full catalog (300+ entries) in **[docs/features.md](docs/features.md)**. Highlig
 - **Online payments** — [Stripe](docs/setup-stripe.md),
   [PayPal](docs/setup-paypal.md), [Square](docs/setup-square.md) behind
   one abstraction, desktop-mode recording included
-- **Interop & migration** — QuickBooks IIF round-trip,
+- **Interop & migration** — QuickBooks IIF round-trip incl. sales
+  receipts ([docs/migrate-from-quickbooks.md](docs/migrate-from-quickbooks.md)),
   [QBO OAuth sync](docs/setup-qbo.md), Migrate Data for Xero / MYOB /
   Sage 50 / Wave / Zoho Books / GnuCash, Opening Balances wizard
 - **Fixed assets** — register, depreciation runs, disposal with

--- a/app/main.py
+++ b/app/main.py
@@ -36,6 +36,7 @@ from app.routes import (
     invoices,
     estimates,
     payments,
+    sales_receipts,
     banking,
     reports,
     settings,
@@ -506,6 +507,7 @@ app.include_router(items.router)
 app.include_router(invoices.router)
 app.include_router(estimates.router)
 app.include_router(payments.router)
+app.include_router(sales_receipts.router)
 app.include_router(banking.router)
 app.include_router(reports.router)
 app.include_router(settings.router)

--- a/app/models/invoices.py
+++ b/app/models/invoices.py
@@ -10,6 +10,7 @@ import enum
 import uuid
 
 from sqlalchemy import (
+    Boolean,
     Column,
     Integer,
     String,
@@ -19,6 +20,7 @@ from sqlalchemy import (
     Text,
     Enum,
     ForeignKey,
+    false,
     func,
 )
 from sqlalchemy.orm import relationship
@@ -88,6 +90,14 @@ class Invoice(Base):
 
     # Class tracking dimension (QB-style); NULL groups with Uncategorized
     class_id = Column(Integer, ForeignKey("classes.id"), nullable=True)
+
+    # Sales receipt = invoice + payment entered as one step (QB's "Enter
+    # Sales Receipts"). Stored as a regular Invoice so reports, PDFs, and
+    # exports need no special casing; the flag drives the dedicated list
+    # and QB interop typing.
+    is_sales_receipt = Column(
+        Boolean, nullable=False, default=False, server_default=false(), index=True
+    )
 
     # Multi-currency: document currency + rate it was booked at (GL is home)
     currency = Column(String(3), nullable=True)

--- a/app/routes/invoices/crud.py
+++ b/app/routes/invoices/crud.py
@@ -34,6 +34,7 @@ from app.routes.invoices.helpers import (
 def list_invoices(
     status: str = None,
     customer_id: int = None,
+    is_sales_receipt: bool = None,
     skip: int = 0,
     limit: int = 500,
     db: Session = Depends(get_db),
@@ -51,6 +52,8 @@ def list_invoices(
         q = q.filter(Invoice.status == status)
     if customer_id:
         q = q.filter(Invoice.customer_id == customer_id)
+    if is_sales_receipt is not None:
+        q = q.filter(Invoice.is_sales_receipt == is_sales_receipt)
     invoices = q.order_by(Invoice.date.desc()).offset(skip).limit(limit).all()
     results = []
     for inv in invoices:

--- a/app/routes/qbo.py
+++ b/app/routes/qbo.py
@@ -105,6 +105,7 @@ _IMPORT_ENTITY_MAP = {
     "items": qbo_import.import_items,
     "invoices": qbo_import.import_invoices,
     "payments": qbo_import.import_payments,
+    "sales_receipts": qbo_import.import_sales_receipts,
 }
 
 

--- a/app/routes/sales_receipts.py
+++ b/app/routes/sales_receipts.py
@@ -1,0 +1,97 @@
+# ============================================================================
+# Enter Sales Receipts — invoice + payment recorded as one step, for
+# point-of-sale style transactions where payment happens at the sale.
+#
+# Composes the existing invoice and payment routes rather than re-posting
+# journals itself, so numbering, closing-date checks, FX, inventory/COGS,
+# and void semantics stay identical to documents entered separately.
+# ============================================================================
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.accounts import Account
+from app.models.invoices import Invoice
+from app.routes.invoices.crud import create_invoice, get_invoice
+from app.routes.invoices.helpers import _compute_totals
+from app.routes.invoices.lifecycle import void_invoice
+from app.routes.payments import create_payment
+from app.schemas.invoices import InvoiceCreate
+from app.schemas.payments import PaymentAllocationCreate, PaymentCreate
+from app.schemas.sales_receipts import SalesReceiptCreate, SalesReceiptResponse
+
+router = APIRouter(prefix="/api/sales-receipts", tags=["sales-receipts"])
+
+
+@router.post("", response_model=SalesReceiptResponse, status_code=201)
+def create_sales_receipt(data: SalesReceiptCreate, db: Session = Depends(get_db)):
+    # Validate up front so nothing is written on inputs the payment step
+    # would reject after the invoice already exists: a $0 payment is
+    # refused by the payments route, and a bad deposit account would only
+    # surface when its journal posts.
+    _, _, total = _compute_totals(data.lines, data.tax_rate)
+    if total <= 0:
+        raise HTTPException(
+            status_code=400,
+            detail="Sales receipt total must be positive; add at least one "
+            "line with an amount",
+        )
+    if data.deposit_to_account_id is not None:
+        acct = (
+            db.query(Account).filter(Account.id == data.deposit_to_account_id).first()
+        )
+        if not acct:
+            raise HTTPException(status_code=404, detail="Deposit account not found")
+
+    inv_resp = create_invoice(
+        InvoiceCreate(
+            customer_id=data.customer_id,
+            date=data.date,
+            due_date=data.date,
+            terms="Due on Receipt",
+            tax_rate=data.tax_rate,
+            notes=data.notes,
+            class_id=data.class_id,
+            currency=data.currency,
+            exchange_rate=data.exchange_rate,
+            lines=data.lines,
+        ),
+        db,
+    )
+    invoice = db.query(Invoice).filter(Invoice.id == inv_resp.id).first()
+    invoice.is_sales_receipt = True
+    db.commit()
+
+    try:
+        pay_resp = create_payment(
+            PaymentCreate(
+                customer_id=data.customer_id,
+                date=data.date,
+                amount=inv_resp.total,
+                method=data.method,
+                check_number=data.check_number,
+                reference=data.reference,
+                deposit_to_account_id=data.deposit_to_account_id,
+                currency=data.currency,
+                exchange_rate=data.exchange_rate,
+                allocations=[
+                    PaymentAllocationCreate(
+                        invoice_id=inv_resp.id, amount=inv_resp.total
+                    )
+                ],
+            ),
+            db,
+        )
+    except Exception:
+        # The invoice committed but its payment didn't: void the invoice so
+        # a failed receipt never leaves a stray open balance, then surface
+        # the original error.
+        db.rollback()
+        try:
+            void_invoice(inv_resp.id, db)
+        except Exception:
+            pass
+        raise
+
+    return SalesReceiptResponse(invoice=get_invoice(inv_resp.id, db), payment=pay_resp)

--- a/app/schemas/iif.py
+++ b/app/schemas/iif.py
@@ -8,6 +8,7 @@ class IIFImportResult(BaseModel):
     items: int = 0
     invoices: int = 0
     payments: int = 0
+    sales_receipts: int = 0
     estimates: int = 0
     bills: int = 0
     deposits: int = 0

--- a/app/schemas/invoices.py
+++ b/app/schemas/invoices.py
@@ -109,6 +109,7 @@ class InvoiceResponse(BaseModel):
     balance_due: Decimal
     notes: Optional[str]
     class_id: Optional[int] = None
+    is_sales_receipt: bool = False
     currency: Optional[str] = None
     exchange_rate: Optional[Decimal] = None
     payment_token: Optional[str] = None

--- a/app/schemas/qbo.py
+++ b/app/schemas/qbo.py
@@ -8,6 +8,7 @@ class QBOImportResult(BaseModel):
     items: int = 0
     invoices: int = 0
     payments: int = 0
+    sales_receipts: int = 0
     errors: list[dict] = []
 
 

--- a/app/schemas/sales_receipts.py
+++ b/app/schemas/sales_receipts.py
@@ -1,0 +1,39 @@
+from datetime import date as dt_date
+from decimal import Decimal
+from typing import Optional
+
+from pydantic import BaseModel, field_validator
+
+from app.schemas.invoices import InvoiceLineCreate, InvoiceResponse
+from app.schemas.payments import PaymentResponse
+
+
+class SalesReceiptCreate(BaseModel):
+    """One-screen sales receipt: an invoice and its full payment entered
+    together (QB's "Enter Sales Receipts"). No terms/due date — payment is
+    at the time of sale."""
+
+    customer_id: int
+    date: dt_date
+    tax_rate: Decimal = Decimal("0")
+    method: Optional[str] = None
+    check_number: Optional[str] = None
+    reference: Optional[str] = None
+    deposit_to_account_id: Optional[int] = None
+    notes: Optional[str] = None
+    class_id: Optional[int] = None
+    currency: Optional[str] = None
+    exchange_rate: Optional[Decimal] = None
+    lines: list[InvoiceLineCreate] = []
+
+    @field_validator("lines")
+    @classmethod
+    def _require_lines(cls, v):
+        if not v:
+            raise ValueError("sales receipt must have at least one line")
+        return v
+
+
+class SalesReceiptResponse(BaseModel):
+    invoice: InvoiceResponse
+    payment: PaymentResponse

--- a/app/services/iif_import.py
+++ b/app/services/iif_import.py
@@ -591,13 +591,15 @@ def import_items(db: Session, rows: list) -> dict:
 def import_transactions(db: Session, blocks: list) -> dict:
     """Import transaction blocks (TRNS/SPL/ENDTRNS) from IIF.
 
-    Routes by TRNSTYPE: INVOICE, PAYMENT, ESTIMATE, BILL, DEPOSIT.
-    Other types (GENERAL JOURNAL, etc.) are silently skipped — extend
-    the dispatch table here when adding support.
+    Routes by TRNSTYPE: INVOICE, PAYMENT, ESTIMATE, BILL, DEPOSIT,
+    CASH SALE (QB's sales receipts). Other types (GENERAL JOURNAL, etc.)
+    are silently skipped — extend the dispatch table here when adding
+    support.
     """
     counts = {
         "invoices": 0,
         "payments": 0,
+        "sales_receipts": 0,
         "estimates": 0,
         "bills": 0,
         "deposits": 0,
@@ -630,6 +632,22 @@ def import_transactions(db: Session, blocks: list) -> dict:
                         warnings.append(
                             f"Payment block {i+1}: imported but journal entry could not be created (account mismatch)"
                         )
+            elif trns_type in ("CASH SALE", "CASHSALE", "SALES RECEIPT"):
+                if not trns.get("NAME", "").strip():
+                    warnings.append(
+                        f"Sales receipt block {i + 1}: no customer name; "
+                        f"assigned to '{WALK_IN_CUSTOMER_NAME}'"
+                    )
+                result = _import_cash_sale(db, trns, spls)
+                if result:
+                    counts["sales_receipts"] += 1
+                    if not result.transaction_id:
+                        doc = result.invoice_number or f"block {i+1}"
+                        warnings.append(
+                            f"Sales receipt {doc}: imported but journal entry could not be created (account mismatch)"
+                        )
+                else:
+                    counts["duplicates_skipped"] += 1
             elif trns_type == "ESTIMATE":
                 result = _import_estimate(db, trns, spls)
                 if result:
@@ -1249,6 +1267,119 @@ def _import_payment(db: Session, trns: dict, spls: list) -> Payment:
     return payment
 
 
+# QB allows sales receipts with a blank Customer:Job (counter sales); an
+# Invoice row can't. Blank-name CASH SALE blocks land on this named bucket
+# customer — a real, visible record, unlike the blank-name auto-creates
+# the importer refuses elsewhere.
+WALK_IN_CUSTOMER_NAME = "Walk-In Customer"
+
+
+def _import_cash_sale(db: Session, trns: dict, spls: list) -> Invoice:
+    """Create a paid invoice + payment from an IIF CASH SALE block.
+
+    QB writes sales receipts as TRNSTYPE "CASH SALE": the TRNS line debits
+    the deposit account (bank / Undeposited Funds) where an INVOICE block
+    would debit A/R, and SPL lines credit income/tax exactly like an
+    invoice. Imported as an invoice flagged is_sales_receipt plus a
+    same-day payment for the full total — the same pair of documents the
+    Enter Sales Receipts screen produces, so void/report behavior matches.
+    """
+    trns = dict(trns)
+    if not trns.get("NAME", "").strip():
+        trns["NAME"] = WALK_IN_CUSTOMER_NAME
+    if not trns.get("TERMS", "").strip():
+        trns["TERMS"] = "Due on Receipt"
+
+    if not trns.get("DOCNUM", "").strip():
+        # POS receipts are often unnumbered. Dedup on customer + date +
+        # amount (the DOCNUM-less analogue of _import_payment's check),
+        # then let the numbering service assign the next number.
+        cust_name = trns.get("NAME", "").strip()[:200]
+        sale_date = _parse_iif_date(trns.get("DATE", "")) or date.today()
+        total = abs(_parse_decimal(trns.get("AMOUNT", "")))
+        existing = (
+            db.query(Invoice)
+            .join(Customer, Invoice.customer_id == Customer.id)
+            .filter(
+                Customer.name == cust_name,
+                Invoice.date == sale_date,
+                Invoice.total == total,
+                Invoice.is_sales_receipt.is_(True),
+            )
+            .first()
+        )
+        if existing:
+            return None
+        from app.services.numbering import next_invoice_number
+
+        trns["DOCNUM"] = next_invoice_number(db)
+
+    invoice = _import_invoice(db, trns, spls)
+    if invoice is None:
+        return None
+    invoice.is_sales_receipt = True
+
+    # Deposit side: TRNS.ACCNT is the bank / Undeposited Funds account the
+    # receipt deposited to. Same fallback chain as _import_payment.
+    deposit_acct = _find_account(db, trns.get("ACCNT", "").strip())
+    if not deposit_acct:
+        from app.services.accounting import get_undeposited_funds_id
+
+        uf_id = get_undeposited_funds_id(db)
+        if uf_id:
+            deposit_acct = db.query(Account).filter(Account.id == uf_id).first()
+
+    total = Decimal(str(invoice.total))
+    payment = Payment(
+        customer_id=invoice.customer_id,
+        date=invoice.date,
+        amount=total,
+        method=trns.get("PAYMETH", "").strip() or None,
+        reference=invoice.invoice_number,
+        deposit_to_account_id=deposit_acct.id if deposit_acct else None,
+    )
+    db.add(payment)
+    db.flush()
+    db.add(
+        PaymentAllocation(payment_id=payment.id, invoice_id=invoice.id, amount=total)
+    )
+    invoice.amount_paid = total
+    invoice.balance_due = Decimal("0")
+    invoice.status = InvoiceStatus.PAID
+
+    # Payment journal: DR deposit account / CR A/R, clearing the A/R debit
+    # _import_invoice posted — the ledger nets to cash + income, matching
+    # the app's own sales-receipt flow.
+    ar_id = get_ar_account_id(db)
+    if ar_id and deposit_acct and total > 0:
+        journal_lines = [
+            {
+                "account_id": deposit_acct.id,
+                "debit": total,
+                "credit": Decimal("0"),
+                "description": f"Sales receipt {invoice.invoice_number}",
+            },
+            {
+                "account_id": ar_id,
+                "debit": Decimal("0"),
+                "credit": total,
+                "description": f"Sales receipt {invoice.invoice_number}",
+            },
+        ]
+        txn = create_journal_entry(
+            db,
+            invoice.date,
+            f"IIF Import — Sales receipt {invoice.invoice_number}",
+            journal_lines,
+            source_type="payment",
+            source_id=payment.id,
+        )
+        payment.transaction_id = txn.id
+
+    db.flush()
+    return invoice
+
+
 def _import_estimate(db: Session, trns: dict, spls: list) -> Estimate:
     """Create an Estimate from IIF TRNS/SPL data."""
     doc_num = trns.get("DOCNUM", "").strip()
@@ -1498,6 +1629,7 @@ def import_all(db: Session, content: str) -> dict:
         "items": 0,
         "invoices": 0,
         "payments": 0,
+        "sales_receipts": 0,
         "estimates": 0,
         "bills": 0,
         "deposits": 0,
@@ -1538,6 +1670,7 @@ def import_all(db: Session, content: str) -> dict:
         counts = r["imported"]
         result["invoices"] = counts.get("invoices", 0)
         result["payments"] = counts.get("payments", 0)
+        result["sales_receipts"] = counts.get("sales_receipts", 0)
         result["estimates"] = counts.get("estimates", 0)
         result["bills"] = counts.get("bills", 0)
         result["deposits"] = counts.get("deposits", 0)

--- a/app/services/qbo_import.py
+++ b/app/services/qbo_import.py
@@ -734,6 +734,203 @@ def import_payments(db: Session) -> dict:
     return {"imported": imported, "errors": errors}
 
 
+def import_sales_receipts(db: Session) -> dict:
+    """Import sales receipts from QBO into Slowbooks.
+
+    QBO's SalesReceipt is an invoice paid at the time of sale. Each one
+    becomes an Invoice flagged is_sales_receipt (status PAID) plus a
+    Payment for the full total — the same document pair the Enter Sales
+    Receipts screen produces.
+    """
+    from quickbooks.objects.salesreceipt import SalesReceipt as QBOSalesReceipt
+
+    client = get_qbo_client(db)
+    imported = 0
+    errors = []
+
+    try:
+        qbo_receipts = QBOSalesReceipt.all(qb=client)
+    except Exception as e:
+        errors.append(
+            {"entity": "sales_receipts", "message": f"Failed to query QBO: {str(e)}"}
+        )
+        return {"imported": 0, "errors": errors}
+
+    for qbo_sr in qbo_receipts:
+        try:
+            qbo_id = _safe(qbo_sr, "Id", "")
+            if not qbo_id:
+                continue
+
+            if get_mapping_by_qbo_id(db, "sales_receipt", qbo_id):
+                continue
+
+            doc_num = _safe(qbo_sr, "DocNumber", "")
+
+            # Dedup by document number against existing invoices/receipts
+            if doc_num:
+                existing = (
+                    db.query(Invoice).filter(Invoice.invoice_number == doc_num).first()
+                )
+                if existing:
+                    create_mapping(
+                        db,
+                        "sales_receipt",
+                        existing.id,
+                        qbo_id,
+                        _safe(qbo_sr, "SyncToken"),
+                    )
+                    db.flush()
+                    continue
+
+            # Resolve customer
+            cust_ref = _safe(qbo_sr, "CustomerRef")
+            customer_id = None
+            if cust_ref:
+                cust_qbo_id = _safe(cust_ref, "value", "")
+                cust_map = get_mapping_by_qbo_id(db, "customer", cust_qbo_id)
+                if cust_map:
+                    customer_id = cust_map.slowbooks_id
+
+            if not customer_id:
+                cust_name = _safe(cust_ref, "name", "") if cust_ref else ""
+                if cust_name:
+                    cust = db.query(Customer).filter(Customer.name == cust_name).first()
+                    if cust:
+                        customer_id = cust.id
+                if not customer_id:
+                    errors.append(
+                        {
+                            "entity": "sales_receipt",
+                            "qbo_id": str(qbo_id),
+                            "message": "Customer not found",
+                        }
+                    )
+                    continue
+
+            total_amt = _safe_decimal(qbo_sr, "TotalAmt")
+            sr_date = _parse_qbo_date(_safe(qbo_sr, "TxnDate"))
+
+            # Extract tax
+            tax_amount = Decimal("0")
+            txn_tax = _safe(qbo_sr, "TxnTaxDetail")
+            if txn_tax:
+                tax_amount = _safe_decimal(txn_tax, "TotalTax")
+
+            if not doc_num:
+                from app.services.numbering import next_invoice_number
+
+                doc_num = next_invoice_number(db)
+
+            invoice = Invoice(
+                invoice_number=doc_num,
+                customer_id=customer_id,
+                date=sr_date,
+                due_date=sr_date,
+                terms="Due on Receipt",
+                status=InvoiceStatus.PAID,
+                is_sales_receipt=True,
+                subtotal=total_amt - tax_amount,
+                tax_rate=Decimal("0"),
+                tax_amount=tax_amount,
+                total=total_amt,
+                amount_paid=total_amt,
+                balance_due=Decimal("0"),
+                notes=(
+                    _safe(qbo_sr, "CustomerMemo", {}).get("value")
+                    if isinstance(_safe(qbo_sr, "CustomerMemo"), dict)
+                    else None
+                ),
+            )
+            db.add(invoice)
+            db.flush()
+
+            # Process line items — only SalesItemLineDetail
+            line_order = 0
+            lines = _safe(qbo_sr, "Line") or []
+            for qbo_line in lines:
+                detail_type = _safe(qbo_line, "DetailType", "")
+                if detail_type != "SalesItemLineDetail":
+                    continue  # Skip SubTotalLineDetail, DiscountLineDetail, etc.
+
+                detail = _safe(qbo_line, "SalesItemLineDetail")
+                if not detail:
+                    continue
+
+                item_id = None
+                item_ref = _safe(detail, "ItemRef")
+                if item_ref:
+                    item_qbo_id = _safe(item_ref, "value", "")
+                    item_map = get_mapping_by_qbo_id(db, "item", item_qbo_id)
+                    if item_map:
+                        item_id = item_map.slowbooks_id
+
+                qty = _safe_decimal(detail, "Qty") or Decimal("1")
+                rate = _safe_decimal(detail, "UnitPrice")
+                amount = _safe_decimal(qbo_line, "Amount")
+
+                inv_line = InvoiceLine(
+                    invoice_id=invoice.id,
+                    item_id=item_id,
+                    description=_safe(qbo_line, "Description") or None,
+                    quantity=qty,
+                    rate=rate,
+                    amount=amount,
+                    line_order=line_order,
+                )
+                db.add(inv_line)
+                line_order += 1
+
+            # Payment for the full total, deposited where QBO says
+            deposit_account_id = None
+            deposit_ref = _safe(qbo_sr, "DepositToAccountRef")
+            if deposit_ref:
+                deposit_qbo_id = _safe(deposit_ref, "value", "")
+                deposit_map = get_mapping_by_qbo_id(db, "account", deposit_qbo_id)
+                if deposit_map:
+                    deposit_account_id = deposit_map.slowbooks_id
+
+            payment = Payment(
+                customer_id=customer_id,
+                date=sr_date,
+                amount=total_amt,
+                method=(
+                    _safe(qbo_sr, "PaymentMethodRef", {}).get("name")
+                    if isinstance(_safe(qbo_sr, "PaymentMethodRef"), dict)
+                    else None
+                ),
+                reference=_safe(qbo_sr, "PaymentRefNum") or None,
+                deposit_to_account_id=deposit_account_id,
+            )
+            db.add(payment)
+            db.flush()
+            db.add(
+                PaymentAllocation(
+                    payment_id=payment.id, invoice_id=invoice.id, amount=total_amt
+                )
+            )
+
+            create_mapping(
+                db, "sales_receipt", invoice.id, qbo_id, _safe(qbo_sr, "SyncToken")
+            )
+
+            # Same inventory treatment as QBO-imported invoices
+            db.flush()
+            db.refresh(invoice)
+            from app.services.inventory_hooks import post_sale_for_invoice
+
+            post_sale_for_invoice(db, invoice, txn_date=invoice.date)
+
+            imported += 1
+
+        except Exception as e:
+            errors.append(
+                {"entity": "sales_receipt", "qbo_id": str(qbo_id), "message": str(e)}
+            )
+
+    return {"imported": imported, "errors": errors}
+
+
 # ============================================================================
 # Master import orchestrator
 # ============================================================================
@@ -751,6 +948,7 @@ def import_all(db: Session) -> dict:
         "items": 0,
         "invoices": 0,
         "payments": 0,
+        "sales_receipts": 0,
         "errors": [],
     }
 
@@ -782,6 +980,11 @@ def import_all(db: Session) -> dict:
     # 6. Payments
     r = import_payments(db)
     result["payments"] = r["imported"]
+    result["errors"].extend(r["errors"])
+
+    # 7. Sales receipts (self-contained invoice + payment pairs)
+    r = import_sales_receipts(db)
+    result["sales_receipts"] = r["imported"]
     result["errors"].extend(r["errors"])
 
     db.commit()

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -9,6 +9,7 @@ const App = {
         '/vendors':       { page: 'vendors',         label: 'Vendor Center',      render: () => VendorsPage.render() },
         '/items':         { page: 'items',           label: 'Item List',          render: () => ItemsPage.render() },
         '/invoices':      { page: 'invoices',        label: 'Create Invoices',    render: () => InvoicesPage.render() },
+        '/sales-receipts': { page: 'sales-receipts', label: 'Enter Sales Receipts', render: () => SalesReceiptsPage.render() },
         '/estimates':     { page: 'estimates',       label: 'Create Estimates',   render: () => EstimatesPage.render() },
         '/payments':      { page: 'payments',        label: 'Receive Payments',   render: () => PaymentsPage.render() },
         '/banking':       { page: 'banking',         label: 'Bank Accounts',      render: () => BankingPage.render() },

--- a/app/static/js/iif.js
+++ b/app/static/js/iif.js
@@ -313,6 +313,7 @@ const IIFPage = {
             const total = (result.accounts || 0) + (result.customers || 0) +
                           (result.vendors || 0) + (result.items || 0) +
                           (result.invoices || 0) + (result.payments || 0) +
+                          (result.sales_receipts || 0) +
                           (result.estimates || 0) + (result.bills || 0) +
                           (result.deposits || 0);
             toast(`Imported ${total} records`);
@@ -331,6 +332,7 @@ const IIFPage = {
             ['Items', result.items],
             ['Invoices', result.invoices],
             ['Payments', result.payments],
+            ['Sales Receipts', result.sales_receipts],
             ['Estimates', result.estimates],
             ['Bills', result.bills],
             ['Deposits', result.deposits],

--- a/app/static/js/invoices.js
+++ b/app/static/js/invoices.js
@@ -5,7 +5,9 @@
  */
 const InvoicesPage = {
     async render() {
-        const invoices = await API.get('/invoices');
+        // Sales receipts are invoices under the hood; they get their own
+        // page, so keep them out of this list.
+        const invoices = await API.get('/invoices?is_sales_receipt=false');
         return renderListPage({
             title: 'Invoices',
             headerHtml: `<button class="btn btn-primary" onclick="InvoicesPage.showForm()">+ New Invoice</button>`,

--- a/app/static/js/qbo.js
+++ b/app/static/js/qbo.js
@@ -22,13 +22,21 @@ const QBOPage = {
             ? `Connected to <strong>${escapeHtml(status.company_name || 'QuickBooks Online')}</strong> (Realm: ${escapeHtml(status.realm_id)})`
             : 'Not connected';
 
-        const entityTypes = ['accounts', 'customers', 'vendors', 'items', 'invoices', 'payments'];
+        const entityTypes = [
+            ['accounts', 'Accounts'], ['customers', 'Customers'], ['vendors', 'Vendors'],
+            ['items', 'Items'], ['invoices', 'Invoices'], ['payments', 'Payments'],
+        ];
+        // Sales receipts import as paid-invoice + payment pairs; there is
+        // no matching export entity, so only the import list offers them.
+        const importEntityTypes = [...entityTypes, ['sales_receipts', 'Sales Receipts']];
 
-        const checkboxes = entityTypes.map(e =>
+        const checkboxHtml = types => types.map(([value, label]) =>
             `<label style="display:inline-flex; align-items:center; gap:4px; margin-right:12px;">
-                <input type="checkbox" value="${e}" checked> ${e.charAt(0).toUpperCase() + e.slice(1)}
+                <input type="checkbox" value="${value}" checked> ${label}
             </label>`
         ).join('');
+        const importCheckboxes = checkboxHtml(importEntityTypes);
+        const checkboxes = checkboxHtml(entityTypes);
 
         return `
             <div class="page-header">
@@ -73,7 +81,7 @@ const QBOPage = {
                         Import Individual Entity Types
                     </div>
                     <div id="qbo-import-checkboxes" style="margin-bottom:8px; font-size:11px;">
-                        ${checkboxes}
+                        ${importCheckboxes}
                     </div>
                     <button class="btn btn-secondary" onclick="QBOPage.importSelected()"
                         ${!status.connected ? 'disabled' : ''}>
@@ -148,7 +156,8 @@ const QBOPage = {
             QBOPage._showResult('qbo-import-result', result, 'imported');
             const total = (result.accounts || 0) + (result.customers || 0) +
                           (result.vendors || 0) + (result.items || 0) +
-                          (result.invoices || 0) + (result.payments || 0);
+                          (result.invoices || 0) + (result.payments || 0) +
+                          (result.sales_receipts || 0);
             toast(`Imported ${total} records from QBO`);
             App.setStatus('QuickBooks Online — Import complete');
         } catch (err) {
@@ -161,7 +170,7 @@ const QBOPage = {
         const checked = QBOPage._getChecked('qbo-import-checkboxes');
         if (checked.length === 0) { toast('Select at least one entity type', 'error'); return; }
 
-        const result = { accounts: 0, customers: 0, vendors: 0, items: 0, invoices: 0, payments: 0, errors: [] };
+        const result = { accounts: 0, customers: 0, vendors: 0, items: 0, invoices: 0, payments: 0, sales_receipts: 0, errors: [] };
         App.setStatus('Importing from QuickBooks Online...');
 
         for (const entity of checked) {
@@ -238,6 +247,7 @@ const QBOPage = {
             ['Items', result.items],
             ['Invoices', result.invoices],
             ['Payments', result.payments],
+            ['Sales Receipts', result.sales_receipts],
         ];
 
         let html = '<div class="iif-results"><h4>Results</h4>';

--- a/app/static/js/sales_receipts.js
+++ b/app/static/js/sales_receipts.js
@@ -1,0 +1,309 @@
+/**
+ * Enter Sales Receipts — invoice + payment in one screen, for
+ * point-of-sale style transactions where payment happens at the sale.
+ * The list shows only receipts (invoices flagged is_sales_receipt);
+ * regular invoices keep their own page.
+ */
+const SalesReceiptsPage = {
+    async render() {
+        const receipts = await API.get('/invoices?is_sales_receipt=true');
+        return renderListPage({
+            title: 'Sales Receipts',
+            headerHtml: `<button class="btn btn-primary" onclick="SalesReceiptsPage.showForm()">+ New Sales Receipt</button>`,
+            filter: {
+                id: 'sr-status-filter',
+                rowSelector: '.sr-row',
+                options: [['paid', 'Paid'], ['void', 'Void']],
+            },
+            empty: `<p>No sales receipts yet. Use them for point-of-sale style sales where the customer pays on the spot.</p>
+                <button class="btn btn-primary" onclick="SalesReceiptsPage.showForm()" style="margin-top:10px;">+ Enter your first sales receipt</button>`,
+            columns: ['Sale #', 'Customer', 'Date', 'Status',
+                { label: 'Total', cls: 'amount' }, 'Actions'],
+            items: receipts,
+            row: sr => `<tr class="sr-row" data-status="${sr.status}">
+                    <td><strong>${escapeHtml(sr.invoice_number)}</strong></td>
+                    <td>${escapeHtml(sr.customer_name || '')}</td>
+                    <td>${formatDate(sr.date)}</td>
+                    <td>${statusBadge(sr.status)}</td>
+                    <td class="amount">${formatCurrency(sr.total)}</td>
+                    <td class="actions">
+                        <button class="btn btn-sm btn-secondary" onclick="SalesReceiptsPage.view(${sr.id})">View</button>
+                    </td>
+                </tr>`,
+        });
+    },
+
+    async view(id) {
+        const sr = await API.get(`/invoices/${id}`);
+        const linesHtml = sr.lines.map(l =>
+            `<tr><td>${escapeHtml(l.description || '')}</td><td class="amount">${l.quantity}</td>
+             <td class="amount">${formatCurrency(l.rate)}</td><td class="amount">${formatCurrency(l.amount)}</td></tr>`
+        ).join('');
+
+        const payment = await SalesReceiptsPage._findPayment(sr);
+
+        openModal(`Sales Receipt #${sr.invoice_number}`, `
+            <div style="margin-bottom:12px;">
+                <strong>Customer:</strong> ${escapeHtml(sr.customer_name || '')}<br>
+                <strong>Date:</strong> ${formatDate(sr.date)}<br>
+                <strong>Status:</strong> ${statusBadge(sr.status)}<br>
+                ${payment && payment.method ? `<strong>Payment Method:</strong> ${escapeHtml(payment.method)}<br>` : ''}
+                ${payment && payment.check_number ? `<strong>Check #:</strong> ${escapeHtml(payment.check_number)}<br>` : ''}
+                ${payment && payment.reference ? `<strong>Reference:</strong> ${escapeHtml(payment.reference)}<br>` : ''}
+            </div>
+            <div class="table-container"><table>
+                <thead><tr><th>Description</th><th class="amount">Qty</th><th class="amount">Rate</th><th class="amount">Amount</th></tr></thead>
+                <tbody>${linesHtml}</tbody>
+            </table></div>
+            <div class="invoice-totals">
+                <div class="total-row"><span class="label">Subtotal</span><span class="value">${formatCurrency(sr.subtotal)}</span></div>
+                <div class="total-row"><span class="label">Tax</span><span class="value">${formatCurrency(sr.tax_amount)}</span></div>
+                <div class="total-row grand-total"><span class="label">Total</span><span class="value">${formatCurrency(sr.total)}</span></div>
+            </div>
+            ${sr.notes ? `<p style="margin-top:12px;color:var(--gray-500);">${escapeHtml(sr.notes)}</p>` : ''}
+            <div class="form-actions">
+                <button class="btn btn-secondary" onclick="window.open('/api/invoices/${sr.id}/pdf','_blank')">Save PDF</button>
+                <button class="btn btn-secondary" onclick="window.open('/api/invoices/${sr.id}/print-preview','_blank')">Print</button>
+                ${sr.status !== 'void' ? `<button class="btn btn-danger" onclick="SalesReceiptsPage.void(${sr.id})">Void Receipt</button>` : ''}
+                <button class="btn btn-secondary" onclick="closeModal()">Close</button>
+            </div>`);
+    },
+
+    // A sales receipt is an invoice + its payment; the payment is found by
+    // its allocation to this invoice.
+    async _findPayment(sr) {
+        try {
+            const payments = await API.get(`/payments?customer_id=${sr.customer_id}`);
+            return payments.find(p =>
+                !p.is_voided && p.allocations.some(a => a.invoice_id === sr.id)
+            ) || null;
+        } catch (e) { return null; }
+    },
+
+    // Void = void the payment first (restores the invoice balance), then
+    // void the invoice — same order the API requires for the two documents.
+    async void(id) {
+        if (!confirm('Void this sales receipt? Its payment and invoice will both be voided. This cannot be undone.')) return;
+        try {
+            const sr = await API.get(`/invoices/${id}`);
+            const payment = await SalesReceiptsPage._findPayment(sr);
+            if (payment) await API.post(`/payments/${payment.id}/void`);
+            await API.post(`/invoices/${id}/void`);
+            toast('Sales receipt voided');
+            closeModal();
+            App.navigate(location.hash);
+        } catch (err) { toast(err.message, 'error'); }
+    },
+
+    lineCount: 0,
+    _customers: [],
+    _items: [],
+
+    async showForm() {
+        const [customers, items, accounts, settings] = await Promise.all([
+            API.get('/customers?active_only=true'),
+            API.get('/items?active_only=true'),
+            API.get('/accounts'),
+            API.get('/settings'),
+        ]);
+        const bankAccts = accounts.filter(a => a.account_type === 'asset');
+
+        const sr = {
+            date: todayISO(),
+            tax_rate: (parseFloat(settings.default_tax_rate || '0') || 0) / 100,
+            lines: [{ item_id: '', description: '', quantity: 1, rate: 0 }],
+        };
+        const classGroup = await classFormGroupHtml(null);
+
+        SalesReceiptsPage.lineCount = sr.lines.length;
+        SalesReceiptsPage._items = items;
+        SalesReceiptsPage._customers = customers;
+
+        const custOpts = customers.map(c => `<option value="${c.id}">${escapeHtml(c.name)}</option>`).join('');
+        const bankOpts = bankAccts.map(a => `<option value="${a.id}">${escapeHtml(a.name)}</option>`).join('');
+
+        openModal('Enter Sales Receipt', `
+            <form id="sales-receipt-form" onsubmit="SalesReceiptsPage.save(event)">
+                <div class="form-grid">
+                    <div class="form-group"><label>Customer *</label>
+                        <select name="customer_id" id="sr-customer-select" required onchange="SalesReceiptsPage.customerSelected(this.value)"><option value="">Select...</option><option value="__new__">+ New Customer</option>${custOpts}</select>
+                        <div id="sr-new-customer-form" style="display:none; margin-top:8px; padding:8px; border:1px solid var(--gray-300); border-radius:4px; background:var(--primary-light);">
+                            <div style="font-weight:700; font-size:11px; margin-bottom:6px;">Quick Add Customer</div>
+                            <input id="sr-new-cust-name" placeholder="Name *" style="width:100%; margin-bottom:4px; padding:4px 8px; border:1px solid var(--gray-300); border-radius:4px;">
+                            <input id="sr-new-cust-email" placeholder="Email" style="width:100%; margin-bottom:4px; padding:4px 8px; border:1px solid var(--gray-300); border-radius:4px;">
+                            <input id="sr-new-cust-phone" placeholder="Phone" style="width:100%; margin-bottom:4px; padding:4px 8px; border:1px solid var(--gray-300); border-radius:4px;">
+                            <div style="display:flex; gap:6px;">
+                                <button type="button" class="btn btn-sm btn-primary" onclick="SalesReceiptsPage.saveNewCustomer()">Save</button>
+                                <button type="button" class="btn btn-sm btn-secondary" onclick="SalesReceiptsPage.cancelNewCustomer()">Cancel</button>
+                            </div>
+                        </div></div>
+                    <div class="form-group"><label>Date *</label>
+                        <input name="date" type="date" required value="${sr.date}"></div>
+                    <div class="form-group"><label>Payment Method</label>
+                        <select name="method">
+                            <option value="">--</option>
+                            <option>Cash</option><option>Check</option>
+                            <option>Credit Card</option><option>ACH/EFT</option><option>Other</option>
+                        </select></div>
+                    <div class="form-group"><label>Check #</label>
+                        <input name="check_number"></div>
+                    <div class="form-group"><label>Reference</label>
+                        <input name="reference"></div>
+                    <div class="form-group"><label>Deposit To</label>
+                        <select name="deposit_to_account_id">
+                            <option value="">Undeposited Funds (default)</option>${bankOpts}</select></div>
+                    ${classGroup}
+                    ${currencyFormGroupsHtml(null, null)}
+                    <div class="form-group"><label>Tax Rate (%)</label>
+                        <input name="tax_rate" type="number" step="0.01" value="${(sr.tax_rate * 100) || 0}"
+                            oninput="SalesReceiptsPage.recalc()"></div>
+                </div>
+                <h3 style="margin:16px 0 8px; font-size:14px; color:var(--gray-600);">Line Items</h3>
+                <table class="line-items-table">
+                    <thead><tr>
+                        <th>Item</th><th>Description</th><th class="col-qty">Qty</th>
+                        <th class="col-rate">Rate</th><th class="col-amount">Amount</th><th class="col-actions"></th>
+                    </tr></thead>
+                    <tbody id="sr-lines">
+                        ${sr.lines.map((l, i) => SalesReceiptsPage.lineRowHtml(i, l, items)).join('')}
+                    </tbody>
+                </table>
+                <button type="button" class="btn btn-sm btn-secondary" style="margin-top:8px;" onclick="SalesReceiptsPage.addLine()">+ Add Line</button>
+                <div class="invoice-totals" id="sr-totals">
+                    <div class="total-row"><span class="label">Subtotal</span><span class="value" id="sr-subtotal">$0.00</span></div>
+                    <div class="total-row"><span class="label">Tax</span><span class="value" id="sr-tax">$0.00</span></div>
+                    <div class="total-row grand-total"><span class="label">Total Received</span><span class="value" id="sr-total">$0.00</span></div>
+                </div>
+                <div class="form-group" style="margin-top:12px;"><label>Notes</label>
+                    <textarea name="notes"></textarea></div>
+                <div class="form-actions">
+                    <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Record Sales Receipt</button>
+                </div>
+            </form>`);
+        SalesReceiptsPage.recalc();
+    },
+
+    customerSelected(customerId) {
+        const form = $('#sr-new-customer-form');
+        if (!form) return;
+        form.style.display = customerId === '__new__' ? 'block' : 'none';
+    },
+
+    async saveNewCustomer() {
+        const name = $('#sr-new-cust-name').value.trim();
+        if (!name) { toast('Customer name is required', 'error'); return; }
+        try {
+            const cust = await API.post('/customers', {
+                name, email: $('#sr-new-cust-email').value.trim() || null,
+                phone: $('#sr-new-cust-phone').value.trim() || null,
+            });
+            SalesReceiptsPage._customers.push(cust);
+            const sel = $('#sr-customer-select');
+            const opt = document.createElement('option');
+            opt.value = cust.id; opt.textContent = cust.name; opt.selected = true;
+            sel.appendChild(opt);
+            $('#sr-new-customer-form').style.display = 'none';
+            toast(`Customer "${cust.name}" created`);
+        } catch (err) { toast(err.message, 'error'); }
+    },
+
+    cancelNewCustomer() {
+        $('#sr-new-customer-form').style.display = 'none';
+        $('#sr-customer-select').value = '';
+    },
+
+    lineRowHtml(idx, line, items) {
+        const itemOpts = items.map(i => `<option value="${i.id}" ${line.item_id==i.id?'selected':''}>${escapeHtml(i.name)}</option>`).join('');
+        return `<tr data-line="${idx}">
+            <td><select class="line-item" onchange="SalesReceiptsPage.itemSelected(${idx})">
+                <option value="">--</option>${itemOpts}</select></td>
+            <td><input class="line-desc" value="${escapeHtml(line.description || '')}"></td>
+            <td><input class="line-qty" type="number" step="0.01" value="${line.quantity || 1}" oninput="SalesReceiptsPage.recalc()"></td>
+            <td><input class="line-rate" type="number" step="0.01" value="${line.rate || 0}" oninput="SalesReceiptsPage.recalc()"></td>
+            <td class="col-amount line-amount">${formatCurrency((line.quantity||1) * (line.rate||0))}</td>
+            <td><button type="button" class="btn btn-sm btn-danger" onclick="SalesReceiptsPage.removeLine(${idx})">X</button></td>
+        </tr>`;
+    },
+
+    addLine() {
+        const tbody = $('#sr-lines');
+        const idx = SalesReceiptsPage.lineCount++;
+        tbody.insertAdjacentHTML('beforeend', SalesReceiptsPage.lineRowHtml(idx, {}, SalesReceiptsPage._items));
+    },
+
+    removeLine(idx) {
+        const row = $(`[data-line="${idx}"]`);
+        if (row) row.remove();
+        SalesReceiptsPage.recalc();
+    },
+
+    itemSelected(idx) {
+        const row = $(`[data-line="${idx}"]`);
+        const itemId = row.querySelector('.line-item').value;
+        const item = SalesReceiptsPage._items.find(i => i.id == itemId);
+        if (item) {
+            row.querySelector('.line-desc').value = item.description || item.name;
+            row.querySelector('.line-rate').value = item.rate;
+            SalesReceiptsPage.recalc();
+        }
+    },
+
+    recalc() {
+        let subtotal = 0;
+        $$('#sr-lines tr').forEach(row => {
+            const qty = parseFloat(row.querySelector('.line-qty')?.value) || 0;
+            const rate = parseFloat(row.querySelector('.line-rate')?.value) || 0;
+            const amount = qty * rate;
+            subtotal += amount;
+            const amountCell = row.querySelector('.line-amount');
+            if (amountCell) amountCell.textContent = formatCurrency(amount);
+        });
+        const taxPct = parseFloat($('#sales-receipt-form [name="tax_rate"]')?.value) || 0;
+        const tax = subtotal * (taxPct / 100);
+        $('#sr-subtotal').textContent = formatCurrency(subtotal);
+        $('#sr-tax').textContent = formatCurrency(tax);
+        $('#sr-total').textContent = formatCurrency(subtotal + tax);
+    },
+
+    async save(e) {
+        e.preventDefault();
+        const form = e.target;
+        const lines = [];
+        $$('#sr-lines tr').forEach((row, i) => {
+            const item_id = row.querySelector('.line-item')?.value;
+            lines.push({
+                item_id: item_id ? parseInt(item_id) : null,
+                description: row.querySelector('.line-desc')?.value || '',
+                quantity: parseFloat(row.querySelector('.line-qty')?.value) || 1,
+                rate: parseFloat(row.querySelector('.line-rate')?.value) || 0,
+                line_order: i,
+            });
+        });
+
+        const data = {
+            customer_id: parseInt(form.customer_id.value),
+            date: form.date.value,
+            method: form.method.value || null,
+            check_number: form.check_number.value || null,
+            reference: form.reference.value || null,
+            deposit_to_account_id: form.deposit_to_account_id.value ? parseInt(form.deposit_to_account_id.value) : null,
+            class_id: classIdFromForm(form),
+            ...currencyPayloadFromForm(form),
+            tax_rate: (parseFloat(form.tax_rate.value) || 0) / 100,
+            notes: form.notes.value || null,
+            lines,
+        };
+
+        try {
+            const result = await API.post('/sales-receipts', data);
+            toast(`Sales Receipt #${result.invoice.invoice_number} recorded`);
+            closeModal();
+            App.navigate(location.hash);
+        } catch (err) { toast(err.message, 'error'); }
+    },
+};
+
+// Top-level const creates no window property — the topbar's
+// data-action dispatch (bootstrap.js callByPath) needs this export.
+window.SalesReceiptsPage = SalesReceiptsPage;

--- a/docs/features.md
+++ b/docs/features.md
@@ -14,6 +14,7 @@ pass, and the per-integration setup guides ([Stripe](setup-stripe.md),
 
 ## Invoicing & Payments (Accounts Receivable)
 - **Invoices** — Create, edit, duplicate, void, mark as sent, email as PDF. Auto-numbering, auto due-date from terms, dynamic line items with running totals. Print/PDF generation via WeasyPrint. Inline customer creation from invoice form
+- **Sales Receipts** — One-screen invoice + payment for point-of-sale style sales where the customer pays on the spot. Payment method, deposit-to account, and line items on a single form; posts both documents and their journal entries atomically. Imports from QuickBooks Desktop (IIF `CASH SALE`) and QuickBooks Online (SalesReceipt API)
 - **Estimates** — Full estimate workflow with convert-to-invoice (deep-copies all fields and line items). Inline customer creation from estimate form
 - **Payments** — Record payments with allocation across multiple invoices. Auto-updates invoice balances and status (draft/sent/partial/paid). Void payments with reversing journal entries
 - **Recurring Invoices** — Schedule automatic invoice generation (weekly/monthly/quarterly/yearly) with manual "Generate Now" or cron script

--- a/docs/migrate-from-quickbooks.md
+++ b/docs/migrate-from-quickbooks.md
@@ -1,0 +1,108 @@
+# Migrating from QuickBooks
+
+SlowBooks imports QuickBooks data two ways, depending on which
+QuickBooks you're leaving:
+
+| You're on | Use | Where in SlowBooks |
+|---|---|---|
+| **QuickBooks Online** | Direct API import over OAuth | sidebar → **QuickBooks Online** |
+| **QuickBooks Desktop** (2003–current) | IIF file import | sidebar → **QuickBooks Interop** |
+
+Both paths import accounts, customers, vendors, items, invoices,
+payments, and **sales receipts**. Sales receipts come across as what
+they are underneath: a paid invoice plus its payment, flagged so they
+show up on SlowBooks' own Sales Receipts page.
+
+---
+
+## Path 1 — QuickBooks Online (direct API)
+
+One-time setup: connect SlowBooks to your QBO company with OAuth —
+follow [setup-qbo.md](setup-qbo.md) (free Intuit developer account,
+~10 minutes). Then:
+
+1. Open **QuickBooks Online** in the sidebar.
+2. Click **Import All Data**. Entities come over in dependency order
+   (accounts → customers → vendors → items → invoices → payments →
+   sales receipts), so references resolve as they land.
+3. Or use the checkboxes to import entity types selectively — e.g.
+   just **Sales Receipts** on a re-run.
+
+Re-runs are safe: every imported record is tracked by its QBO id, and
+untracked records are matched by name/number, so nothing imports twice.
+
+---
+
+## Path 2 — QuickBooks Desktop (IIF files)
+
+### What Desktop can export by itself
+
+QuickBooks Desktop's built-in IIF export (`File → Utilities → Export →
+Lists to IIF Files`) covers **lists only**: chart of accounts,
+customers, vendors, items. Export those and drop the `.iif` file(s) on
+**QuickBooks Interop → Import** — there's a **Validate** button that
+checks the file before anything is written.
+
+### Transactions need one extra step
+
+Desktop does not export transactions to IIF natively. Two options:
+
+- **A third-party IIF transaction exporter** (several exist for QB
+  Desktop). The importer understands `INVOICE`, `PAYMENT`,
+  `CASH SALE` (sales receipts), `ESTIMATE`, `BILL`, and `DEPOSIT`
+  blocks. Import lists first, then transactions, so customer/item/
+  account names resolve.
+- **A clean report export** to review your data or hand-build IIF from.
+  The messy-report trap is exporting a summary report; use a detail
+  report filtered to one transaction type instead:
+
+  1. **Reports → Custom Reports → Transaction Detail**
+  2. Set the date range to **All**.
+  3. **Filters** tab → *Transaction Type* → **Sales Receipt**.
+  4. **Display** tab → trim the columns to Date, Num, Name, Item, Qty,
+     Sales Price, Amount.
+  5. **Excel → Create New Worksheet** (or Print → Save as CSV).
+
+  That yields one row per line item with no subtotal noise — the same
+  recipe works for invoices and payments by switching the filter.
+
+### How CASH SALE blocks import
+
+QuickBooks writes each sales receipt as a `CASH SALE` transaction
+block: the header line carries the deposit account (bank or Undeposited
+Funds), the split lines carry income and sales-tax credits. SlowBooks
+imports each one as:
+
+- an **invoice** flagged as a sales receipt, status **Paid**, with the
+  split lines as line items (splits against accounts containing "tax"
+  become the tax amount);
+- a **payment** for the full total, deposited to the header account
+  (falling back to Undeposited Funds if the account name doesn't
+  match);
+- balanced journal entries for both, so the ledger nets to
+  cash/Undeposited Funds + income — identical to a receipt entered on
+  the Sales Receipts screen.
+
+Details worth knowing:
+
+- **Blank customer** — QB allows counter sales with no Customer:Job.
+  Those import against an auto-created **"Walk-In Customer"** (the
+  import report notes each one).
+- **Unnumbered receipts** — receipts without a `DOCNUM` get the next
+  SlowBooks invoice number. Numbered receipts keep their numbers.
+- **Duplicates** — re-importing the same file skips receipts whose
+  document number already exists (or, for unnumbered ones, an existing
+  receipt with the same customer + date + total).
+
+---
+
+## After the import
+
+- Spot-check **Reports → Trial Balance** against the same report in
+  QuickBooks as of your cutover date (mind the date range — set it to
+  cover the imported history).
+- Sales receipts are listed on **Sales Receipts** in the sidebar;
+  regular invoices stay on **Invoices**.
+- Going forward, enter point-of-sale style sales on the **Sales
+  Receipts** screen — one form records the sale and the payment
+  together.

--- a/index.html
+++ b/index.html
@@ -74,6 +74,8 @@
                         <span class="nav-icon">&#9679;</span> Customers</a></li>
                     <li><a href="#/invoices" class="nav-link" data-page="invoices">
                         <span class="nav-icon">&#9830;</span> Invoices</a></li>
+                    <li><a href="#/sales-receipts" class="nav-link" data-page="sales-receipts">
+                        <span class="nav-icon">&#9635;</span> Sales Receipts</a></li>
                     <li><a href="#/estimates" class="nav-link" data-page="estimates">
                         <span class="nav-icon">&#9826;</span> Estimates</a></li>
                     <li><a href="#/payments" class="nav-link" data-page="payments">
@@ -208,6 +210,7 @@
     <script src="/static/js/vendors.js"></script>
     <script src="/static/js/items.js"></script>
     <script src="/static/js/invoices.js"></script>
+    <script src="/static/js/sales_receipts.js"></script>
     <script src="/static/js/estimates.js"></script>
     <script src="/static/js/payments.js"></script>
     <script src="/static/js/banking.js"></script>

--- a/migrations/versions/c7d8e9f0a1b2_add_invoice_is_sales_receipt.py
+++ b/migrations/versions/c7d8e9f0a1b2_add_invoice_is_sales_receipt.py
@@ -1,0 +1,37 @@
+"""Sales receipts: is_sales_receipt flag on invoices
+
+A sales receipt is stored as an Invoice plus an immediate Payment; the
+flag distinguishes the two document types in lists and QB interop.
+
+Revision ID: c7d8e9f0a1b2
+Revises: b6c7d8e9f0a1
+Create Date: 2026-08-17
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c7d8e9f0a1b2"
+down_revision = "b6c7d8e9f0a1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Batch mode for SQLite compatibility (desktop company files)
+    with op.batch_alter_table("invoices") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "is_sales_receipt",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+        batch_op.create_index("ix_invoices_is_sales_receipt", ["is_sales_receipt"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("invoices") as batch_op:
+        batch_op.drop_index("ix_invoices_is_sales_receipt")
+        batch_op.drop_column("is_sales_receipt")

--- a/tests/test_iif_import.py
+++ b/tests/test_iif_import.py
@@ -426,3 +426,122 @@ def test_reimport_reports_duplicates_skipped(db_session, seed_accounts):
     assert second["bills"] == 0
     assert second["deposits"] == 0
     assert second["duplicates_skipped"] == 3
+
+
+# ---------------------------------------------------------------------------
+# CASH SALE (sales receipts)
+# ---------------------------------------------------------------------------
+
+CASH_SALE_IIF = (
+    "!TRNS\tTRNSID\tTRNSTYPE\tDATE\tACCNT\tNAME\tAMOUNT\tDOCNUM\tPAYMETH\n"
+    "!SPL\tSPLID\tTRNSTYPE\tDATE\tACCNT\tNAME\tAMOUNT\tINVITEM\tQNTY\tPRICE\n"
+    "!ENDTRNS\n"
+    "TRNS\t1\tCASH SALE\t2026-04-02\tChecking\tWalkup Wanda\t108.75\tSR-100\tCash\n"
+    "SPL\t2\tCASH SALE\t2026-04-02\tService Income\tWalkup Wanda\t-100.00\t\t1\t100.00\n"
+    "SPL\t3\tCASH SALE\t2026-04-02\tSales Tax Payable\tWalkup Wanda\t-8.75\t\t\t\n"
+    "ENDTRNS\n"
+)
+
+# Counter sale: no customer name, no document number.
+ANON_CASH_SALE_IIF = (
+    "!TRNS\tTRNSID\tTRNSTYPE\tDATE\tACCNT\tNAME\tAMOUNT\tDOCNUM\tPAYMETH\n"
+    "!SPL\tSPLID\tTRNSTYPE\tDATE\tACCNT\tNAME\tAMOUNT\tINVITEM\tQNTY\tPRICE\n"
+    "!ENDTRNS\n"
+    "TRNS\t1\tCASH SALE\t2026-04-03\tChecking\t\t25.00\t\tCash\n"
+    "SPL\t2\tCASH SALE\t2026-04-03\tService Income\t\t-25.00\t\t1\t25.00\n"
+    "ENDTRNS\n"
+)
+
+
+def test_iif_import_cash_sale_creates_paid_receipt(db_session, seed_accounts):
+    from app.services.iif_import import parse_iif, import_transactions
+    from app.models.invoices import Invoice, InvoiceStatus
+    from app.models.payments import Payment, PaymentAllocation
+    from app.models.contacts import Customer
+    from app.models.transactions import TransactionLine
+
+    db_session.add(Customer(name="Walkup Wanda", is_active=True))
+    db_session.commit()
+
+    parsed = parse_iif(CASH_SALE_IIF)
+    result = import_transactions(db_session, parsed["TRNS"])
+    db_session.commit()
+
+    assert result["imported"]["sales_receipts"] == 1, result
+    invoice = db_session.query(Invoice).filter_by(invoice_number="SR-100").first()
+    assert invoice is not None
+    assert invoice.is_sales_receipt is True
+    assert invoice.status == InvoiceStatus.PAID
+    assert invoice.subtotal == Decimal("100.00")
+    assert invoice.tax_amount == Decimal("8.75")
+    assert invoice.total == Decimal("108.75")
+    assert invoice.balance_due == Decimal("0")
+
+    payment = db_session.query(Payment).first()
+    assert payment.amount == Decimal("108.75")
+    assert payment.method == "Cash"
+    checking = seed_accounts["1000"]
+    assert payment.deposit_to_account_id == checking.id
+    alloc = db_session.query(PaymentAllocation).first()
+    assert alloc.invoice_id == invoice.id
+    assert alloc.amount == Decimal("108.75")
+
+    # Both journals balance; the payment journal debits Checking.
+    for txn_id in (invoice.transaction_id, payment.transaction_id):
+        assert txn_id is not None
+        lines = db_session.query(TransactionLine).filter_by(transaction_id=txn_id).all()
+        dr = sum((Decimal(str(line.debit)) for line in lines), Decimal("0"))
+        cr = sum((Decimal(str(line.credit)) for line in lines), Decimal("0"))
+        assert dr == cr == Decimal("108.75")
+    debit_line = (
+        db_session.query(TransactionLine)
+        .filter_by(transaction_id=payment.transaction_id, account_id=checking.id)
+        .first()
+    )
+    assert Decimal(str(debit_line.debit)) == Decimal("108.75")
+
+
+def test_iif_import_anonymous_cash_sale_uses_walk_in_customer(
+    db_session, seed_accounts
+):
+    from app.services.iif_import import (
+        WALK_IN_CUSTOMER_NAME,
+        import_transactions,
+        parse_iif,
+    )
+    from app.models.invoices import Invoice
+    from app.models.contacts import Customer
+
+    parsed = parse_iif(ANON_CASH_SALE_IIF)
+    result = import_transactions(db_session, parsed["TRNS"])
+    db_session.commit()
+
+    assert result["imported"]["sales_receipts"] == 1, result
+    assert any(WALK_IN_CUSTOMER_NAME in w for w in result["warnings"])
+
+    walk_in = db_session.query(Customer).filter_by(name=WALK_IN_CUSTOMER_NAME).first()
+    assert walk_in is not None
+    invoice = db_session.query(Invoice).first()
+    assert invoice.customer_id == walk_in.id
+    # Unnumbered receipt got the next invoice number from the numbering service
+    assert invoice.invoice_number
+
+
+def test_iif_reimport_cash_sale_skips_duplicates(db_session, seed_accounts):
+    from app.services.iif_import import parse_iif, import_transactions
+    from app.models.invoices import Invoice
+    from app.models.contacts import Customer
+
+    db_session.add(Customer(name="Walkup Wanda", is_active=True))
+    db_session.commit()
+
+    combined = parse_iif(CASH_SALE_IIF + ANON_CASH_SALE_IIF)
+    first = import_transactions(db_session, combined["TRNS"])
+    db_session.commit()
+    assert first["imported"]["sales_receipts"] == 2
+
+    second = import_transactions(db_session, combined["TRNS"])
+    db_session.commit()
+    assert second["imported"]["sales_receipts"] == 0
+    assert second["imported"]["duplicates_skipped"] == 2
+    assert db_session.query(Invoice).count() == 2

--- a/tests/test_sales_receipts.py
+++ b/tests/test_sales_receipts.py
@@ -1,0 +1,281 @@
+"""Sales receipts — the one-screen invoice+payment endpoint and QBO import.
+
+A sales receipt is stored as an Invoice flagged is_sales_receipt plus a
+Payment for the full total. These tests pin: both documents and their
+journal entries post atomically, validation rejects inputs that would
+strand a half-written receipt, the list filter separates receipts from
+regular invoices, and the QBO SalesReceipt importer produces the same
+document pair with id-mapped dedup.
+"""
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+
+def _post_receipt(client, customer_id, **overrides):
+    body = {
+        "customer_id": customer_id,
+        "date": "2026-04-01",
+        "tax_rate": "0.0875",
+        "method": "Cash",
+        "lines": [
+            {
+                "description": "Widget",
+                "quantity": "1",
+                "rate": "100.00",
+                "line_order": 0,
+            }
+        ],
+    }
+    body.update(overrides)
+    return client.post("/api/sales-receipts", json=body)
+
+
+def _sum_debits_credits(db_session, txn_id):
+    from app.models.transactions import TransactionLine
+
+    lines = db_session.query(TransactionLine).filter_by(transaction_id=txn_id).all()
+    return (
+        sum((Decimal(str(line.debit)) for line in lines), Decimal("0")),
+        sum((Decimal(str(line.credit)) for line in lines), Decimal("0")),
+    )
+
+
+def test_create_sales_receipt_posts_paid_invoice_and_payment(
+    client, db_session, seed_accounts, seed_customer
+):
+    r = _post_receipt(client, seed_customer.id)
+    assert r.status_code == 201, r.text
+    data = r.json()
+
+    from app.models.invoices import Invoice, InvoiceStatus
+    from app.models.payments import Payment, PaymentAllocation
+
+    invoice = db_session.query(Invoice).filter_by(id=data["invoice"]["id"]).first()
+    assert invoice.is_sales_receipt is True
+    assert invoice.status == InvoiceStatus.PAID
+    assert invoice.subtotal == Decimal("100.00")
+    assert invoice.tax_amount == Decimal("8.75")
+    assert invoice.total == Decimal("108.75")
+    assert invoice.amount_paid == Decimal("108.75")
+    assert invoice.balance_due == Decimal("0.00")
+
+    payment = db_session.query(Payment).filter_by(id=data["payment"]["id"]).first()
+    assert payment.amount == Decimal("108.75")
+    assert payment.method == "Cash"
+    alloc = db_session.query(PaymentAllocation).filter_by(payment_id=payment.id).first()
+    assert alloc.invoice_id == invoice.id
+    assert alloc.amount == Decimal("108.75")
+
+    # Both journal entries exist and balance
+    assert invoice.transaction_id is not None
+    dr, cr = _sum_debits_credits(db_session, invoice.transaction_id)
+    assert dr == cr == Decimal("108.75")
+    assert payment.transaction_id is not None
+    dr, cr = _sum_debits_credits(db_session, payment.transaction_id)
+    assert dr == cr == Decimal("108.75")
+
+    # Default deposit: the payment journal debits Undeposited Funds (1200)
+    from app.models.transactions import TransactionLine
+
+    uf = seed_accounts["1200"]
+    debit_line = (
+        db_session.query(TransactionLine)
+        .filter_by(transaction_id=payment.transaction_id, account_id=uf.id)
+        .first()
+    )
+    assert debit_line is not None
+    assert Decimal(str(debit_line.debit)) == Decimal("108.75")
+
+
+def test_create_sales_receipt_with_explicit_deposit_account(
+    client, db_session, seed_accounts, seed_customer
+):
+    checking = seed_accounts["1000"]
+    r = _post_receipt(
+        client, seed_customer.id, deposit_to_account_id=checking.id, tax_rate="0"
+    )
+    assert r.status_code == 201, r.text
+
+    from app.models.payments import Payment
+    from app.models.transactions import TransactionLine
+
+    payment = db_session.query(Payment).filter_by(id=r.json()["payment"]["id"]).first()
+    assert payment.deposit_to_account_id == checking.id
+    debit_line = (
+        db_session.query(TransactionLine)
+        .filter_by(transaction_id=payment.transaction_id, account_id=checking.id)
+        .first()
+    )
+    assert Decimal(str(debit_line.debit)) == Decimal("100.00")
+
+
+def test_zero_total_sales_receipt_rejected_before_writing(
+    client, db_session, seed_accounts, seed_customer
+):
+    r = _post_receipt(
+        client,
+        seed_customer.id,
+        tax_rate="0",
+        lines=[{"description": "Freebie", "quantity": "1", "rate": "0"}],
+    )
+    assert r.status_code == 400
+
+    from app.models.invoices import Invoice
+
+    assert db_session.query(Invoice).count() == 0
+
+
+def test_unknown_deposit_account_rejected_before_writing(
+    client, db_session, seed_accounts, seed_customer
+):
+    r = _post_receipt(client, seed_customer.id, deposit_to_account_id=999999)
+    assert r.status_code == 404
+
+    from app.models.invoices import Invoice
+
+    assert db_session.query(Invoice).count() == 0
+
+
+def test_unknown_customer_rejected(client, seed_accounts):
+    r = _post_receipt(client, 999999)
+    assert r.status_code == 404
+
+
+def test_list_filter_separates_receipts_from_invoices(
+    client, seed_accounts, seed_customer
+):
+    receipt_id = _post_receipt(client, seed_customer.id).json()["invoice"]["id"]
+    r = client.post(
+        "/api/invoices",
+        json={
+            "customer_id": seed_customer.id,
+            "date": "2026-04-01",
+            "terms": "Net 30",
+            "tax_rate": "0",
+            "lines": [{"description": "Consulting", "quantity": "1", "rate": "50"}],
+        },
+    )
+    assert r.status_code == 201
+    invoice_id = r.json()["id"]
+
+    receipts = client.get("/api/invoices?is_sales_receipt=true").json()
+    assert [i["id"] for i in receipts] == [receipt_id]
+    invoices = client.get("/api/invoices?is_sales_receipt=false").json()
+    assert [i["id"] for i in invoices] == [invoice_id]
+    # No filter -> everything, as before
+    all_ids = {i["id"] for i in client.get("/api/invoices").json()}
+    assert all_ids == {receipt_id, invoice_id}
+
+
+# ---------------------------------------------------------------------------
+# QBO SalesReceipt import
+# ---------------------------------------------------------------------------
+
+
+def _fake_qbo_receipt(**overrides):
+    receipt = SimpleNamespace(
+        Id="SR-77",
+        SyncToken="0",
+        DocNumber="SR-1001",
+        CustomerRef=SimpleNamespace(value="99", name="Walkup Wanda"),
+        TotalAmt=108.75,
+        TxnDate="2026-04-01",
+        TxnTaxDetail=SimpleNamespace(TotalTax=8.75),
+        DepositToAccountRef=None,
+        PaymentMethodRef={"name": "Cash"},
+        PaymentRefNum="REG-1",
+        CustomerMemo={"value": "counter sale"},
+        Line=[
+            SimpleNamespace(
+                DetailType="SalesItemLineDetail",
+                SalesItemLineDetail=SimpleNamespace(
+                    ItemRef=None, Qty=1, UnitPrice=100.00
+                ),
+                Amount=100.00,
+                Description="Widget",
+            )
+        ],
+    )
+    for key, val in overrides.items():
+        setattr(receipt, key, val)
+    return receipt
+
+
+def _wire_fake_qbo(monkeypatch, receipts):
+    from app.services import qbo_import
+    import quickbooks.objects.salesreceipt as sr_mod
+
+    monkeypatch.setattr(qbo_import, "get_qbo_client", lambda db: None)
+    monkeypatch.setattr(
+        sr_mod.SalesReceipt, "all", classmethod(lambda cls, qb=None: list(receipts))
+    )
+
+
+def test_qbo_import_sales_receipts(db_session, seed_accounts, monkeypatch):
+    from app.models.contacts import Customer
+    from app.models.invoices import Invoice, InvoiceStatus
+    from app.models.payments import Payment, PaymentAllocation
+    from app.services import qbo_import
+    from app.services.qbo_common import get_mapping_by_qbo_id
+
+    db_session.add(Customer(name="Walkup Wanda", is_active=True))
+    db_session.commit()
+
+    _wire_fake_qbo(monkeypatch, [_fake_qbo_receipt()])
+    result = qbo_import.import_sales_receipts(db_session)
+    db_session.commit()
+    assert result["imported"] == 1, result
+    assert result["errors"] == []
+
+    invoice = db_session.query(Invoice).filter_by(invoice_number="SR-1001").first()
+    assert invoice is not None
+    assert invoice.is_sales_receipt is True
+    assert invoice.status == InvoiceStatus.PAID
+    assert invoice.subtotal == Decimal("100.00")
+    assert invoice.tax_amount == Decimal("8.75")
+    assert invoice.total == Decimal("108.75")
+    assert invoice.balance_due == Decimal("0")
+    assert len(invoice.lines) == 1
+    assert invoice.lines[0].description == "Widget"
+
+    payment = db_session.query(Payment).first()
+    assert payment.amount == Decimal("108.75")
+    assert payment.method == "Cash"
+    assert payment.reference == "REG-1"
+    alloc = db_session.query(PaymentAllocation).first()
+    assert alloc.invoice_id == invoice.id
+
+    assert get_mapping_by_qbo_id(db_session, "sales_receipt", "SR-77") is not None
+
+
+def test_qbo_import_sales_receipts_dedups_on_rerun(
+    db_session, seed_accounts, monkeypatch
+):
+    from app.models.contacts import Customer
+    from app.models.invoices import Invoice
+    from app.services import qbo_import
+
+    db_session.add(Customer(name="Walkup Wanda", is_active=True))
+    db_session.commit()
+
+    _wire_fake_qbo(monkeypatch, [_fake_qbo_receipt()])
+    assert qbo_import.import_sales_receipts(db_session)["imported"] == 1
+    db_session.commit()
+    assert qbo_import.import_sales_receipts(db_session)["imported"] == 0
+    db_session.commit()
+    assert db_session.query(Invoice).count() == 1
+
+
+def test_qbo_import_sales_receipt_without_customer_reports_error(
+    db_session, seed_accounts, monkeypatch
+):
+    from app.services import qbo_import
+
+    _wire_fake_qbo(
+        monkeypatch,
+        [_fake_qbo_receipt(CustomerRef=SimpleNamespace(value="1", name="Nobody"))],
+    )
+    result = qbo_import.import_sales_receipts(db_session)
+    assert result["imported"] == 0
+    assert result["errors"] and "Customer not found" in result["errors"][0]["message"]


### PR DESCRIPTION
Adds the sales-receipts feature set requested by a user migrating from QuickBooks who rings up most sales POS-style.

## What a sales receipt is here

An Invoice flagged `is_sales_receipt` (status **Paid**) plus a Payment for the full total — the exact document pair you'd get entering an invoice and receiving payment separately. Every existing report, PDF, export, and void path works unchanged. Migration `c7d8e9f0a1b2` adds the flag (batch mode, SQLite-safe; new DBs get it via create_all).

## The three pieces

**1. Enter Sales Receipts screen** — new sidebar page under Customers & Sales. One form: customer (with quick-add), date, payment method, check #/reference, deposit-to account (defaults to Undeposited Funds), tax, class, currency, line items. `POST /api/sales-receipts` composes the existing `create_invoice` + `create_payment` routes, so numbering, closing-date enforcement, FX, and inventory/COGS behave identically; if the payment half fails, the invoice half is voided rather than left open. Receipts list on their own page; the Invoices page now filters them out (`GET /api/invoices?is_sales_receipt=…`; omitting the param returns everything, as before — API-compatible).

**2. IIF import: `CASH SALE`** — QB Desktop's sales receipts previously hit the silently-skipped TRNSTYPE bucket. They now import as paid invoice + payment with balanced journals (deposit account from the TRNS header, Undeposited Funds fallback). Blank Customer:Job → auto-created "Walk-In Customer" (reported as a warning); unnumbered receipts get the next invoice number; re-imports dedup by DOCNUM or customer+date+total.

**3. QBO import: SalesReceipt** — pulled after invoices/payments in `import_all`, same id-mapping dedup, `sales_receipts` entity on `/api/qbo/import/{entity}`. Import-only checkbox on the QBO page (no matching export entity).

Plus **docs/migrate-from-quickbooks.md** covering both paths — including that Desktop's built-in IIF export is lists-only, and the clean Transaction Detail report recipe (filter to one transaction type, trim columns) for getting sales history out without the messy summary reports.

## Testing

- 13 new tests (API atomicity/validation/filtering, IIF CASH SALE incl. walk-in + dedup, QBO import with faked SDK objects incl. rerun dedup)
- Full suite: **1176 passed**; black + ruff clean; `alembic upgrade head` verified on a fresh SQLite DB
- No RBAC changes needed — `/api/sales-receipts` is a daily-books write, covered by the existing bookkeeper policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)