### PR TITLE
QB report import: post-merge review follow-ups from #62

### DIFF
--- a/app/routes/csv.py
+++ b/app/routes/csv.py
@@ -5,7 +5,7 @@
 
 from datetime import date
 
-from fastapi import APIRouter, Depends, Request, UploadFile, File, Query
+from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File, Query
 from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
@@ -79,11 +79,28 @@ def csv_export_accounts(request: Request, db: Session = Depends(get_db)):
     return _csv_response(csv_data, "chart_of_accounts.csv", request)
 
 
+def _decode_csv_upload(raw: bytes) -> str:
+    """Decode an uploaded CSV: UTF-8 (BOM-tolerant) first, then
+    Windows-1252 — QB Desktop's Print -> Save as CSV frequently writes
+    ANSI, and a payee like "José" previously 500'd (#62 review)."""
+    try:
+        return raw.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        try:
+            return raw.decode("cp1252")
+        except UnicodeDecodeError:
+            raise HTTPException(
+                status_code=400,
+                detail="Could not read the file as text. Re-export it as a "
+                "UTF-8 / standard CSV and try again.",
+            )
+
+
 @router.post("/import/customers")
 async def csv_import_customers(
     file: UploadFile = File(...), db: Session = Depends(get_db)
 ):
-    content = (await read_limited(file, label="CSV file")).decode("utf-8-sig")
+    content = _decode_csv_upload(await read_limited(file, label="CSV file"))
     result = import_customers(db, content)
     return result
 
@@ -92,14 +109,14 @@ async def csv_import_customers(
 async def csv_import_vendors(
     file: UploadFile = File(...), db: Session = Depends(get_db)
 ):
-    content = (await read_limited(file, label="CSV file")).decode("utf-8-sig")
+    content = _decode_csv_upload(await read_limited(file, label="CSV file"))
     result = import_vendors(db, content)
     return result
 
 
 @router.post("/import/items")
 async def csv_import_items(file: UploadFile = File(...), db: Session = Depends(get_db)):
-    content = (await read_limited(file, label="CSV file")).decode("utf-8-sig")
+    content = _decode_csv_upload(await read_limited(file, label="CSV file"))
     result = import_items(db, content)
     return result
 
@@ -114,5 +131,5 @@ async def csv_import_qb_report(
     Deposit Detail, or Check Detail."""
     from app.services.qb_report_import import import_qb_report
 
-    content = (await read_limited(file, label="CSV file")).decode("utf-8-sig")
+    content = _decode_csv_upload(await read_limited(file, label="CSV file"))
     return import_qb_report(db, content)

--- a/app/services/qb_report_import.py
+++ b/app/services/qb_report_import.py
@@ -425,10 +425,16 @@ def import_sales_receipt_report(db: Session, csv_text: str) -> dict:
 # ============================================================================
 
 
-def _group_blocks(rows, cols, start, header_type):
+def _group_blocks(rows, cols, start, header_type, skipped=None):
     """Group report rows into blocks: a Type==header_type row starts a
     block, a TOTAL rail ends it, everything between with an Account is a
-    detail line."""
+    detail line.
+
+    A dated, typed row OUTSIDE any block is a block header of some other
+    transaction type (Check Detail reports can carry "Bill Pmt -Check",
+    "Paycheck", and "Transfer" blocks) — tallied into `skipped` so the
+    importer can warn instead of silently dropping them (#62 review).
+    """
     blocks = []
     current = None
     for n, row in enumerate(rows[start + 1 :], start=start + 2):
@@ -440,6 +446,14 @@ def _group_blocks(rows, cols, start, header_type):
         if rtype == header_type:
             current = {"row": n, "header": row, "details": []}
             blocks.append(current)
+            continue
+        if (
+            skipped is not None
+            and current is None
+            and rtype
+            and _parse_date(_cell(row, cols, "Date"))
+        ):
+            skipped[rtype] = skipped.get(rtype, 0) + 1
             continue
         if current is not None and _cell(row, cols, "Account"):
             current["details"].append(row)
@@ -455,7 +469,8 @@ def import_deposit_report(db: Session, csv_text: str) -> dict:
         result["errors"].append("Could not find the Deposit Detail header row.")
         return result
 
-    for block in _group_blocks(rows, cols, header_idx, "Deposit"):
+    skipped_types = {}
+    for block in _group_blocks(rows, cols, header_idx, "Deposit", skipped_types):
         sp = db.begin_nested()
         try:
             hdr = block["header"]
@@ -539,6 +554,11 @@ def import_deposit_report(db: Session, csv_text: str) -> dict:
             sp.rollback()
             result["errors"].append(f"Deposit block at row {block['row']}: {e}")
 
+    for btype, count in sorted(skipped_types.items()):
+        result["warnings"].append(
+            f"{count} '{btype}' block(s) skipped — this report import "
+            "handles Deposit blocks only"
+        )
     db.commit()
     return result
 
@@ -564,7 +584,8 @@ def import_check_report(db: Session, csv_text: str) -> dict:
         result["errors"].append("Could not find the Check Detail header row.")
         return result
 
-    for block in _group_blocks(rows, cols, header_idx, "Check"):
+    skipped_types = {}
+    for block in _group_blocks(rows, cols, header_idx, "Check", skipped_types):
         sp = db.begin_nested()
         try:
             hdr = block["header"]
@@ -663,6 +684,12 @@ def import_check_report(db: Session, csv_text: str) -> dict:
             sp.rollback()
             result["errors"].append(f"Check block at row {block['row']}: {e}")
 
+    for btype, count in sorted(skipped_types.items()):
+        result["warnings"].append(
+            f"{count} '{btype}' block(s) skipped — this report import "
+            "handles Check blocks only (Bill Pmt -Check, Paycheck, and "
+            "Transfer support is on the roadmap)"
+        )
     db.commit()
     return result
 
@@ -687,8 +714,10 @@ def detect_report_type(csv_text: str) -> str | None:
 def import_qb_report(db: Session, csv_text: str) -> dict:
     """Import any supported QB report CSV, auto-detected by its columns.
 
-    Check detection runs before deposit: the check signature is a strict
-    superset of the deposit signature minus Amount, so ordering matters.
+    Detection order (receipts, checks, deposits) is cosmetic: the three
+    column signatures are mutually exclusive on exact cell matches — the
+    deposit signature's bare "Amount" never appears in a check header
+    ("Original Amount"/"Paid Amount" are distinct cells). (#62 review)
     """
     kind = detect_report_type(csv_text)
     base = {

--- a/tests/test_qb_report_import.py
+++ b/tests/test_qb_report_import.py
@@ -319,3 +319,61 @@ def test_payroll_check_with_withholding_contra_lines(db_session, seed_accounts):
     dr = sum(d for d, _ in by_acct.values())
     cr = sum(c for _, c in by_acct.values())
     assert dr == cr
+
+
+# ---------------------------------------------------------------------------
+# #62 post-merge review follow-ups (Keith)
+# ---------------------------------------------------------------------------
+
+BILL_PMT_BLOCK = (
+    " ,,,,,,,,,\n"
+    ",Bill Pmt -Check,03/07/26,2001,Parts Supplier Co,,,Checking,-250.00,\n"
+    " ,,,,,,,,,\n"
+    ",,,,,inv 4451,,Accounts Payable,250.00,-250.00\n"
+    "TOTAL,,,,,,,,250.00,-250.00\n"
+)
+
+
+def test_unrecognized_check_block_types_are_warned_not_silent(
+    db_session, seed_accounts
+):
+    """A Check Detail export can carry Bill Pmt -Check / Paycheck /
+    Transfer blocks; they aren't supported yet but must be COUNTED, not
+    silently dropped."""
+    from app.services.qb_report_import import import_check_report
+
+    text = CHECK_FIXTURE.read_text() + BILL_PMT_BLOCK
+    result = import_check_report(db_session, text)
+    assert result["checks"] == 4  # the real checks still import
+    assert result["errors"] == []
+    assert any(
+        "Bill Pmt -Check" in w and "skipped" in w for w in result["warnings"]
+    ), result["warnings"]
+
+
+def test_cp1252_export_decodes_instead_of_500(client, seed_accounts):
+    """QB Desktop's Save-as-CSV often writes Windows-1252; a payee like
+    'José' must import, not UnicodeDecodeError into a 500."""
+    text = CHECK_FIXTURE.read_text().replace("Freight Express", "José Hernández")
+    raw = text.encode("cp1252")
+    r = client.post(
+        "/api/csv/import/qb-report",
+        files={"file": ("checks.csv", raw, "text/csv")},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["detected"] == "checks"
+    assert body["checks"] == 4
+    receipts = client.get("/api/invoices?limit=10").json()  # sanity: api alive
+    assert isinstance(receipts, list)
+
+
+def test_undecodable_upload_gets_400_not_500(client, seed_accounts):
+    # 0x81 is undefined in cp1252 and invalid UTF-8 continuation
+    raw = b"\xff\xfe\x81\x81 not really text \x81"
+    r = client.post(
+        "/api/csv/import/qb-report",
+        files={"file": ("junk.csv", raw, "text/csv")},
+    )
+    assert r.status_code == 400
+    assert "UTF-8" in r.json()["detail"]


### PR DESCRIPTION
**PARKED — rides with the next release.** All three findings from @ContractorKeith's post-merge review of #62, verified real and fixed:

1. **Skipped block types now warn** — `Bill Pmt -Check`, `Paycheck`, and `Transfer` blocks in a Check Detail export were silently dropped; they're now tallied into warnings ("N 'Bill Pmt -Check' block(s) skipped — … support is on the roadmap"), so nobody believes a partial import was complete. Same guard on the Deposit path.
2. **Windows-1252 fallback on all four CSV import endpoints** — QB Desktop's Save-as-CSV frequently writes ANSI; "José" now imports instead of 500ing, and a file neither UTF-8 nor cp1252 can read gets a guided 400.
3. **Docstring corrected** — detection ordering is cosmetic; the three signatures are mutually exclusive on exact cell matches, exactly as the review noted.

3 regression tests (unsupported-block warning, cp1252 end-to-end through the endpoint, undecodable→400). Full suite **1201 passed**; black + ruff clean. Pure backend — no platform implications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)