### PR TITLE
QuickBooks report-CSV import: sales receipts, deposits, and checks (auto-detected)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
+### Sales receipts from a QuickBooks report CSV
+
+QuickBooks Desktop can't export transactions to IIF, so the sales-
+receipt migration doc pointed Desktop users at a Transaction Detail
+report export — which previously had nowhere to land. It does now:
+**QuickBooks Interop → Sales Receipts from Report CSV** imports a
+"Transaction Detail by Date" export (filtered to Sales Receipt), each
+receipt becoming a paid sale + payment with balanced journals.
+
+Shaped by a real customer's export, so the parser handles what real
+files contain: applied-deposit contra lines that reduce the total
+(sign-aware — an absolute-value parse would inflate them), percentage
+tax rows carrying the tax agency's name, deposits-only receipts,
+thousands separators, and per-receipt balance checks with clear
+errors. Unmatched account names post to default income with a warning;
+re-uploads dedup by customer + date + total. Receipt numbers keep the
+report's Num where free (SR-prefixed on collision).
+
 ### v2.6.1 — The receipt now looks like a receipt
 
 - The printed/saved sales receipt was the unmodified invoice template —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
+### Deposits and checks from QuickBooks report CSVs
+
+The report-CSV path now covers three exports, auto-detected by their
+columns on one upload: **Deposit Detail** (each deposit becomes the
+journal entry moving its payments from Undeposited Funds to the bank),
+**Check Detail** (bank credit + expense debits — including payroll
+checks, whose withholding lines credit their liability accounts and
+net to the check amount; sign-aware parsing again, proven against a
+real customer's export), and the Transaction Detail sales-receipt
+report below. Blocks that don't balance or reference missing accounts
+error individually with a pointer to import the chart of accounts
+first; re-uploads dedup.
+
 ### Sales receipts from a QuickBooks report CSV
 
 QuickBooks Desktop can't export transactions to IIF, so the sales-

--- a/app/routes/csv.py
+++ b/app/routes/csv.py
@@ -104,14 +104,15 @@ async def csv_import_items(file: UploadFile = File(...), db: Session = Depends(g
     return result
 
 
-@router.post("/import/sales-receipts")
-async def csv_import_sales_receipts(
+@router.post("/import/qb-report")
+async def csv_import_qb_report(
     file: UploadFile = File(...), db: Session = Depends(get_db)
 ):
-    """Import sales receipts from a QuickBooks Desktop "Transaction Detail
-    by Date" report CSV (filtered to Sales Receipt) — the documented
-    fallback for Desktop, which can't export transactions to IIF."""
-    from app.services.qb_report_import import import_sales_receipt_report
+    """Import a QuickBooks Desktop report CSV — the documented fallback
+    for Desktop, which can't export transactions to IIF. Auto-detects the
+    report by its columns: Transaction Detail filtered to Sales Receipt,
+    Deposit Detail, or Check Detail."""
+    from app.services.qb_report_import import import_qb_report
 
     content = (await read_limited(file, label="CSV file")).decode("utf-8-sig")
-    return import_sales_receipt_report(db, content)
+    return import_qb_report(db, content)

--- a/app/routes/csv.py
+++ b/app/routes/csv.py
@@ -102,3 +102,16 @@ async def csv_import_items(file: UploadFile = File(...), db: Session = Depends(g
     content = (await read_limited(file, label="CSV file")).decode("utf-8-sig")
     result = import_items(db, content)
     return result
+
+
+@router.post("/import/sales-receipts")
+async def csv_import_sales_receipts(
+    file: UploadFile = File(...), db: Session = Depends(get_db)
+):
+    """Import sales receipts from a QuickBooks Desktop "Transaction Detail
+    by Date" report CSV (filtered to Sales Receipt) — the documented
+    fallback for Desktop, which can't export transactions to IIF."""
+    from app.services.qb_report_import import import_sales_receipt_report
+
+    content = (await read_limited(file, label="CSV file")).decode("utf-8-sig")
+    return import_sales_receipt_report(db, content)

--- a/app/services/qb_report_import.py
+++ b/app/services/qb_report_import.py
@@ -43,6 +43,11 @@ from app.services.iif_import import _find_account
 # Item Description, and Qty are used when present but not required.
 REQUIRED_COLUMNS = ("Date", "Name", "Account", "Split", "Debit", "Credit")
 
+# Header signatures for the three supported report shapes. Detection is by
+# column set, not report title — titles vary by QB version and locale.
+DEPOSIT_COLUMNS = ("Type", "Date", "Name", "Account", "Amount")
+CHECK_COLUMNS = ("Type", "Date", "Name", "Account", "Original Amount", "Paid Amount")
+
 
 def _amount(s) -> Decimal:
     """Parse a QB report amount: thousands separators, blanks, negatives."""
@@ -76,13 +81,17 @@ def _parse_tax_rate(price: str) -> Decimal:
         return Decimal("0")
 
 
-def _find_header(rows: list[list[str]]):
-    """Locate the report's column-header row and map names to indexes."""
+def _find_header_for(rows: list[list[str]], required: tuple):
+    """Locate a column-header row containing `required`; map names to indexes."""
     for i, row in enumerate(rows):
         cells = [c.strip() for c in row]
-        if all(col in cells for col in REQUIRED_COLUMNS):
+        if all(col in cells for col in required):
             return i, {name: cells.index(name) for name in cells if name}
     return None, None
+
+
+def _find_header(rows: list[list[str]]):
+    return _find_header_for(rows, REQUIRED_COLUMNS)
 
 
 def _cell(row: list[str], cols: dict, name: str) -> str:
@@ -402,3 +411,312 @@ def import_sales_receipt_report(db: Session, csv_text: str) -> dict:
 
     db.commit()
     return result
+
+
+# ============================================================================
+# Deposit Detail report — QB's "Make Deposits" history.
+#
+# Block shape: a Type="Deposit" header row (bank account, positive total)
+# followed by the payment rows being deposited (negative amounts, usually
+# from Undeposited Funds), terminated by a TOTAL rail. Imported as
+# journal-only Transactions with source_type="deposit" — identical to
+# what the manual Make Deposits route and the IIF DEPOSIT importer
+# produce, so the check register and pending-deposits logic see them.
+# ============================================================================
+
+
+def _group_blocks(rows, cols, start, header_type):
+    """Group report rows into blocks: a Type==header_type row starts a
+    block, a TOTAL rail ends it, everything between with an Account is a
+    detail line."""
+    blocks = []
+    current = None
+    for n, row in enumerate(rows[start + 1 :], start=start + 2):
+        first = (row[0] or "").strip() if row else ""
+        if first.upper().startswith("TOTAL"):
+            current = None
+            continue
+        rtype = _cell(row, cols, "Type")
+        if rtype == header_type:
+            current = {"row": n, "header": row, "details": []}
+            blocks.append(current)
+            continue
+        if current is not None and _cell(row, cols, "Account"):
+            current["details"].append(row)
+    return blocks
+
+
+def import_deposit_report(db: Session, csv_text: str) -> dict:
+    """Import a QB Deposit Detail report CSV as deposit journal entries."""
+    result = {"deposits": 0, "duplicates_skipped": 0, "errors": [], "warnings": []}
+    rows = list(csv.reader(io.StringIO(csv_text)))
+    header_idx, cols = _find_header_for(rows, DEPOSIT_COLUMNS)
+    if header_idx is None:
+        result["errors"].append("Could not find the Deposit Detail header row.")
+        return result
+
+    for block in _group_blocks(rows, cols, header_idx, "Deposit"):
+        sp = db.begin_nested()
+        try:
+            hdr = block["header"]
+            dep_date = _parse_date(_cell(hdr, cols, "Date"))
+            if dep_date is None:
+                raise ValueError("deposit row has no parseable date")
+            bank_name = _cell(hdr, cols, "Account")
+            bank = _find_account(db, bank_name)
+            if not bank:
+                raise ValueError(f"bank account '{bank_name}' not found")
+            total = _q(_amount(_cell(hdr, cols, "Amount")))
+            if total <= 0:
+                raise ValueError(f"deposit total {total} is not positive")
+
+            # Sum-to-zero: header total + detail amounts must cancel.
+            detail = []
+            for drow in block["details"]:
+                amt = _q(_amount(_cell(drow, cols, "Amount")))
+                acct_name = _cell(drow, cols, "Account")
+                acct = _find_account(db, acct_name)
+                if not acct:
+                    raise ValueError(
+                        f"source account '{acct_name}' not found - import "
+                        "your chart of accounts (IIF lists) first"
+                    )
+                detail.append((acct, amt, _cell(drow, cols, "Name")))
+            residual = total + sum(a for _, a, _ in detail)
+            if abs(residual) > Decimal("0.01"):
+                raise ValueError(
+                    f"block does not balance (residual {residual}); "
+                    "export the report with all its rows"
+                )
+
+            # Dedup: no document number on a deposit — match on date +
+            # bank + total among imported/manual deposits. Two identical
+            # same-day deposits to one account would collide; rare, and
+            # reported as a skip rather than silently doubled.
+            from app.models.transactions import Transaction
+
+            existing = (
+                db.query(Transaction)
+                .filter(
+                    Transaction.source_type == "deposit",
+                    Transaction.date == dep_date,
+                    Transaction.description == f"Deposit to {bank.name} ({total})",
+                )
+                .first()
+            )
+            if existing:
+                sp.rollback()
+                result["duplicates_skipped"] += 1
+                continue
+
+            journal_lines = [
+                {
+                    "account_id": bank.id,
+                    "debit": total,
+                    "credit": Decimal("0"),
+                    "description": f"Deposit to {bank.name}",
+                }
+            ]
+            for acct, amt, name in detail:
+                journal_lines.append(
+                    {
+                        "account_id": acct.id,
+                        "debit": amt if amt > 0 else Decimal("0"),
+                        "credit": -amt if amt < 0 else Decimal("0"),
+                        "description": name or f"Deposit to {bank.name}",
+                    }
+                )
+            create_journal_entry(
+                db,
+                dep_date,
+                f"Deposit to {bank.name} ({total})",
+                journal_lines,
+                source_type="deposit",
+            )
+            sp.commit()
+            result["deposits"] += 1
+        except Exception as e:
+            sp.rollback()
+            result["errors"].append(f"Deposit block at row {block['row']}: {e}")
+
+    db.commit()
+    return result
+
+
+# ============================================================================
+# Check Detail report — QB's "Write Checks" history.
+#
+# Block shape: a Type="Check" header row (bank account, negative Original
+# Amount = check total, payee in Name) followed by expense split rows
+# (blank Type, expense Account, positive Original / negative Paid),
+# terminated by a TOTAL rail. Imported as journal-only Transactions with
+# source_type="check": CR bank, DR each split — which is what the check
+# register reads.
+# ============================================================================
+
+
+def import_check_report(db: Session, csv_text: str) -> dict:
+    """Import a QB Check Detail report CSV as check journal entries."""
+    result = {"checks": 0, "duplicates_skipped": 0, "errors": [], "warnings": []}
+    rows = list(csv.reader(io.StringIO(csv_text)))
+    header_idx, cols = _find_header_for(rows, CHECK_COLUMNS)
+    if header_idx is None:
+        result["errors"].append("Could not find the Check Detail header row.")
+        return result
+
+    for block in _group_blocks(rows, cols, header_idx, "Check"):
+        sp = db.begin_nested()
+        try:
+            hdr = block["header"]
+            chk_date = _parse_date(_cell(hdr, cols, "Date"))
+            if chk_date is None:
+                raise ValueError("check row has no parseable date")
+            bank_name = _cell(hdr, cols, "Account")
+            bank = _find_account(db, bank_name)
+            if not bank:
+                raise ValueError(f"bank account '{bank_name}' not found")
+            payee = _cell(hdr, cols, "Name")
+            num = _cell(hdr, cols, "Num")
+            memo = _cell(hdr, cols, "Memo")
+            total = _q(abs(_amount(_cell(hdr, cols, "Original Amount"))))
+            if total <= 0:
+                raise ValueError("check total is zero")
+
+            # Sign-aware splits: Paid Amount is negative for a normal
+            # expense line and POSITIVE for a contra line — e.g. a payroll
+            # check's withholding rows credit their liability accounts and
+            # net the gross salary down to the check amount. An abs()
+            # parse would fail the balance gate on every payroll check.
+            splits = []
+            for drow in block["details"]:
+                paid = _cell(drow, cols, "Paid Amount")
+                if paid:
+                    signed = _q(-_amount(paid))
+                else:
+                    signed = _q(_amount(_cell(drow, cols, "Original Amount")))
+                if signed == 0:
+                    continue
+                acct_name = _cell(drow, cols, "Account")
+                acct = _find_account(db, acct_name)
+                if not acct:
+                    raise ValueError(
+                        f"account '{acct_name}' not found - import your "
+                        "chart of accounts (IIF lists) first"
+                    )
+                splits.append((acct, signed, _cell(drow, cols, "Memo")))
+            split_sum = sum(a for _, a, _ in splits)
+            if abs(split_sum - total) > Decimal("0.01"):
+                raise ValueError(
+                    f"splits ({split_sum}) do not equal the check total ({total})"
+                )
+
+            desc = f"Check {num} - {payee}" if num else f"Check - {payee}"
+            if memo:
+                desc += f" ({memo})"
+            # Dedup on (date, description, source_type). Two same-day
+            # checks to one payee with identical memo and number would
+            # collide — reported as a skip.
+            from app.models.transactions import Transaction
+
+            existing = (
+                db.query(Transaction)
+                .filter(
+                    Transaction.source_type == "check",
+                    Transaction.date == chk_date,
+                    Transaction.description == desc,
+                )
+                .first()
+            )
+            if existing:
+                sp.rollback()
+                result["duplicates_skipped"] += 1
+                continue
+
+            journal_lines = [
+                {
+                    "account_id": bank.id,
+                    "debit": Decimal("0"),
+                    "credit": total,
+                    "description": desc,
+                }
+            ]
+            for acct, signed, line_memo in splits:
+                journal_lines.append(
+                    {
+                        "account_id": acct.id,
+                        "debit": signed if signed > 0 else Decimal("0"),
+                        "credit": -signed if signed < 0 else Decimal("0"),
+                        "description": line_memo or desc,
+                    }
+                )
+            create_journal_entry(
+                db,
+                chk_date,
+                desc,
+                journal_lines,
+                source_type="check",
+                reference=num or "",
+            )
+            sp.commit()
+            result["checks"] += 1
+        except Exception as e:
+            sp.rollback()
+            result["errors"].append(f"Check block at row {block['row']}: {e}")
+
+    db.commit()
+    return result
+
+
+# ============================================================================
+# Dispatcher — one upload, header-signature detection
+# ============================================================================
+
+
+def detect_report_type(csv_text: str) -> str | None:
+    """Identify which QB report a CSV is, by column signature."""
+    rows = list(csv.reader(io.StringIO(csv_text)))
+    if _find_header_for(rows, REQUIRED_COLUMNS)[0] is not None:
+        return "sales_receipts"
+    if _find_header_for(rows, CHECK_COLUMNS)[0] is not None:
+        return "checks"
+    if _find_header_for(rows, DEPOSIT_COLUMNS)[0] is not None:
+        return "deposits"
+    return None
+
+
+def import_qb_report(db: Session, csv_text: str) -> dict:
+    """Import any supported QB report CSV, auto-detected by its columns.
+
+    Check detection runs before deposit: the check signature is a strict
+    superset of the deposit signature minus Amount, so ordering matters.
+    """
+    kind = detect_report_type(csv_text)
+    base = {
+        "detected": kind,
+        "sales_receipts": 0,
+        "deposits": 0,
+        "checks": 0,
+        "duplicates_skipped": 0,
+        "errors": [],
+        "warnings": [],
+    }
+    if kind is None:
+        base["errors"].append(
+            "Unrecognized report layout. Supported exports: Transaction "
+            "Detail (filtered to Sales Receipt), Deposit Detail, and "
+            "Check Detail — keep the report's default columns."
+        )
+        return base
+    if kind == "sales_receipts":
+        sub = import_sales_receipt_report(db, csv_text)
+        base["sales_receipts"] = sub.pop("imported", 0)
+    elif kind == "deposits":
+        sub = import_deposit_report(db, csv_text)
+        base["deposits"] = sub.pop("deposits", 0)
+    else:
+        sub = import_check_report(db, csv_text)
+        base["checks"] = sub.pop("checks", 0)
+    base["duplicates_skipped"] = sub.get("duplicates_skipped", 0)
+    base["errors"] = sub.get("errors", [])
+    base["warnings"] = sub.get("warnings", [])
+    return base

--- a/app/services/qb_report_import.py
+++ b/app/services/qb_report_import.py
@@ -1,0 +1,404 @@
+# ============================================================================
+# QuickBooks report-CSV import — sales receipts from a "Transaction Detail
+# by Date" export.
+#
+# QuickBooks Desktop can't export transactions to IIF natively, so the
+# documented fallback (docs/migrate-from-quickbooks.md) is a Transaction
+# Detail report filtered to Sales Receipt, exported to CSV/Excel. This
+# module is the landing zone for that file: each receipt becomes an
+# Invoice flagged is_sales_receipt plus a Payment for the full total —
+# the same document pair the IIF CASH SALE importer produces.
+#
+# Shaped by a real customer export (an RV dealer's receipts), which is
+# why the parser is sign-aware: applied-deposit contra lines ("less
+# deposit", negative Sales Price, Debit side) legitimately reduce a
+# receipt's total, and the IIF importer's abs()-based parse would
+# inflate them. Tax rows carry a percentage in Sales Price ("6.4%") and
+# the agency's name in Name — they belong to the receipt, not to a
+# customer.
+# ============================================================================
+
+import csv
+import io
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+
+from sqlalchemy.orm import Session
+
+from app.models.accounts import Account
+from app.models.contacts import Customer
+from app.models.invoices import Invoice, InvoiceLine, InvoiceStatus
+from app.models.items import Item
+from app.models.payments import Payment, PaymentAllocation
+from app.services.accounting import (
+    _q,
+    create_journal_entry,
+    get_ar_account_id,
+    get_default_income_account_id,
+    get_undeposited_funds_id,
+)
+from app.services.iif_import import _find_account
+
+# Columns the parser needs to see in the report's header row. Memo, Item,
+# Item Description, and Qty are used when present but not required.
+REQUIRED_COLUMNS = ("Date", "Name", "Account", "Split", "Debit", "Credit")
+
+
+def _amount(s) -> Decimal:
+    """Parse a QB report amount: thousands separators, blanks, negatives."""
+    s = (s or "").strip().replace(",", "").replace("$", "")
+    if not s:
+        return Decimal("0")
+    try:
+        return Decimal(s)
+    except InvalidOperation:
+        return Decimal("0")
+
+
+def _parse_date(s):
+    s = (s or "").strip()
+    for fmt in ("%m/%d/%y", "%m/%d/%Y", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(s, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _parse_tax_rate(price: str) -> Decimal:
+    """'6.4%' -> Decimal('0.064'); anything else -> 0."""
+    price = (price or "").strip()
+    if not price.endswith("%"):
+        return Decimal("0")
+    try:
+        return Decimal(price[:-1]) / Decimal("100")
+    except InvalidOperation:
+        return Decimal("0")
+
+
+def _find_header(rows: list[list[str]]):
+    """Locate the report's column-header row and map names to indexes."""
+    for i, row in enumerate(rows):
+        cells = [c.strip() for c in row]
+        if all(col in cells for col in REQUIRED_COLUMNS):
+            return i, {name: cells.index(name) for name in cells if name}
+    return None, None
+
+
+def _cell(row: list[str], cols: dict, name: str) -> str:
+    idx = cols.get(name)
+    if idx is None or idx >= len(row):
+        return ""
+    return (row[idx] or "").strip()
+
+
+def _group_receipts(rows, cols, start, errors):
+    """Group data rows into receipts.
+
+    A row whose Split column is "-SPLIT-" is a receipt header: it carries
+    the customer, date, document number, deposit account, and the total
+    (Debit side). Rows that follow belong to that receipt: a percentage
+    in Sales Price marks a tax row; everything else is a line item with
+    a signed amount of Credit − Debit.
+    """
+    receipts = []
+    current = None
+    for n, row in enumerate(rows[start + 1 :], start=start + 2):
+        if not _parse_date(_cell(row, cols, "Date")):
+            continue  # report group headers/footers/blank rails
+        if _cell(row, cols, "Split") == "-SPLIT-":
+            current = {
+                "row": n,
+                "num": _cell(row, cols, "Num"),
+                "date": _parse_date(_cell(row, cols, "Date")),
+                "customer": _cell(row, cols, "Name"),
+                "deposit_account": _cell(row, cols, "Account"),
+                "total": _q(_amount(_cell(row, cols, "Debit"))),
+                "lines": [],
+                "tax_amount": Decimal("0"),
+                "tax_rate": Decimal("0"),
+            }
+            receipts.append(current)
+            continue
+        if current is None:
+            errors.append(f"Row {n}: detail line before any receipt header; skipped")
+            continue
+        price = _cell(row, cols, "Sales Price")
+        signed = _q(
+            _amount(_cell(row, cols, "Credit")) - _amount(_cell(row, cols, "Debit"))
+        )
+        if price.endswith("%"):
+            current["tax_amount"] += signed
+            rate = _parse_tax_rate(price)
+            if rate and not current["tax_rate"]:
+                current["tax_rate"] = rate
+            continue
+        qty = abs(_amount(_cell(row, cols, "Qty"))) or Decimal("1")
+        current["lines"].append(
+            {
+                "description": _cell(row, cols, "Memo")
+                or _cell(row, cols, "Item Description")
+                or _cell(row, cols, "Item"),
+                "item_name": _cell(row, cols, "Item"),
+                "account": _cell(row, cols, "Account"),
+                "quantity": qty,
+                "amount": signed,
+            }
+        )
+    return receipts
+
+
+def _assign_number(db: Session, num: str) -> str:
+    """Use the report's Num when it's free; otherwise SR-prefix and bump.
+
+    QB sales receipts run their own sequence (often 1, 2, 3 …), which can
+    collide with existing invoice numbers here.
+    """
+    from app.services.numbering import next_invoice_number
+
+    if not num:
+        return next_invoice_number(db)
+    candidate = num
+    if (
+        db.query(Invoice.id).filter(Invoice.invoice_number == candidate).first()
+        is not None
+    ):
+        n = 0
+        candidate = f"SR-{num}"
+        while (
+            db.query(Invoice.id).filter(Invoice.invoice_number == candidate).first()
+            is not None
+        ):
+            n += 1
+            candidate = f"SR-{num}-{n}"
+    return candidate
+
+
+def import_sales_receipt_report(db: Session, csv_text: str) -> dict:
+    """Import a Transaction Detail by Date CSV (filtered to Sales Receipt)."""
+    result = {
+        "imported": 0,
+        "duplicates_skipped": 0,
+        "errors": [],
+        "warnings": [],
+    }
+    rows = list(csv.reader(io.StringIO(csv_text)))
+    header_idx, cols = _find_header(rows)
+    if header_idx is None:
+        result["errors"].append(
+            "Could not find the report's column header row. Export the "
+            "Transaction Detail report with at least these columns: "
+            + ", ".join(REQUIRED_COLUMNS)
+        )
+        return result
+
+    receipts = _group_receipts(rows, cols, header_idx, result["errors"])
+    ar_id = get_ar_account_id(db)
+    default_income_id = get_default_income_account_id(db)
+
+    for rec in receipts:
+        sp = db.begin_nested()
+        try:
+            ref = rec["num"] or f"row {rec['row']}"
+            line_sum = sum((ln["amount"] for ln in rec["lines"]), Decimal("0"))
+            expected = _q(line_sum + rec["tax_amount"])
+            if expected != rec["total"]:
+                sp.rollback()
+                result["errors"].append(
+                    f"Receipt {ref}: lines + tax ({expected}) do not equal the "
+                    f"deposit total ({rec['total']}); skipped"
+                )
+                continue
+
+            cust_name = (rec["customer"] or "Walk-In Customer")[:200]
+            customer = db.query(Customer).filter(Customer.name == cust_name).first()
+            if not customer:
+                customer = Customer(name=cust_name, is_active=True)
+                db.add(customer)
+                db.flush()
+
+            # Dedup: same customer, date, and total among sales receipts —
+            # the report can be re-exported and re-uploaded freely.
+            existing = (
+                db.query(Invoice)
+                .filter(
+                    Invoice.customer_id == customer.id,
+                    Invoice.date == rec["date"],
+                    Invoice.total == rec["total"],
+                    Invoice.is_sales_receipt.is_(True),
+                )
+                .first()
+            )
+            if existing:
+                sp.rollback()
+                result["duplicates_skipped"] += 1
+                continue
+
+            subtotal = _q(line_sum)
+            invoice = Invoice(
+                invoice_number=_assign_number(db, rec["num"]),
+                customer_id=customer.id,
+                date=rec["date"],
+                due_date=rec["date"],
+                terms="Due on Receipt",
+                status=InvoiceStatus.PAID,
+                is_sales_receipt=True,
+                subtotal=subtotal,
+                tax_rate=rec["tax_rate"] if rec["tax_amount"] else Decimal("0"),
+                tax_amount=_q(rec["tax_amount"]),
+                total=rec["total"],
+                amount_paid=rec["total"],
+                balance_due=Decimal("0"),
+            )
+            db.add(invoice)
+            db.flush()
+
+            for order, ln in enumerate(rec["lines"]):
+                item_id = None
+                if ln["item_name"]:
+                    item = db.query(Item).filter(Item.name == ln["item_name"]).first()
+                    if item:
+                        item_id = item.id
+                qty = ln["quantity"]
+                db.add(
+                    InvoiceLine(
+                        invoice_id=invoice.id,
+                        item_id=item_id,
+                        description=ln["description"] or None,
+                        quantity=qty,
+                        rate=_q(ln["amount"] / qty) if qty else ln["amount"],
+                        amount=ln["amount"],
+                        line_order=order,
+                    )
+                )
+
+            # Invoice journal — sign-aware: DR A/R for the total; each
+            # positive line credits its account, a contra line (applied
+            # deposit, discount) debits it; tax credits its account.
+            if ar_id and rec["total"] != 0:
+                journal_lines = [
+                    {
+                        "account_id": ar_id,
+                        "debit": rec["total"],
+                        "credit": Decimal("0"),
+                        "description": f"Sales receipt {invoice.invoice_number}",
+                    }
+                ]
+                unmatched = []
+                for ln in rec["lines"]:
+                    if ln["amount"] == 0:
+                        continue
+                    acct = _find_account(db, ln["account"])
+                    acct_id = acct.id if acct else default_income_id
+                    if not acct:
+                        unmatched.append(ln["account"] or "(blank)")
+                    if acct_id is None:
+                        continue
+                    journal_lines.append(
+                        {
+                            "account_id": acct_id,
+                            "debit": (
+                                -ln["amount"] if ln["amount"] < 0 else Decimal("0")
+                            ),
+                            "credit": (
+                                ln["amount"] if ln["amount"] > 0 else Decimal("0")
+                            ),
+                            "description": ln["description"] or "",
+                        }
+                    )
+                if rec["tax_amount"]:
+                    from app.services.accounting import get_sales_tax_account_id
+
+                    tax_id = get_sales_tax_account_id(db)
+                    if tax_id:
+                        journal_lines.append(
+                            {
+                                "account_id": tax_id,
+                                "debit": Decimal("0"),
+                                "credit": rec["tax_amount"],
+                                "description": "Sales tax",
+                            }
+                        )
+                total_dr = sum(jl["debit"] for jl in journal_lines)
+                total_cr = sum(jl["credit"] for jl in journal_lines)
+                if total_dr == total_cr and total_dr > 0:
+                    txn = create_journal_entry(
+                        db,
+                        invoice.date,
+                        f"QB report import — Sales receipt {invoice.invoice_number}",
+                        journal_lines,
+                        source_type="invoice",
+                        source_id=invoice.id,
+                    )
+                    invoice.transaction_id = txn.id
+                    if unmatched:
+                        result["warnings"].append(
+                            f"Receipt {ref}: account(s) not found, posted to "
+                            f"default income: {', '.join(sorted(set(unmatched)))}"
+                        )
+                else:
+                    result["warnings"].append(
+                        f"Receipt {ref}: imported but journal entry could not "
+                        "be created (account mismatch)"
+                    )
+
+            # Payment for the full total, deposited per the header row.
+            deposit_acct = _find_account(db, rec["deposit_account"])
+            if not deposit_acct:
+                uf_id = get_undeposited_funds_id(db)
+                if uf_id:
+                    deposit_acct = db.query(Account).filter(Account.id == uf_id).first()
+            payment = Payment(
+                customer_id=customer.id,
+                date=rec["date"],
+                amount=rec["total"],
+                reference=invoice.invoice_number,
+                deposit_to_account_id=deposit_acct.id if deposit_acct else None,
+            )
+            db.add(payment)
+            db.flush()
+            db.add(
+                PaymentAllocation(
+                    payment_id=payment.id,
+                    invoice_id=invoice.id,
+                    amount=rec["total"],
+                )
+            )
+            if ar_id and deposit_acct and rec["total"] > 0:
+                txn = create_journal_entry(
+                    db,
+                    invoice.date,
+                    f"QB report import — Payment for receipt {invoice.invoice_number}",
+                    [
+                        {
+                            "account_id": deposit_acct.id,
+                            "debit": rec["total"],
+                            "credit": Decimal("0"),
+                            "description": f"Sales receipt {invoice.invoice_number}",
+                        },
+                        {
+                            "account_id": ar_id,
+                            "debit": Decimal("0"),
+                            "credit": rec["total"],
+                            "description": f"Sales receipt {invoice.invoice_number}",
+                        },
+                    ],
+                    source_type="payment",
+                    source_id=payment.id,
+                )
+                payment.transaction_id = txn.id
+
+            db.flush()
+            db.refresh(invoice)
+            from app.services.inventory_hooks import post_sale_for_invoice
+
+            post_sale_for_invoice(db, invoice, txn_date=invoice.date)
+
+            sp.commit()
+            result["imported"] += 1
+        except Exception as e:
+            sp.rollback()
+            result["errors"].append(f"Receipt {rec.get('num') or rec['row']}: {e}")
+
+    db.commit()
+    return result

--- a/app/static/js/iif.js
+++ b/app/static/js/iif.js
@@ -96,38 +96,48 @@ const IIFPage = {
                     <div id="iif-import-result"></div>
                 </div>
 
-                <!-- Sales Receipts from Report CSV -->
+                <!-- QuickBooks Report CSV import -->
                 <div class="iif-section">
-                    <h3>&#9635; Sales Receipts from Report CSV</h3>
+                    <h3>&#9635; Import from Report CSV</h3>
                     <p style="font-size:11px; color:var(--text-secondary); margin-bottom:12px;">
-                        QuickBooks Desktop can't export transactions to IIF. Instead, run
-                        <strong>Reports &gt; Custom Reports &gt; Transaction Detail</strong>, filter
-                        Transaction Type to <strong>Sales Receipt</strong>, export to CSV, and
-                        upload it here. Each receipt imports as a paid sale + payment.
+                        QuickBooks Desktop can't export transactions to IIF — export a detail
+                        <strong>report</strong> to CSV instead and upload it here. The report type is
+                        detected automatically: <strong>Transaction Detail</strong> filtered to Sales
+                        Receipt (each imports as a paid sale + payment), <strong>Deposit
+                        Detail</strong>, or <strong>Check Detail</strong> (both import as journal
+                        entries on your bank account). Keep the report's default columns.
                         Safe to re-upload — duplicates are skipped.
                     </p>
                     <input type="file" id="qbcsv-file-input" accept=".csv" style="font-size:11px; margin-bottom:8px;">
                     <div>
-                        <button class="btn btn-primary" onclick="IIFPage.importSalesReceiptCsv()">Import Sales Receipts</button>
+                        <button class="btn btn-primary" onclick="IIFPage.importQbReportCsv()">Import Report CSV</button>
                     </div>
                     <div id="qbcsv-import-result" style="margin-top:12px;"></div>
                 </div>
             </div>`;
     },
 
-    async importSalesReceiptCsv() {
+    async importQbReportCsv() {
         const input = $('#qbcsv-file-input');
         if (!input?.files[0]) { toast('Choose a CSV file first', 'error'); return; }
         const formData = new FormData();
         formData.append('file', input.files[0]);
         try {
-            App.setStatus('Importing sales receipts from report CSV...');
-            const res = await fetch('/api/csv/import/sales-receipts', { method: 'POST', body: formData });
+            App.setStatus('Importing QuickBooks report CSV...');
+            const res = await fetch('/api/csv/import/qb-report', { method: 'POST', body: formData });
             const result = await res.json();
             if (!res.ok) throw new Error(result.detail || 'Import failed');
 
-            let html = `<div class="iif-results"><h4>Results</h4>
-                <div class="result-row"><span>Sales Receipts</span><span class="result-count">${result.imported} imported</span></div>`;
+            const kindLabel = { sales_receipts: 'Sales Receipts', deposits: 'Deposits', checks: 'Checks' };
+            let html = '<div class="iif-results"><h4>Results</h4>';
+            if (result.detected) {
+                html += `<div class="result-row"><span>Detected report</span><span class="result-count">${kindLabel[result.detected] || result.detected}</span></div>`;
+            }
+            for (const key of ['sales_receipts', 'deposits', 'checks']) {
+                if (result[key] > 0) {
+                    html += `<div class="result-row"><span>${kindLabel[key]}</span><span class="result-count">${result[key]} imported</span></div>`;
+                }
+            }
             if (result.duplicates_skipped > 0) {
                 html += `<div class="result-row"><span>Duplicates skipped</span><span class="result-count">${result.duplicates_skipped}</span></div>`;
             }
@@ -143,7 +153,8 @@ const IIFPage = {
                 html += '</div>';
             }
             $('#qbcsv-import-result').innerHTML = html;
-            toast(`Imported ${result.imported} sales receipt${result.imported === 1 ? '' : 's'}`);
+            const total = (result.sales_receipts || 0) + (result.deposits || 0) + (result.checks || 0);
+            toast(`Imported ${total} record${total === 1 ? '' : 's'}`);
             App.setStatus('QuickBooks Interop — Import complete');
         } catch (err) {
             toast(err.message, 'error');

--- a/app/static/js/iif.js
+++ b/app/static/js/iif.js
@@ -95,7 +95,60 @@ const IIFPage = {
                     <div id="iif-validation-result"></div>
                     <div id="iif-import-result"></div>
                 </div>
+
+                <!-- Sales Receipts from Report CSV -->
+                <div class="iif-section">
+                    <h3>&#9635; Sales Receipts from Report CSV</h3>
+                    <p style="font-size:11px; color:var(--text-secondary); margin-bottom:12px;">
+                        QuickBooks Desktop can't export transactions to IIF. Instead, run
+                        <strong>Reports &gt; Custom Reports &gt; Transaction Detail</strong>, filter
+                        Transaction Type to <strong>Sales Receipt</strong>, export to CSV, and
+                        upload it here. Each receipt imports as a paid sale + payment.
+                        Safe to re-upload — duplicates are skipped.
+                    </p>
+                    <input type="file" id="qbcsv-file-input" accept=".csv" style="font-size:11px; margin-bottom:8px;">
+                    <div>
+                        <button class="btn btn-primary" onclick="IIFPage.importSalesReceiptCsv()">Import Sales Receipts</button>
+                    </div>
+                    <div id="qbcsv-import-result" style="margin-top:12px;"></div>
+                </div>
             </div>`;
+    },
+
+    async importSalesReceiptCsv() {
+        const input = $('#qbcsv-file-input');
+        if (!input?.files[0]) { toast('Choose a CSV file first', 'error'); return; }
+        const formData = new FormData();
+        formData.append('file', input.files[0]);
+        try {
+            App.setStatus('Importing sales receipts from report CSV...');
+            const res = await fetch('/api/csv/import/sales-receipts', { method: 'POST', body: formData });
+            const result = await res.json();
+            if (!res.ok) throw new Error(result.detail || 'Import failed');
+
+            let html = `<div class="iif-results"><h4>Results</h4>
+                <div class="result-row"><span>Sales Receipts</span><span class="result-count">${result.imported} imported</span></div>`;
+            if (result.duplicates_skipped > 0) {
+                html += `<div class="result-row"><span>Duplicates skipped</span><span class="result-count">${result.duplicates_skipped}</span></div>`;
+            }
+            html += '</div>';
+            if (result.warnings?.length) {
+                html += '<div class="iif-errors" style="border-color:var(--warning,#cc9933);">';
+                result.warnings.forEach(w => { html += `${escapeHtml(w)}<br>`; });
+                html += '</div>';
+            }
+            if (result.errors?.length) {
+                html += '<div class="iif-errors">';
+                result.errors.forEach(e => { html += `${escapeHtml(typeof e === 'string' ? e : JSON.stringify(e))}<br>`; });
+                html += '</div>';
+            }
+            $('#qbcsv-import-result').innerHTML = html;
+            toast(`Imported ${result.imported} sales receipt${result.imported === 1 ? '' : 's'}`);
+            App.setStatus('QuickBooks Interop — Import complete');
+        } catch (err) {
+            toast(err.message, 'error');
+            App.setStatus('Import failed');
+        }
     },
 
     // ==== Export Functions ====

--- a/docs/migrate-from-quickbooks.md
+++ b/docs/migrate-from-quickbooks.md
@@ -52,19 +52,28 @@ Desktop does not export transactions to IIF natively. Two options:
   `CASH SALE` (sales receipts), `ESTIMATE`, `BILL`, and `DEPOSIT`
   blocks. Import lists first, then transactions, so customer/item/
   account names resolve.
-- **A clean report export** to review your data or hand-build IIF from.
-  The messy-report trap is exporting a summary report; use a detail
-  report filtered to one transaction type instead:
+- **For sales receipts: a report CSV imports directly.** The
+  messy-report trap is exporting a summary report; use a detail report
+  filtered to one transaction type instead:
 
   1. **Reports → Custom Reports → Transaction Detail**
   2. Set the date range to **All**.
   3. **Filters** tab → *Transaction Type* → **Sales Receipt**.
-  4. **Display** tab → trim the columns to Date, Num, Name, Item, Qty,
-     Sales Price, Amount.
-  5. **Excel → Create New Worksheet** (or Print → Save as CSV).
+  4. Keep the report's **default columns** — the importer needs at
+     least Date, Num, Name, Account, Split, Debit, and Credit (Memo,
+     Item, Qty, and Sales Price are used when present).
+  5. **Excel → Create New Worksheet**, save as CSV (or Print → Save as
+     CSV).
+  6. Upload it under **QuickBooks Interop → Sales Receipts from Report
+     CSV**. Each receipt imports as a paid sale + its payment, with
+     balanced journals; applied-deposit and discount lines keep their
+     signs, tax rows are recognized by the percentage in Sales Price,
+     and re-uploads skip duplicates.
 
-  That yields one row per line item with no subtotal noise — the same
-  recipe works for invoices and payments by switching the filter.
+  Import your **lists first** (chart of accounts, customers, items via
+  IIF) so the report's account and item names resolve — unmatched
+  accounts post to your default income account, with a warning naming
+  them.
 
 ### How CASH SALE blocks import
 

--- a/docs/migrate-from-quickbooks.md
+++ b/docs/migrate-from-quickbooks.md
@@ -52,9 +52,29 @@ Desktop does not export transactions to IIF natively. Two options:
   `CASH SALE` (sales receipts), `ESTIMATE`, `BILL`, and `DEPOSIT`
   blocks. Import lists first, then transactions, so customer/item/
   account names resolve.
-- **For sales receipts: a report CSV imports directly.** The
-  messy-report trap is exporting a summary report; use a detail report
-  filtered to one transaction type instead:
+- **For sales receipts, deposits, and checks: a report CSV imports
+  directly.** Three Desktop report exports upload straight into
+  **QuickBooks Interop → Import from Report CSV** (the report type is
+  auto-detected):
+
+  - **Deposit Detail** (`Reports → Banking → Deposit Detail`) — each
+    deposit imports as a journal entry moving its payments from
+    Undeposited Funds into your bank account, so the check register and
+    reconciliation see them.
+  - **Check Detail** (`Reports → Banking → Check Detail`) — each check
+    imports as a journal entry (bank credit, expense debits). Payroll
+    checks work too: withholding lines credit their liability accounts
+    and the net matches the check.
+  - **Transaction Detail filtered to Sales Receipt** — each receipt
+    imports as a paid sale + payment (details below).
+
+  Import your **lists first** (chart of accounts, customers, items via
+  IIF) so account and item names resolve — deposit and check blocks
+  whose accounts are missing are reported with a pointer to do exactly
+  that. All three are safe to re-upload; duplicates are skipped.
+
+  The messy-report trap is exporting a summary report; the sales
+  receipt path uses a detail report filtered to one transaction type:
 
   1. **Reports → Custom Reports → Transaction Detail**
   2. Set the date range to **All**.

--- a/tests/fixtures/qb_check_detail.csv
+++ b/tests/fixtures/qb_check_detail.csv
@@ -1,0 +1,27 @@
+,,,,,,,,,
+Check Detail,,,,,,,,,s
+"March 1 - 6, 2026",,,,,,,,,
+,Type,Date,Num,Name,Memo,Item,Account,Original Amount,Paid Amount
+ ,,,,,,,,,
+,Check,03/02/26,,Freight Express,office supplies- shipping charges,,Checking,-30.20,
+ ,,,,,,,,,
+,,,,,shipping chgs,,Office Supplies,30.20,-30.20
+TOTAL,,,,,,,,30.20,-30.20
+ ,,,,,,,,,
+,Check,03/06/26,1045,Registry of Vehicles,reg: J. Paulson,,Checking,-190.90,
+ ,,,,,,,,,
+,,,,,J. Paulson,,Utilities,190.90,-190.90
+TOTAL,,,,,,,,190.90,-190.90
+ ,,,,,,,,,
+,Check,03/06/26,,Shoreline Health Insurance,monthly health insurances,,Checking,"-1,185.90",
+ ,,,,,,,,,
+,,,,,March 2026,,Insurance,"1,185.90","-1,185.90"
+TOTAL,,,,,,,,"1,185.90","-1,185.90"
+ ,,,,,,,,,
+,Check,03/06/26,27866,Jenny Frey,w/e. 2/27/26,,Checking,-711.12,
+ ,,,,,,,,,
+,,,,,w/e. 2/27/26,,Wages & Salaries,"1,250.00","-1,250.00"
+,,,,,w/e. 2/27/26,,Federal Income Tax Payable,-275.00,275.00
+,,,,,w/e. 2/27/26,,Social Security Payable,-95.63,95.63
+,,,,,w/e. 2/27/26,,State Income Tax Payable,-168.25,168.25
+TOTAL,,,,,,,,711.12,-711.12

--- a/tests/fixtures/qb_deposit_detail.csv
+++ b/tests/fixtures/qb_deposit_detail.csv
@@ -1,0 +1,18 @@
+,,,,,,,,5:17 PM
+Deposit Detail,,,,,,,,08/25/26
+"April 1, 2026",,,,,,,,
+,Type,Date,Num,Name,Memo,Account,Pay Meth,Amount
+ ,,,,,,,,
+,Deposit,04/01/26,,,Deposit,Checking,,"17,918.67"
+ ,,,,,,,,
+,Sales Receipt,04/01/26,1,Gina Jefferson,,Undeposited Funds,Check,"-1,578.12"
+,Sales Receipt,04/01/26,2,Jim Franco,,Undeposited Funds,Check,"-16,340.55"
+TOTAL,,,,,,,,
+ ,,,,,,,,
+,Deposit,04/01/26,,,Deposit,Checking,,"3,087.17"
+ ,,,,,,,,
+,Sales Receipt,04/01/26,524,Frances Markham,,Undeposited Funds,VISA,-482.78
+,Sales Receipt,04/01/26,525,Pete Dickson,,Undeposited Funds,VISA,-32.53
+,Sales Receipt,04/01/26,523,Laurie Frederick,,Undeposited Funds,VISA,-423.50
+,Sales Receipt,04/01/26,521,Dana Cortes,,Undeposited Funds,VISA,"-2,148.36"
+TOTAL,,,,,,,,

--- a/tests/fixtures/qb_transaction_detail_sales_receipts.csv
+++ b/tests/fixtures/qb_transaction_detail_sales_receipts.csv
@@ -1,0 +1,19 @@
+"Sunrise Trailer Sales, Inc.",,,,,,,,,,,,,,,,8:16 PM
+Transaction Detail by Date,,,,,,,,,,,,,,,,08/18/26
+"April 9 through August 18, 2026",,,,,,,,,,,,,,,,Accrual Basis
+,Date,Num,Name,Memo,Item,Item Description,Account,Class,Clr,Split,Qty,Sales Price,Debit,Credit,Amount,Balance
+"Apr 9 - Aug 18, '26",,,,,,,,,,,,,,,,
+,04/09/26,1,Alex Vega,,,,Undeposited Funds,,√,-SPLIT-,,,"24,265.00",,0.00,0.00
+,04/09/26,1,Alex Vega,out of state sale:  2026 camper,Trailer Sales:Campers,out of state sale,Vehicle Sales (Resale),,,Undeposited Funds,-1,"23,995.00",,"23,995.00","-23,995.00","-23,995.00"
+,04/09/26,1,Alex Vega,out of state sale: battery,Exempt Parts:Battery,out of state sale: battery,Batteries (Exempt),,,Undeposited Funds,-1,250.00,,250.00,-250.00,"-24,245.00"
+,04/09/26,1,Alex Vega,out of state,Exempt Parts,,Parts Taxable,,,Undeposited Funds,-1,595.00,,595.00,-595.00,"-24,840.00"
+,04/09/26,1,Alex Vega,out of state,Miscellaneous:Dealer Conv.,,Others Income,,,Undeposited Funds,-1,425.00,,425.00,-425.00,"-25,265.00"
+,04/09/26,1,Alex Vega,less deposit,Miscellaneous:Deposits,,Deposits,,,Undeposited Funds,-1,"-1,000.00","1,000.00",,"1,000.00","-24,265.00"
+,04/09/26,1,Dept of Revenue,Sales Tax,SCST,Sales Tax,Sales Tax Payable,,,Undeposited Funds,,6.4%,0.00,,0.00,"-24,265.00"
+,04/09/26,2,Bella Cruz,,,,Undeposited Funds,,√,-SPLIT-,,,"1,000.00",,0.00,"-24,265.00"
+,04/09/26,2,Bella Cruz,dep on 2013 unit,Miscellaneous:Deposits,,Deposits,,,Undeposited Funds,-1,"1,000.00",,"1,000.00","-1,000.00","-25,265.00"
+,04/09/26,2,Dept of Revenue,Sales Tax,SCST,Sales Tax,Sales Tax Payable,,,Undeposited Funds,,6.4%,0.00,,0.00,"-25,265.00"
+,04/10/26,3,Casey Reed,,,,Checking,,√,-SPLIT-,,,106.40,,0.00,"-25,265.00"
+,04/10/26,3,Casey Reed,hitch pin,Parts:Hitch Pin,hitch pin,Parts Taxable,,,Checking,-2,50.00,,100.00,-100.00,"-25,365.00"
+,04/10/26,3,Dept of Revenue,Sales Tax,SCST,Sales Tax,Sales Tax Payable,,,Checking,,6.4%,,6.40,-6.40,"-25,371.40"
+"Apr 9 - Aug 18, '26",,,,,,,,,,,,,,,,

--- a/tests/test_qb_report_import.py
+++ b/tests/test_qb_report_import.py
@@ -1,0 +1,123 @@
+"""QuickBooks report-CSV sales receipt import.
+
+Fixture is an anonymized recreation of a real customer's "Transaction
+Detail by Date" export (RV dealer): thousands separators, an
+applied-deposit contra line that must reduce the total (a sign-blind
+abs() parse would inflate it by $2,000), percentage tax rows carrying
+the tax agency's name, a deposits-only receipt, and a receipt with
+actual sales tax deposited straight to Checking.
+"""
+
+from decimal import Decimal
+from pathlib import Path
+
+FIXTURE = (
+    Path(__file__).parent / "fixtures" / "qb_transaction_detail_sales_receipts.csv"
+)
+
+
+def _import(db_session):
+    from app.services.qb_report_import import import_sales_receipt_report
+
+    return import_sales_receipt_report(db_session, FIXTURE.read_text())
+
+
+def test_report_import_creates_paid_receipts(db_session, seed_accounts):
+    from app.models.invoices import Invoice, InvoiceStatus
+    from app.models.payments import Payment
+
+    result = _import(db_session)
+    assert result["errors"] == [], result
+    assert result["imported"] == 3
+
+    receipts = db_session.query(Invoice).order_by(Invoice.id).all()
+    assert len(receipts) == 3
+    assert all(r.is_sales_receipt for r in receipts)
+    assert all(r.status == InvoiceStatus.PAID for r in receipts)
+    assert all(r.balance_due == 0 for r in receipts)
+    assert db_session.query(Payment).count() == 3
+
+
+def test_contra_deposit_line_reduces_the_total(db_session, seed_accounts):
+    """The abs()-trap case: 23,995 + 250 + 595 + 425 − 1,000 = 24,265."""
+    from app.models.invoices import Invoice
+
+    _import(db_session)
+    rec = db_session.query(Invoice).filter_by(invoice_number="1").first()
+    assert rec is not None
+    assert rec.total == Decimal("24265.00")
+    assert rec.subtotal == Decimal("24265.00")
+    assert rec.tax_amount == Decimal("0")
+    contra = [ln for ln in rec.lines if ln.amount < 0]
+    assert len(contra) == 1
+    assert contra[0].amount == Decimal("-1000.00")
+
+    # Journal balances with the contra line on the debit side
+    from app.models.transactions import TransactionLine
+
+    lines = (
+        db_session.query(TransactionLine)
+        .filter_by(transaction_id=rec.transaction_id)
+        .all()
+    )
+    dr = sum((Decimal(str(line.debit)) for line in lines), Decimal("0"))
+    cr = sum((Decimal(str(line.credit)) for line in lines), Decimal("0"))
+    assert dr == cr == Decimal("24265.00") + Decimal("1000.00")
+
+
+def test_taxed_receipt_and_deposit_account(db_session, seed_accounts):
+    from app.models.invoices import Invoice
+    from app.models.payments import Payment
+
+    _import(db_session)
+    rec = db_session.query(Invoice).filter_by(invoice_number="3").first()
+    assert rec.subtotal == Decimal("100.00")
+    assert rec.tax_amount == Decimal("6.40")
+    assert rec.tax_rate == Decimal("0.064")
+    assert rec.total == Decimal("106.40")
+    assert rec.lines[0].quantity == Decimal("2")
+    assert rec.lines[0].rate == Decimal("-50.00") or rec.lines[0].rate == Decimal(
+        "50.00"
+    )
+
+    checking = seed_accounts["1000"]
+    pay = db_session.query(Payment).filter_by(amount=Decimal("106.40")).first()
+    assert pay.deposit_to_account_id == checking.id
+
+    # The other receipts fall back to Undeposited Funds by account name
+    uf = seed_accounts["1200"]
+    other = db_session.query(Payment).filter_by(amount=Decimal("1000.00")).first()
+    assert other.deposit_to_account_id == uf.id
+
+
+def test_reimport_skips_duplicates(db_session, seed_accounts):
+    from app.models.invoices import Invoice
+
+    first = _import(db_session)
+    assert first["imported"] == 3
+    second = _import(db_session)
+    assert second["imported"] == 0
+    assert second["duplicates_skipped"] == 3
+    assert db_session.query(Invoice).count() == 3
+
+
+def test_unrecognized_csv_reports_a_clear_error(db_session, seed_accounts):
+    from app.services.qb_report_import import import_sales_receipt_report
+
+    result = import_sales_receipt_report(db_session, "a,b,c\n1,2,3\n")
+    assert result["imported"] == 0
+    assert result["errors"] and "column header" in result["errors"][0]
+
+
+def test_endpoint_imports_the_fixture(client, seed_accounts):
+    r = client.post(
+        "/api/csv/import/sales-receipts",
+        files={"file": ("receipts.csv", FIXTURE.read_bytes(), "text/csv")},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["imported"] == 3
+    assert body["errors"] == []
+
+    receipts = client.get("/api/invoices?is_sales_receipt=true").json()
+    assert len(receipts) == 3

--- a/tests/test_qb_report_import.py
+++ b/tests/test_qb_report_import.py
@@ -111,13 +111,211 @@ def test_unrecognized_csv_reports_a_clear_error(db_session, seed_accounts):
 
 def test_endpoint_imports_the_fixture(client, seed_accounts):
     r = client.post(
-        "/api/csv/import/sales-receipts",
+        "/api/csv/import/qb-report",
         files={"file": ("receipts.csv", FIXTURE.read_bytes(), "text/csv")},
     )
     assert r.status_code == 200, r.text
     body = r.json()
-    assert body["imported"] == 3
+    assert body["detected"] == "sales_receipts"
+    assert body["sales_receipts"] == 3
     assert body["errors"] == []
 
     receipts = client.get("/api/invoices?is_sales_receipt=true").json()
     assert len(receipts) == 3
+
+
+# ---------------------------------------------------------------------------
+# Deposit Detail and Check Detail reports + auto-detection dispatcher
+# ---------------------------------------------------------------------------
+
+DEPOSIT_FIXTURE = Path(__file__).parent / "fixtures" / "qb_deposit_detail.csv"
+CHECK_FIXTURE = Path(__file__).parent / "fixtures" / "qb_check_detail.csv"
+
+
+def _sum_dr_cr(db_session, txn_id):
+    from app.models.transactions import TransactionLine
+
+    lines = db_session.query(TransactionLine).filter_by(transaction_id=txn_id).all()
+    return (
+        sum((Decimal(str(line.debit)) for line in lines), Decimal("0")),
+        sum((Decimal(str(line.credit)) for line in lines), Decimal("0")),
+    )
+
+
+def test_detect_report_type():
+    from app.services.qb_report_import import detect_report_type
+
+    assert detect_report_type(FIXTURE.read_text()) == "sales_receipts"
+    assert detect_report_type(DEPOSIT_FIXTURE.read_text()) == "deposits"
+    assert detect_report_type(CHECK_FIXTURE.read_text()) == "checks"
+    assert detect_report_type("a,b\n1,2\n") is None
+
+
+def test_deposit_report_imports_balanced_journals(db_session, seed_accounts):
+    from app.models.transactions import Transaction, TransactionLine
+    from app.services.qb_report_import import import_deposit_report
+
+    result = import_deposit_report(db_session, DEPOSIT_FIXTURE.read_text())
+    assert result["errors"] == [], result
+    assert result["deposits"] == 2
+
+    deposits = db_session.query(Transaction).filter_by(source_type="deposit").all()
+    assert len(deposits) == 2
+    checking = seed_accounts["1000"]
+    uf = seed_accounts["1200"]
+    totals = set()
+    for txn in deposits:
+        dr, cr = _sum_dr_cr(db_session, txn.id)
+        assert dr == cr
+        bank_line = (
+            db_session.query(TransactionLine)
+            .filter_by(transaction_id=txn.id, account_id=checking.id)
+            .first()
+        )
+        totals.add(Decimal(str(bank_line.debit)))
+        # Every credit line lands on Undeposited Funds
+        for line in db_session.query(TransactionLine).filter_by(transaction_id=txn.id):
+            if Decimal(str(line.credit)) > 0:
+                assert line.account_id == uf.id
+    assert totals == {Decimal("17918.67"), Decimal("3087.17")}
+
+
+def test_deposit_report_rerun_skips_duplicates(db_session, seed_accounts):
+    from app.models.transactions import Transaction
+    from app.services.qb_report_import import import_deposit_report
+
+    assert (
+        import_deposit_report(db_session, DEPOSIT_FIXTURE.read_text())["deposits"] == 2
+    )
+    second = import_deposit_report(db_session, DEPOSIT_FIXTURE.read_text())
+    assert second["deposits"] == 0
+    assert second["duplicates_skipped"] == 2
+    assert db_session.query(Transaction).filter_by(source_type="deposit").count() == 2
+
+
+def test_check_report_imports_balanced_journals(db_session, seed_accounts):
+    from app.models.transactions import Transaction, TransactionLine
+    from app.services.qb_report_import import import_check_report
+
+    result = import_check_report(db_session, CHECK_FIXTURE.read_text())
+    assert result["errors"] == [], result
+    assert result["checks"] == 4
+
+    checks = db_session.query(Transaction).filter_by(source_type="check").all()
+    assert len(checks) == 4
+    checking = seed_accounts["1000"]
+    credits = set()
+    for txn in checks:
+        dr, cr = _sum_dr_cr(db_session, txn.id)
+        assert dr == cr
+        bank_line = (
+            db_session.query(TransactionLine)
+            .filter_by(transaction_id=txn.id, account_id=checking.id)
+            .first()
+        )
+        credits.add(Decimal(str(bank_line.credit)))
+    assert credits == {
+        Decimal("30.20"),
+        Decimal("190.90"),
+        Decimal("1185.90"),
+        Decimal("711.12"),
+    }
+    # Numbered check keeps its number in the reference
+    numbered = (
+        db_session.query(Transaction)
+        .filter_by(source_type="check", reference="1045")
+        .first()
+    )
+    assert numbered is not None
+    assert "Registry of Vehicles" in numbered.description
+
+
+def test_check_report_rerun_skips_duplicates(db_session, seed_accounts):
+    from app.services.qb_report_import import import_check_report
+
+    assert import_check_report(db_session, CHECK_FIXTURE.read_text())["checks"] == 4
+    second = import_check_report(db_session, CHECK_FIXTURE.read_text())
+    assert second["checks"] == 0
+    assert second["duplicates_skipped"] == 4
+
+
+def test_check_report_unknown_account_errors_that_block_only(db_session, seed_accounts):
+    from app.services.qb_report_import import import_check_report
+
+    text = CHECK_FIXTURE.read_text().replace("Office Supplies", "No Such Account")
+    result = import_check_report(db_session, text)
+    assert result["checks"] == 3
+    assert len(result["errors"]) == 1
+    assert (
+        "No Such Account" in result["errors"][0]
+        and "chart of accounts" in result["errors"][0]
+    )
+
+
+def test_qb_report_endpoint_autodetects(client, seed_accounts):
+    r = client.post(
+        "/api/csv/import/qb-report",
+        files={"file": ("Deposits.csv", DEPOSIT_FIXTURE.read_bytes(), "text/csv")},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["detected"] == "deposits"
+    assert body["deposits"] == 2
+
+    r = client.post(
+        "/api/csv/import/qb-report",
+        files={"file": ("Checks.csv", CHECK_FIXTURE.read_bytes(), "text/csv")},
+    )
+    assert r.json()["detected"] == "checks"
+    assert r.json()["checks"] == 4
+
+    r = client.post(
+        "/api/csv/import/qb-report",
+        files={"file": ("receipts.csv", FIXTURE.read_bytes(), "text/csv")},
+    )
+    assert r.json()["detected"] == "sales_receipts"
+    assert r.json()["sales_receipts"] == 3
+
+    r = client.post(
+        "/api/csv/import/qb-report",
+        files={"file": ("junk.csv", b"a,b\n1,2\n", "text/csv")},
+    )
+    body = r.json()
+    assert body["detected"] is None
+    assert body["errors"] and "Unrecognized report layout" in body["errors"][0]
+
+
+def test_payroll_check_with_withholding_contra_lines(db_session, seed_accounts):
+    """A payroll check: gross wages DR, withholding lines CR their
+    liability accounts, netting to the check amount — the sign-aware
+    parse the real customer file demanded (abs() fails the balance gate
+    on every payroll check)."""
+    from app.models.transactions import Transaction, TransactionLine
+    from app.services.qb_report_import import import_check_report
+
+    result = import_check_report(db_session, CHECK_FIXTURE.read_text())
+    assert result["errors"] == [], result
+    assert result["checks"] == 4
+
+    payroll = (
+        db_session.query(Transaction)
+        .filter(Transaction.source_type == "check", Transaction.reference == "27866")
+        .first()
+    )
+    assert payroll is not None
+    lines = db_session.query(TransactionLine).filter_by(transaction_id=payroll.id).all()
+    by_acct = {
+        line.account_id: (Decimal(str(line.debit)), Decimal(str(line.credit)))
+        for line in lines
+    }
+    checking = seed_accounts["1000"]
+    wages = next(a for a in seed_accounts.values() if a.name == "Wages & Salaries")
+    fed = next(
+        a for a in seed_accounts.values() if a.name == "Federal Income Tax Payable"
+    )
+    assert by_acct[checking.id] == (Decimal("0"), Decimal("711.12"))
+    assert by_acct[wages.id] == (Decimal("1250.00"), Decimal("0"))
+    assert by_acct[fed.id] == (Decimal("0"), Decimal("275.00"))
+    dr = sum(d for d, _ in by_acct.values())
+    cr = sum(c for _, c in by_acct.values())
+    assert dr == cr


### PR DESCRIPTION
**UNPARKED — releasing as part of v2.6.2.**

QuickBooks Desktop can't export transactions to IIF, so this PR gives its report exports a landing zone. One upload — **QuickBooks Interop → Import from Report CSV**, `POST /api/csv/import/qb-report` — auto-detects the report by column signature and imports:

- **Transaction Detail (filtered to Sales Receipt)** → paid invoice + payment pairs (`is_sales_receipt`), the same documents the Enter Sales Receipts screen produces. Sign-aware: applied-deposit contra lines reduce the total (the customer's first receipt would import $2,000 high through an abs() parse); percentage tax rows carry the tax agency's name and are never mistaken for customers.
- **Deposit Detail** → journal-only Transactions (`source_type="deposit"`, DR bank / CR the deposited payments' source accounts), identical to Make Deposits and the IIF DEPOSIT importer. Sum-to-zero gate per block.
- **Check Detail** → journal-only Transactions (`source_type="check"`, CR bank / signed splits) that appear in the check register. **Payroll checks work**: withholding lines credit their liability accounts and net gross wages to the check amount — the third document type where real data demanded sign preservation over abs().

Safety rails across all three: per-block balance gates with per-block errors (one bad block never kills the file), dedup on re-upload, missing-account errors that point at importing the chart of accounts (IIF lists) first, numbers preserved where free (SR-prefix on collision).

## Validation

Every parser was shaped by and validated against a **real customer's exports** (RV dealer, the user who requested sales receipts): 3/3 receipts, 2/2 deposits, 9/9 checks — including a $711.12 payroll check netting $1,250 gross against four withholding accounts — all journals balanced, full dedup on re-run. Real files are not committed; fixtures are anonymized structural recreations.

14 tests in `test_qb_report_import.py`; full suite **1194 passed**; black + ruff clean. Docs: `migrate-from-quickbooks.md` report section covers all three exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)