### PR TITLE
IIF import: read the QuickBooks class list (!CLASS)

### DIFF
--- a/app/schemas/iif.py
+++ b/app/schemas/iif.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel
 
 
 class IIFImportResult(BaseModel):
+    classes: int = 0
     accounts: int = 0
     customers: int = 0
     vendors: int = 0

--- a/app/services/iif_import.py
+++ b/app/services/iif_import.py
@@ -6,7 +6,7 @@
 # and collects per-row errors instead of aborting the entire import.
 #
 # Import order mirrors dependency chain:
-#   accounts -> customers -> vendors -> items -> transactions
+#   classes -> accounts -> customers -> vendors -> items -> transactions
 #
 # Duplicate detection: matches on name (accounts, customers, vendors, items)
 # or document number (invoices, payments) to prevent re-import collisions.
@@ -19,6 +19,7 @@ from decimal import Decimal, InvalidOperation
 from sqlalchemy.orm import Session
 
 from app.models.accounts import Account, AccountType
+from app.models.classes import TxnClass
 from app.models.contacts import Customer, Vendor
 from app.models.items import Item, ItemType
 from app.models.invoices import Invoice, InvoiceLine, InvoiceStatus
@@ -44,14 +45,20 @@ logger = logging.getLogger(__name__)
 def parse_iif(content: str) -> dict:
     """Parse IIF file content into structured sections.
 
-    Returns dict with keys like "ACCNT", "CUST", "VEND", "INVITEM",
-    and "TRNS" (list of transaction blocks).
+    Returns dict with keys like "ACCNT", "CLASS", "CUST", "VEND",
+    "INVITEM", and "TRNS" (list of transaction blocks).
 
     Each list/row section contains dicts keyed by header field names.
     Transaction blocks group TRNS + SPL lines until ENDTRNS.
     """
     result = {
         "ACCNT": [],
+        # QuickBooks exports the class list separately from transactions
+        # (File > Utilities > Export > Lists > Class List). A transaction
+        # IIF only ever carries CLASS as a column on SPL rows, never the
+        # definitions — so without this section there is nothing for
+        # _resolve_block_class to find.
+        "CLASS": [],
         "CUST": [],
         "VEND": [],
         "INVITEM": [],
@@ -104,7 +111,7 @@ def parse_iif(content: str) -> dict:
                 current_txn["spl"].append(row_dict)
             continue
 
-        # List rows: ACCNT, CUST, VEND, INVITEM
+        # List rows: ACCNT, CLASS, CUST, VEND, INVITEM
         if row_type in result and row_type != "TRNS":
             hdr = headers.get(row_type, [])
             row_dict = _fields_to_dict(hdr, fields)
@@ -215,6 +222,74 @@ def _find_account(db: Session, name: str) -> Account:
 # ============================================================================
 # Import Functions
 # ============================================================================
+
+
+# Read off the column rather than hardcoding 100, so the two can't drift.
+_CLASS_NAME_MAX = TxnClass.__table__.c.name.type.length
+
+
+def import_classes(db: Session, rows: list) -> dict:
+    """Import class-list rows (!CLASS) from IIF.
+
+    Names are stored verbatim, including QuickBooks' "Parent:Child"
+    subclass path. Classes are flat here, but the SPL CLASS column uses
+    that same full path, so keeping it intact is exactly what makes the
+    two match at transaction time.
+    """
+    imported = 0
+    errors = []
+
+    for i, row in enumerate(rows):
+        sp = db.begin_nested()
+        try:
+            name = row.get("NAME", "").strip()
+            if not name:
+                errors.append({"row": i + 1, "message": "Missing class NAME"})
+                sp.rollback()
+                continue
+
+            # Deliberately NOT truncated the way vendor/customer names are.
+            # A shortened class still imports but then matches no SPL CLASS
+            # value, so the problem resurfaces as a puzzling "class not
+            # found" on every transaction that cites it. Refuse the one row
+            # and name the limit instead.
+            if len(name) > _CLASS_NAME_MAX:
+                errors.append(
+                    {
+                        "row": i + 1,
+                        "message": (
+                            f"Class '{name[:40]}...' is {len(name)} characters, "
+                            f"over the {_CLASS_NAME_MAX}-character limit — "
+                            f"shorten it in QuickBooks and re-export"
+                        ),
+                    }
+                )
+                sp.rollback()
+                continue
+
+            # Case-insensitive dedup, matching both resolve_class_id's lookup
+            # and POST /api/classes' conflict check, so re-importing the same
+            # list is a no-op rather than a unique-constraint failure.
+            existing = db.query(TxnClass).filter(TxnClass.name.ilike(name)).first()
+            if existing:
+                sp.rollback()
+                continue
+
+            # QuickBooks flags inactive list entries with HIDDEN=Y, which is
+            # what archived means here: kept on historical rows, absent from
+            # entry-form dropdowns. Missing column -> "" -> active.
+            hidden = row.get("HIDDEN", "").strip().upper() in ("Y", "YES", "TRUE")
+
+            db.add(TxnClass(name=name, is_archived=hidden))
+            db.flush()
+            sp.commit()
+            imported += 1
+
+        except Exception as e:
+            sp.rollback()
+            errors.append({"row": i + 1, "message": str(e)})
+
+    return {"imported": imported, "errors": errors}
 
 
 def import_accounts(db: Session, rows: list) -> dict:
@@ -705,8 +780,10 @@ def _resolve_block_class(db: Session, trns_type: str, doc_ref: str, spls: list):
     class_id = resolve_class_id(db, name)
     if class_id is None:
         raise ValueError(
-            f"{trns_type} {doc_ref}: class '{name}' not found. Create it under "
-            f"Settings → Classes first, or correct the CLASS in the IIF file."
+            f"{trns_type} {doc_ref}: class '{name}' not found. Import your "
+            f"QuickBooks class list (File > Utilities > Export > Lists > Class "
+            f"List) or create it under Settings → Classes first, or correct "
+            f"the CLASS in the IIF file."
         )
     return class_id
 
@@ -1528,7 +1605,7 @@ def validate_iif(content: str) -> dict:
         return report
 
     # Check what sections exist
-    for section in ["ACCNT", "CUST", "VEND", "INVITEM"]:
+    for section in ["ACCNT", "CLASS", "CUST", "VEND", "INVITEM"]:
         count = len(parsed.get(section, []))
         if count > 0:
             report["sections_found"].append(section)
@@ -1555,6 +1632,19 @@ def validate_iif(content: str) -> dict:
             report["warnings"].append(
                 f"Account '{name}': unrecognized type '{atype}' (will default to Expense)"
             )
+
+    # Validate classes
+    for i, row in enumerate(parsed.get("CLASS", [])):
+        name = row.get("NAME", "").strip()
+        if not name:
+            report["errors"].append(f"Class row {i + 1}: missing NAME")
+            report["valid"] = False
+        elif len(name) > _CLASS_NAME_MAX:
+            report["errors"].append(
+                f"Class row {i + 1}: name is {len(name)} characters, over the "
+                f"{_CLASS_NAME_MAX}-character limit"
+            )
+            report["valid"] = False
 
     # Validate customers
     for i, row in enumerate(parsed.get("CUST", [])):
@@ -1618,10 +1708,12 @@ def validate_iif(content: str) -> dict:
 def import_all(db: Session, content: str) -> dict:
     """Import an entire IIF file into Slowbooks.
 
-    Processes in dependency order: accounts -> customers -> vendors -> items -> transactions.
+    Processes in dependency order: classes -> accounts -> customers ->
+    vendors -> items -> transactions.
     Returns counts of imported records and any errors.
     """
     result = {
+        "classes": 0,
         "accounts": 0,
         "opening_balance_lines": 0,
         "customers": 0,
@@ -1640,6 +1732,15 @@ def import_all(db: Session, content: str) -> dict:
     parsed = parse_iif(content)
 
     # Import lists first (order matters for FK resolution)
+
+    # Classes have no dependencies of their own, but transactions cite them
+    # by name and _resolve_block_class refuses unknown ones — so the list
+    # lands before anything that can carry a CLASS.
+    if parsed["CLASS"]:
+        r = import_classes(db, parsed["CLASS"])
+        result["classes"] = r["imported"]
+        result["errors"].extend(r["errors"])
+
     if parsed["ACCNT"]:
         r = import_accounts(db, parsed["ACCNT"])
         result["accounts"] = r["imported"]

--- a/app/static/js/iif.js
+++ b/app/static/js/iif.js
@@ -374,7 +374,7 @@ const IIFPage = {
             const result = await res.json();
             IIFPage._showImportResult(result);
 
-            const total = (result.accounts || 0) + (result.customers || 0) +
+            const total = (result.classes || 0) + (result.accounts || 0) + (result.customers || 0) +
                           (result.vendors || 0) + (result.items || 0) +
                           (result.invoices || 0) + (result.payments || 0) +
                           (result.sales_receipts || 0) +
@@ -390,6 +390,7 @@ const IIFPage = {
 
     _showImportResult(result) {
         const sections = [
+            ['Classes', result.classes],
             ['Accounts', result.accounts],
             ['Customers', result.customers],
             ['Vendors', result.vendors],

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -239,3 +239,147 @@ def test_iif_bill_unknown_class_errors(db_session, seed_accounts):
     result = import_all(db_session, iif)
     assert result["bills"] == 0
     assert any("No Such Class" in e["message"] for e in result["errors"])
+
+
+# ── IIF class list (!CLASS) ──────────────────────────────────────────────
+
+
+# Shape of a real QuickBooks class-list export: File > Utilities > Export >
+# Lists > Class List. "Main Office:North" is a subclass — QB writes the full
+# parent:child path here AND in the SPL CLASS column, so it has to survive
+# the round trip verbatim for the two to match.
+IIF_CLASS_LIST = (
+    "!CLASS\tNAME\tREFNUM\tTIMESTAMP\tBASETYPE\tEXTRA\n"
+    "CLASS\tSide Gig\t1\t1187300000\tCLASS\t\n"
+    "CLASS\tMain Office\t2\t1187300000\tCLASS\t\n"
+    "CLASS\tMain Office:North\t3\t1187300000\tCLASS\t\n"
+)
+
+
+def _class_names(db_session):
+    return {c.name for c in db_session.query(TxnClass).all()}
+
+
+def test_iif_class_list_imports(db_session):
+    from app.services.iif_import import import_all
+
+    result = import_all(db_session, IIF_CLASS_LIST)
+    assert result["classes"] == 3, result["errors"]
+    assert not result["errors"]
+    names = _class_names(db_session)
+    assert {"Side Gig", "Main Office", "Main Office:North"} <= names
+
+
+def test_iif_class_list_dedups_case_insensitively(client, db_session):
+    from app.services.iif_import import import_all
+
+    client.post("/api/classes", json={"name": "side gig"})
+
+    result = import_all(db_session, IIF_CLASS_LIST)
+    assert result["classes"] == 2, result["errors"]
+    # The pre-existing row keeps its own casing; no second "Side Gig" appears.
+    names = _class_names(db_session)
+    assert "side gig" in names
+    assert "Side Gig" not in names
+
+
+def test_iif_class_list_reimport_is_a_noop(db_session):
+    from app.services.iif_import import import_all
+
+    import_all(db_session, IIF_CLASS_LIST)
+    again = import_all(db_session, IIF_CLASS_LIST)
+    assert again["classes"] == 0
+    assert not again["errors"]
+    assert db_session.query(TxnClass).filter(TxnClass.name == "Side Gig").count() == 1
+
+
+def test_iif_class_hidden_imports_archived(db_session):
+    from app.services.iif_import import import_all
+
+    iif = (
+        "!CLASS\tNAME\tREFNUM\tTIMESTAMP\tBASETYPE\tEXTRA\tHIDDEN\n"
+        "CLASS\tRetired Division\t1\t1187300000\tCLASS\t\tY\n"
+        "CLASS\tLive Division\t2\t1187300000\tCLASS\t\tN\n"
+    )
+    result = import_all(db_session, iif)
+    assert result["classes"] == 2, result["errors"]
+    retired = (
+        db_session.query(TxnClass).filter(TxnClass.name == "Retired Division").one()
+    )
+    live = db_session.query(TxnClass).filter(TxnClass.name == "Live Division").one()
+    assert retired.is_archived is True
+    assert live.is_archived is False
+
+
+def test_iif_class_missing_name_errors(db_session):
+    from app.services.iif_import import import_all
+
+    iif = (
+        "!CLASS\tNAME\tREFNUM\tTIMESTAMP\tBASETYPE\tEXTRA\n"
+        "CLASS\t\t1\t1187300000\tCLASS\t\n"
+        "CLASS\tGood One\t2\t1187300000\tCLASS\t\n"
+    )
+    result = import_all(db_session, iif)
+    assert result["classes"] == 1
+    assert any("Missing class NAME" in e["message"] for e in result["errors"])
+
+
+def test_iif_class_overlong_name_errors_rather_than_truncating(db_session):
+    """A truncated class would import but never match its SPL CLASS value."""
+    from app.services.iif_import import _CLASS_NAME_MAX, import_all
+
+    long_name = "L" * (_CLASS_NAME_MAX + 1)
+    iif = (
+        "!CLASS\tNAME\tREFNUM\tTIMESTAMP\tBASETYPE\tEXTRA\n"
+        f"CLASS\t{long_name}\t1\t1187300000\tCLASS\t\n"
+    )
+    result = import_all(db_session, iif)
+    assert result["classes"] == 0
+    assert any(str(_CLASS_NAME_MAX) in e["message"] for e in result["errors"])
+    assert db_session.query(TxnClass).filter(TxnClass.name == long_name).count() == 0
+
+
+def test_iif_class_list_then_transaction_resolves(db_session, seed_accounts):
+    """End-to-end: one file carrying both the class list and a bill that
+    cites it imports cleanly, with no class pre-created by hand."""
+    from app.models.bills import Bill
+    from app.models.contacts import Vendor
+    from app.services.iif_import import import_all
+
+    db_session.add(Vendor(name="Apple Store", is_active=True))
+    db_session.commit()
+
+    result = import_all(db_session, IIF_CLASS_LIST + IIF_BILL_WITH_CLASS)
+    assert result["classes"] == 3, result["errors"]
+    assert result["bills"] == 1, result["errors"]
+
+    cls = db_session.query(TxnClass).filter(TxnClass.name == "Side Gig").one()
+    bill = db_session.query(Bill).filter(Bill.bill_number == "B-CL-1").one()
+    assert bill.class_id == cls.id
+    txn = db_session.get(Transaction, bill.transaction_id)
+    assert txn.class_id == cls.id
+
+
+def test_iif_class_list_imports_before_transactions_regardless_of_order(
+    db_session, seed_accounts
+):
+    """The class list still lands first when it trails the transactions."""
+    from app.models.bills import Bill
+    from app.models.contacts import Vendor
+    from app.services.iif_import import import_all
+
+    db_session.add(Vendor(name="Apple Store", is_active=True))
+    db_session.commit()
+
+    result = import_all(db_session, IIF_BILL_WITH_CLASS + IIF_CLASS_LIST)
+    assert result["bills"] == 1, result["errors"]
+    assert db_session.query(Bill).filter(Bill.bill_number == "B-CL-1").one().class_id
+
+
+def test_validate_reports_class_section():
+    from app.services.iif_import import validate_iif
+
+    report = validate_iif(IIF_CLASS_LIST)
+    assert report["valid"] is True
+    assert "CLASS" in report["sections_found"]
+    assert report["record_counts"]["CLASS"] == 3


### PR DESCRIPTION
## The problem

A user migrating from QuickBooks reported that their classes didn't come through on the IIF import. Two reasons, both by design until now:

1. **The parser didn't recognize a class list.** `parse_iif()` only collected `ACCNT`, `CUST`, `VEND` and `INVITEM`. A QuickBooks class-list export (**File > Utilities > Export > Lists > Class List**) hit the "skips unknown sections" path and vanished silently.
2. **A transaction IIF never carries the class definitions anyway** — `CLASS` appears only as a column on `SPL` rows, as a name reference.

So there was no path into the `classes` table short of typing every name into Settings → Classes by hand, and `_resolve_block_class` failed every document citing an unknown class:

> `BILL B-1234: class 'Side Gig' not found. Create it under Settings → Classes first...`

## The change

`parse_iif()` collects `CLASS`, and `import_classes()` runs ahead of anything that can carry a `CLASS` — so one file holding both the list and the transactions imports cleanly, in either section order. `validate_iif()` counts and checks the section so the pre-flight report shows classes before the user commits. The import-results panel and `IIFImportResult` gained a `classes` count.

### Judgment calls worth a look

- **`Parent:Child` is kept verbatim.** QuickBooks writes the full subclass path in *both* the class list and the `SPL CLASS` column. Classes are flat here, so keeping the path intact is precisely what makes the two match — flattening to `North` would break every transaction citing it.
- **Over-length names are refused, not truncated** the way vendor names are (`[:200]`). A truncated class imports fine and then matches no `SPL CLASS` value, so the problem resurfaces as a puzzling "class not found" on every transaction that cites it. The limit is read off the column so it can't drift from the model.
- **`HIDDEN=Y` imports as archived.** Same meaning on both sides: kept on historical rows, gone from entry-form dropdowns. Files without the column are unaffected.
- **Dedup is case-insensitive**, matching `resolve_class_id()` and `POST /api/classes`, so re-importing a list is a no-op rather than a unique-constraint failure.
- **Strict resolution is deliberately unchanged.** An unknown `CLASS` on an `SPL` row still fails its document rather than being auto-created — a messy file would otherwise mass-create typo'd classes. Only the error message changed, to name the list export as the fix. Happy to revisit if we'd rather auto-create.

## Testing

9 new tests in `tests/test_classes.py`: list import, case-insensitive dedup, re-import no-op, `HIDDEN`→archived, missing name, over-length refusal, end-to-end list+bill in one file, reversed section order, and the validation report.

- `tests/test_classes.py` — 19 passed
- **Full suite — 1207 passed**
- `ruff` and `black` clean

## Out of scope, but noted

`iif_export.py` never emits classes at all — not as a `!CLASS` list, not as a `CLASS` column on `SPL` rows — so exporting back to QuickBooks silently drops the dimension. Symmetric gap, separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
