### PR TITLE
Sales receipt PDF renders as a receipt, not an invoice (#60)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -273,6 +273,9 @@ jobs:
           # Stable asset name: the website's direct-download links depend on it.
           cp "$dmg" "$stage/SlowBooksPro-macos-arm64.dmg"
           cp "$report_dir/SHA256SUMS" "$stage/SHA256SUMS.macos"
+          # The stable-named copy needs its own checksum line — same bytes,
+          # second name — so the README's direct download is verifiable too.
+          ( cd "$stage" && shasum -a 256 SlowBooksPro-macos-arm64.dmg >> SHA256SUMS.macos )
           tar -czf "$stage/release-evidence.tar.gz" --exclude='*.dmg' \
             -C "$(dirname "$report_dir")" "$(basename "$report_dir")"
           ls -la "$stage"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
+### v2.6.1 — The receipt now looks like a receipt
+
+- The printed/saved sales receipt was the unmodified invoice template —
+  titled INVOICE, with Due Date, Terms, and Balance Due rows, saved as
+  `Invoice_<n>.pdf`. It now renders as a SALES RECEIPT: date only, Sold
+  To, Total + Paid (no balance line — nothing is due), filename
+  `SalesReceipt_<n>.pdf`, and the same for the email attachment name.
+  Found on macOS hardware by the build maintainer during the v2.6.0
+  release pass. (#60)
+- The PDF's Bill To / Sold To block always prints the customer's name
+  now: the template fell back on a `customer_name` attribute only some
+  callers stamped onto the invoice, so the direct PDF route printed a
+  bare header whenever the customer had no address on file.
+- `SHA256SUMS.macos` now also lists the stable-named
+  `SlowBooksPro-macos-arm64.dmg`, so the README's direct download can be
+  checksum-verified, not just the versioned asset.
+
 ### v2.6.0 — Sales receipts: one-screen POS sales + QuickBooks import
 
 For businesses that ring up sales at a counter instead of invoicing:

--- a/app/routes/invoices/documents.py
+++ b/app/routes/invoices/documents.py
@@ -26,11 +26,12 @@ def invoice_pdf(invoice_id: int, db: Session = Depends(get_db)):
         raise HTTPException(status_code=404, detail="Invoice not found")
     company = get_settings(db)
     pdf_bytes = generate_invoice_pdf(inv, company)
+    doc_kind = "SalesReceipt" if inv.is_sales_receipt else "Invoice"
     return Response(
         content=pdf_bytes,
         media_type="application/pdf",
         headers={
-            "Content-Disposition": f"inline; filename=Invoice_{inv.invoice_number}.pdf"
+            "Content-Disposition": f"inline; filename={doc_kind}_{inv.invoice_number}.pdf"
         },
     )
 
@@ -103,7 +104,11 @@ def email_invoice(
             subject=subject,
             html_body=html_body,
             attachment_bytes=pdf_bytes,
-            attachment_name=f"Invoice_{inv.invoice_number}.pdf",
+            attachment_name=(
+                f"SalesReceipt_{inv.invoice_number}.pdf"
+                if inv.is_sales_receipt
+                else f"Invoice_{inv.invoice_number}.pdf"
+            ),
             entity_type="invoice",
             entity_id=inv.id,
         )

--- a/app/templates/invoice_pdf.html
+++ b/app/templates/invoice_pdf.html
@@ -46,23 +46,28 @@
             </div>
         </div>
         <div class="invoice-title">
-            <h1>INVOICE</h1>
+            <h1>{% if inv.is_sales_receipt %}SALES RECEIPT{% else %}INVOICE{% endif %}</h1>
             <div class="invoice-number">#{{ inv.invoice_number }}</div>
         </div>
     </div>
 
+    {# A sales receipt is paid at the time of sale — no due date, no terms. #}
     <table class="meta-table"><tr>
         <td class="meta-label">Date:</td><td>{{ inv.date | fdate }}</td>
+        {% if not inv.is_sales_receipt %}
         <td class="meta-label">Due Date:</td><td>{{ inv.due_date | fdate }}</td>
         <td class="meta-label">Terms:</td><td>{{ inv.terms or '' }}</td>
+        {% endif %}
         {% if inv.po_number %}<td class="meta-label">PO #:</td><td>{{ inv.po_number }}</td>{% endif %}
     </tr></table>
 
     <div class="addresses">
         <div class="address-block">
-            <div class="address-label">Bill To</div>
+            <div class="address-label">{% if inv.is_sales_receipt %}Sold To{% else %}Bill To{% endif %}</div>
             <div class="address-text">
-                <strong>{{ inv.customer_name or '' }}</strong><br>
+                {# customer_name is only stamped on by some callers; fall back
+                   to the relationship so the name always prints. #}
+                <strong>{{ inv.customer_name or (inv.customer.name if inv.customer else '') }}</strong><br>
                 {% if inv.bill_address1 %}{{ inv.bill_address1 }}<br>{% endif %}
                 {% if inv.bill_address2 %}{{ inv.bill_address2 }}<br>{% endif %}
                 {% if inv.bill_city %}{{ inv.bill_city }}, {{ inv.bill_state }} {{ inv.bill_zip }}{% endif %}
@@ -101,7 +106,10 @@
             <tr><td class="label">Tax ({{ "%.2f" | format(inv.tax_rate * 100) }}%)</td><td class="r">{{ inv.tax_amount | currency }}</td></tr>
             {% endif %}
             <tr><td class="label grand">Total</td><td class="r grand">{{ inv.total | currency }}</td></tr>
-            {% if inv.amount_paid and inv.amount_paid != 0 %}
+            {% if inv.is_sales_receipt %}
+            {# Paid at the time of sale — no balance line on a receipt. #}
+            <tr><td class="label">Paid</td><td class="r">{{ inv.amount_paid | currency }}</td></tr>
+            {% elif inv.amount_paid and inv.amount_paid != 0 %}
             <tr><td class="label">Paid</td><td class="r">{{ inv.amount_paid | currency }}</td></tr>
             <tr><td class="label grand">Balance Due</td><td class="r grand">{{ inv.balance_due | currency }}</td></tr>
             {% endif %}

--- a/tests/test_sales_receipts.py
+++ b/tests/test_sales_receipts.py
@@ -279,3 +279,78 @@ def test_qbo_import_sales_receipt_without_customer_reports_error(
     result = qbo_import.import_sales_receipts(db_session)
     assert result["imported"] == 0
     assert result["errors"] and "Customer not found" in result["errors"][0]["message"]
+
+
+# ---------------------------------------------------------------------------
+# PDF / print artifact (#60): a receipt must not render as an invoice
+# ---------------------------------------------------------------------------
+
+
+def test_sales_receipt_pdf_is_a_receipt_not_an_invoice(
+    client, seed_accounts, seed_customer
+):
+    sr = _post_receipt(client, seed_customer.id).json()
+    inv_id = sr["invoice"]["id"]
+
+    r = client.get(f"/api/invoices/{inv_id}/pdf")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "application/pdf"
+    assert f"SalesReceipt_{sr['invoice']['invoice_number']}.pdf" in r.headers.get(
+        "content-disposition", ""
+    )
+
+    # The print preview renders the same template as HTML, so the document
+    # semantics can be asserted as text.
+    html = client.get(f"/api/invoices/{inv_id}/print-preview").text
+    assert "SALES RECEIPT" in html
+    assert "Balance Due" not in html
+    assert "Due Date" not in html
+    assert "Terms" not in html
+    assert "Sold To" in html
+    assert "Test Customer" in html
+
+
+def test_invoice_pdf_keeps_invoice_semantics(client, seed_accounts, seed_customer):
+    r = client.post(
+        "/api/invoices",
+        json={
+            "customer_id": seed_customer.id,
+            "date": "2026-04-01",
+            "terms": "Net 30",
+            "tax_rate": "0",
+            "lines": [{"description": "Consulting", "quantity": "1", "rate": "50"}],
+        },
+    )
+    inv = r.json()
+
+    r = client.get(f"/api/invoices/{inv['id']}/pdf")
+    assert r.status_code == 200
+    assert f"Invoice_{inv['invoice_number']}.pdf" in r.headers.get(
+        "content-disposition", ""
+    )
+
+    html = client.get(f"/api/invoices/{inv['id']}/print-preview").text
+    assert "INVOICE" in html
+    assert "SALES RECEIPT" not in html
+    assert "Due Date" in html
+    assert "Bill To" in html
+    # Regression for the bare BILL TO block: the customer name must print
+    # even when the callers don't stamp customer_name onto the ORM object.
+    assert "Test Customer" in html
+
+
+def test_pdf_template_prints_name_via_customer_relationship(
+    client, db_session, seed_accounts, seed_customer
+):
+    """The /pdf route renders the ORM object directly (no customer_name
+    attribute) — the template must fall back to inv.customer.name."""
+    sr = _post_receipt(client, seed_customer.id).json()
+
+    from app.models.invoices import Invoice
+    from app.services.pdf_service import _jinja_env
+
+    inv = db_session.query(Invoice).filter_by(id=sr["invoice"]["id"]).first()
+    assert not hasattr(inv, "customer_name")
+    html = _jinja_env.get_template("invoice_pdf.html").render(inv=inv, company={})
+    assert "Test Customer" in html
+    assert "SALES RECEIPT" in html


### PR DESCRIPTION
Fixes #60, found by @ContractorKeith on macOS hardware during the v2.6.0 release pass.

All six items from the report:

1. **Title** → `SALES RECEIPT` when `is_sales_receipt` is set (invoices unchanged)
2. **Filename** → `SalesReceipt_<n>.pdf` for the download and the email attachment
3. **Due Date row** → suppressed for receipts (meta row shows the date only)
4. **Terms row** → suppressed for receipts
5. **Balance Due** → suppressed; receipts show Total + Paid and stop there
6. **Bare BILL TO** → root cause was broader than quick-add customers: the template read `inv.customer_name`, an attribute only the print-preview route stamps on — the direct `/pdf` route rendered the raw ORM object, so the name never printed there. The template now falls back to `inv.customer.name`, fixing invoices and receipts on every render path. Receipts label the block **Sold To**.

Also picked up your checksum note: the release staging step now appends a `SHA256SUMS.macos` line for the stable-named `SlowBooksPro-macos-arm64.dmg` (same bytes, second name), so the README's direct-download link is verifiable against the published sums from the next tag onward.

Print preview shares the template, so it inherits every fix.

Tests: 3 new (receipt semantics via print-preview text, invoice-semantics control incl. the name regression, and a direct template render proving the relationship fallback — the preview route can't exercise it because it stamps `customer_name` itself). Full suite: **1179 passed**; black + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)