### PR TITLE
OCR engine seam: platform-native adapters behind one interface (step 1.5)

### DIFF
--- a/app/routes/ocr.py
+++ b/app/routes/ocr.py
@@ -25,8 +25,9 @@ from app.schemas.ocr import (
     OcrField,
     OcrReceiptResponse,
     OcrStatusResponse,
+    OcrWordBox,
 )
-from app.services import ocr_service, storage
+from app.services import ocr_engines, ocr_service, storage
 from app.services.rate_limit import limiter
 from app.services.upload_limits import MAX_IMPORT_BYTES, read_limited
 
@@ -40,12 +41,6 @@ _SAFE_FILENAME_RE = re.compile(r"[^A-Za-z0-9 ._()\-]")
 
 STATIC_BASE = storage.files_root().resolve()
 UPLOAD_BASE = (STATIC_BASE / "uploads" / "attachments").resolve()
-
-_TESSERACT_MESSAGE = (
-    "Tesseract OCR is not installed. Install it to enable scanning "
-    "(Ubuntu: sudo apt-get install tesseract-ocr; macOS: brew install "
-    "tesseract; Windows: see Settings for an installer link)."
-)
 
 
 def _sanitize_filename(raw: str) -> str:
@@ -62,12 +57,14 @@ def _sanitize_filename(raw: str) -> str:
 
 @router.get("/status", response_model=OcrStatusResponse)
 def ocr_status():
-    """Frontend gating + Settings-page status row (spec §6.6)."""
-    info = ocr_service.tesseract_info()
+    """Frontend gating + Settings-page status row (spec §6.6). Reports the
+    active engine for this platform (engine seam, design doc §engines)."""
+    info = ocr_engines.engine_status()
     return OcrStatusResponse(
         available=info["available"],
         version=info["version"],
         languages=info["languages"] or None,
+        engine=info["engine"],
     )
 
 
@@ -91,8 +88,10 @@ async def scan_receipt(request: Request, file: UploadFile = File(...)):
             status_code=400, detail=f"File extension '{extension}' not allowed"
         )
 
-    if not ocr_service.tesseract_available():
-        return OcrReceiptResponse(ocr_available=False, message=_TESSERACT_MESSAGE)
+    engine = ocr_engines.get_engine()
+    reason = engine.unavailable_reason()
+    if reason:
+        return OcrReceiptResponse(ocr_available=False, message=reason)
 
     # Rasterize PDFs via poppler-utils (page 1, per spec §3); images pass
     # through as-is — Tesseract decodes PNG/JPEG/WebP natively, so no image
@@ -107,21 +106,19 @@ async def scan_receipt(request: Request, file: UploadFile = File(...)):
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
-    lang = ocr_service.ocr_language()
-    if lang is None:
-        return OcrReceiptResponse(
-            ocr_available=False,
-            message=(
-                "Tesseract is installed but has no usable language data "
-                "(expected at least 'eng'). Install the tesseract-ocr "
-                "language packs and try again."
-            ),
-        )
-
     try:
-        raw_text = ocr_service.ocr_image_bytes(ocr_input, lang=lang)
+        result = engine.recognize(ocr_input)
+    except ocr_engines.EngineUnavailable as exc:
+        return OcrReceiptResponse(ocr_available=False, message=str(exc))
     except ocr_service.OCRRuntimeError as exc:
-        raise HTTPException(status_code=500, detail=f"OCR failed: {exc}")
+        # The engine ran and rejected the input — a corrupt or non-image
+        # file with a valid MIME type is the user's to fix, not a 500.
+        raise HTTPException(
+            status_code=400,
+            detail=f"Could not read the image — is it a valid receipt scan? ({exc})",
+        )
+    raw_text = result.text
+    lang = result.language
 
     extracted = ocr_service.extract_receipt(raw_text)
     intake_id = ocr_service.save_intake(
@@ -155,6 +152,8 @@ async def scan_receipt(request: Request, file: UploadFile = File(...)):
         tax=extracted["tax"],
         tax_detected=extracted["tax_detected"],
         language=lang,
+        engine=result.engine,
+        words=[OcrWordBox(**vars(w)) for w in result.words] or None,
         multi_page=multi_page,
         partial=bool(partial_reasons),
         partial_reasons=partial_reasons,

--- a/app/schemas/ocr.py
+++ b/app/schemas/ocr.py
@@ -9,11 +9,25 @@ from pydantic import BaseModel
 
 
 class OcrStatusResponse(BaseModel):
-    """GET /api/ocr/status — is the Tesseract binary usable?"""
+    """GET /api/ocr/status — is an OCR engine usable, and which one?"""
 
     available: bool
     version: Optional[str] = None
     languages: Optional[list[str]] = None
+    # Which engine answers scans on this platform: tesseract | vision | winrt
+    engine: str = "tesseract"
+
+
+class OcrWordBox(BaseModel):
+    """A recognized word (or line, engine-dependent) with pixel bounds —
+    the v2 box-to-fix canvas draws these over the scanned image."""
+
+    text: str
+    left: int
+    top: int
+    width: int
+    height: int
+    conf: float = -1.0
 
 
 class OcrField(BaseModel):
@@ -47,6 +61,8 @@ class OcrReceiptResponse(BaseModel):
     tax_detected: bool = False
 
     language: Optional[str] = None
+    engine: Optional[str] = None
+    words: Optional[list[OcrWordBox]] = None
     multi_page: bool = False
 
     partial: bool = False

--- a/app/services/ocr_engines.py
+++ b/app/services/ocr_engines.py
@@ -1,0 +1,308 @@
+# ============================================================================
+# OCR engine seam — platform-native engines behind one interface.
+# See docs/design/receipt-intake.md § "OCR engine strategy".
+#
+# Engines: tesseract (Linux/Docker default; universal detect-if-present
+# fallback), Apple Vision (macOS, preinstalled), Windows.Media.Ocr
+# (Windows 10/11, preinstalled). Native adapters lazy-import their platform
+# bridges (pyobjc / winsdk) which ship only in the frozen desktop builds —
+# requirements.txt is untouched. Every adapter degrades to unavailable
+# rather than raising at import time.
+#
+# NOTE: the Vision and WinRT adapters are written to the platform APIs but
+# are HARDWARE-VERIFY-PENDING — they cannot execute on this repo's Linux CI.
+# The tesseract path is fully covered by tests.
+# ============================================================================
+
+import asyncio
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import Optional
+
+from app.services import ocr_service
+
+
+@dataclass
+class WordBox:
+    """One recognized word (or line, for engines that report lines) with its
+    pixel bounding box. The v2 canvas draws these."""
+
+    text: str
+    left: int
+    top: int
+    width: int
+    height: int
+    conf: float = -1.0
+
+
+@dataclass
+class OcrResult:
+    text: str
+    words: list[WordBox] = field(default_factory=list)
+    engine: str = "tesseract"
+    language: Optional[str] = None
+
+
+class EngineUnavailable(Exception):
+    """The selected engine cannot run on this machine right now."""
+
+
+# ---------------------------------------------------------------------------
+# Tesseract — delegates to ocr_service's probe/invoke functions so the
+# existing tests (which monkeypatch those) keep controlling behavior.
+# ---------------------------------------------------------------------------
+
+
+TESSERACT_MISSING_MESSAGE = (
+    "Tesseract OCR is not installed. Install it to enable scanning "
+    "(Ubuntu: sudo apt-get install tesseract-ocr; macOS: brew install "
+    "tesseract; Windows: see Settings for an installer link)."
+)
+LANGUAGE_DATA_MESSAGE = (
+    "Tesseract is installed but has no usable language data "
+    "(expected at least 'eng'). Install the tesseract-ocr "
+    "language packs and try again."
+)
+NATIVE_MISSING_MESSAGE = (
+    "No OCR engine is available. The built-in platform engine could not "
+    "start and Tesseract is not installed — install Tesseract to enable "
+    "scanning (see Settings)."
+)
+
+
+class TesseractEngine:
+    name = "tesseract"
+
+    def unavailable_reason(self) -> Optional[str]:
+        if not ocr_service.tesseract_available():
+            return TESSERACT_MISSING_MESSAGE
+        if ocr_service.ocr_language() is None:
+            return LANGUAGE_DATA_MESSAGE
+        return None
+
+    def info(self) -> dict:
+        raw = ocr_service.tesseract_info()
+        return {
+            "available": self.unavailable_reason() is None,
+            "version": raw["version"],
+            "languages": raw["languages"],
+        }
+
+    def available(self) -> bool:
+        return self.unavailable_reason() is None
+
+    def recognize(self, data: bytes, lang: Optional[str] = None) -> OcrResult:
+        lang = lang or ocr_service.ocr_language()
+        if lang is None:
+            raise EngineUnavailable("tesseract has no usable language data")
+        text, rows = ocr_service.ocr_image_words(data, lang=lang)
+        words = [WordBox(**row) for row in rows]
+        return OcrResult(text=text, words=words, engine=self.name, language=lang)
+
+
+# ---------------------------------------------------------------------------
+# Apple Vision (macOS) — VNRecognizeTextRequest via pyobjc.
+# Reports line-level boxes (Vision observations are lines, not words).
+# HARDWARE-VERIFY-PENDING.
+# ---------------------------------------------------------------------------
+
+
+class VisionEngine:
+    name = "vision"
+
+    def _bridge(self):
+        import Quartz  # pyobjc-framework-Quartz (frozen mac build only)
+        import Vision  # pyobjc-framework-Vision
+
+        return Quartz, Vision
+
+    def info(self) -> dict:
+        if sys.platform != "darwin":
+            return {"available": False, "version": None, "languages": None}
+        try:
+            self._bridge()
+        except Exception:
+            return {"available": False, "version": None, "languages": None}
+        return {"available": True, "version": "macOS Vision", "languages": None}
+
+    def available(self) -> bool:
+        return self.info()["available"]
+
+    def unavailable_reason(self) -> Optional[str]:
+        return None if self.available() else NATIVE_MISSING_MESSAGE
+
+    def recognize(self, data: bytes, lang: Optional[str] = None) -> OcrResult:
+        Quartz, Vision = self._bridge()
+        src = Quartz.CGImageSourceCreateWithData(data, None)
+        if src is None:
+            raise ocr_service.OCRRuntimeError("Could not decode the image")
+        img = Quartz.CGImageSourceCreateImageAtIndex(src, 0, None)
+        if img is None:
+            raise ocr_service.OCRRuntimeError("Could not decode the image")
+        width = Quartz.CGImageGetWidth(img)
+        height = Quartz.CGImageGetHeight(img)
+
+        handler = Vision.VNImageRequestHandler.alloc().initWithCGImage_options_(
+            img, None
+        )
+        request = Vision.VNRecognizeTextRequest.alloc().init()
+        request.setRecognitionLevel_(0)  # VNRequestTextRecognitionLevelAccurate
+        request.setUsesLanguageCorrection_(False)  # receipts aren't prose
+        ok, _err = handler.performRequests_error_([request], None)
+        if not ok:
+            raise ocr_service.OCRRuntimeError("Vision text recognition failed")
+
+        lines: list[tuple[float, str, WordBox]] = []
+        for obs in request.results() or []:
+            cands = obs.topCandidates_(1)
+            if not cands or not len(cands):
+                continue
+            text = str(cands[0].string())
+            bb = obs.boundingBox()  # normalized, origin bottom-left
+            x = bb.origin.x * width
+            w = bb.size.width * width
+            h = bb.size.height * height
+            top = (1.0 - bb.origin.y - bb.size.height) * height
+            box = WordBox(
+                text=text,
+                left=int(x),
+                top=int(top),
+                width=int(w),
+                height=int(h),
+                conf=float(cands[0].confidence()) * 100.0,
+            )
+            lines.append((top, text, box))
+        lines.sort(key=lambda item: item[0])
+        return OcrResult(
+            text="\n".join(item[1] for item in lines),
+            words=[item[2] for item in lines],
+            engine=self.name,
+            language=lang,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Windows.Media.Ocr (Windows 10/11) via winsdk. Word-level boxes.
+# HARDWARE-VERIFY-PENDING.
+# ---------------------------------------------------------------------------
+
+
+class WinRTEngine:
+    name = "winrt"
+
+    def _bridge(self):
+        from winsdk.windows.graphics.imaging import BitmapDecoder
+        from winsdk.windows.media.ocr import OcrEngine as WinOcr
+        from winsdk.windows.storage.streams import (
+            DataWriter,
+            InMemoryRandomAccessStream,
+        )
+
+        return BitmapDecoder, WinOcr, DataWriter, InMemoryRandomAccessStream
+
+    def info(self) -> dict:
+        if sys.platform != "win32":
+            return {"available": False, "version": None, "languages": None}
+        try:
+            _, WinOcr, _, _ = self._bridge()
+            engine = WinOcr.try_create_from_user_profile_languages()
+            if engine is None:
+                return {"available": False, "version": None, "languages": None}
+            return {
+                "available": True,
+                "version": "Windows.Media.Ocr",
+                "languages": [str(engine.recognizer_language.language_tag)],
+            }
+        except Exception:
+            return {"available": False, "version": None, "languages": None}
+
+    def available(self) -> bool:
+        return self.info()["available"]
+
+    def unavailable_reason(self) -> Optional[str]:
+        return None if self.available() else NATIVE_MISSING_MESSAGE
+
+    def recognize(self, data: bytes, lang: Optional[str] = None) -> OcrResult:
+        BitmapDecoder, WinOcr, DataWriter, Stream = self._bridge()
+
+        async def _run():
+            stream = Stream()
+            writer = DataWriter(stream.get_output_stream_at(0))
+            writer.write_bytes(data)
+            await writer.store_async()
+            decoder = await BitmapDecoder.create_async(stream)
+            bitmap = await decoder.get_software_bitmap_async()
+            engine = WinOcr.try_create_from_user_profile_languages()
+            if engine is None:
+                raise EngineUnavailable("No OCR language available in Windows")
+            return await engine.recognize_async(bitmap)
+
+        result = asyncio.run(_run())
+        text_lines = []
+        words: list[WordBox] = []
+        for line in result.lines:
+            text_lines.append(str(line.text))
+            for word in line.words:
+                r = word.bounding_rect
+                words.append(
+                    WordBox(
+                        text=str(word.text),
+                        left=int(r.x),
+                        top=int(r.y),
+                        width=int(r.width),
+                        height=int(r.height),
+                    )
+                )
+        return OcrResult(
+            text="\n".join(text_lines),
+            words=words,
+            engine=self.name,
+            language=lang,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Selection — platform-native first, tesseract as the universal fallback.
+# SLOWBOOKS_OCR_ENGINE=tesseract|vision|winrt|auto overrides (support tool
+# and test hook, not a documented user setting).
+# ---------------------------------------------------------------------------
+
+_ENGINES = {
+    "tesseract": TesseractEngine,
+    "vision": VisionEngine,
+    "winrt": WinRTEngine,
+}
+
+
+def _native_engine_for_platform():
+    if sys.platform == "darwin":
+        return VisionEngine()
+    if sys.platform == "win32":
+        return WinRTEngine()
+    return None
+
+
+def get_engine():
+    """The engine to use right now. Never raises; the returned engine may
+    report unavailable (routes turn that into the guidance envelope)."""
+    override = os.environ.get("SLOWBOOKS_OCR_ENGINE", "auto").strip().lower()
+    if override in _ENGINES:
+        return _ENGINES[override]()
+    native = _native_engine_for_platform()
+    if native is not None and native.available():
+        return native
+    tess = TesseractEngine()
+    if tess.available():
+        return tess
+    # Nothing works. Tesseract's reason is the actionable one everywhere
+    # (the native engine ships with the OS or not at all).
+    return tess
+
+
+def engine_status() -> dict:
+    """For /api/ocr/status: the active engine's info + which engine it is."""
+    engine = get_engine()
+    info = engine.info()
+    info["engine"] = engine.name
+    return info

--- a/app/services/ocr_service.py
+++ b/app/services/ocr_service.py
@@ -125,7 +125,7 @@ def ocr_language() -> Optional[str]:
     usable = installed & ALLOWED_LANGS
     if not usable:
         return None
-    return "eng" if "eng" in usable else ",".join(sorted(usable))
+    return "eng" if "eng" in usable else "+".join(sorted(usable))
 
 
 # ---------------------------------------------------------------------------
@@ -164,6 +164,97 @@ def ocr_image_bytes(data: bytes, lang: Optional[str] = None) -> str:
             + (f": {stderr[:300]}" if stderr else "")
         )
     return (proc.stdout or b"").decode("utf-8", errors="replace")
+
+
+def ocr_image_words(data: bytes, lang: Optional[str] = None):
+    """OCR raw image bytes via `tesseract stdin stdout tsv`.
+
+    Returns (text, words): `text` reconstructed from the TSV word rows
+    (line-faithful — the deterministic parsers are line-based), `words` a
+    list of {text, left, top, width, height, conf} dicts for the v2
+    canvas. One subprocess call serves both. Raises OCRRuntimeError like
+    ocr_image_bytes.
+    """
+    cmd = ["tesseract", "stdin", "stdout", "--psm", "3"]
+    if lang:
+        cmd += ["-l", lang]
+    cmd += ["tsv"]
+    try:
+        proc = subprocess.run(
+            cmd,
+            input=data,
+            capture_output=True,
+            timeout=OCR_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise OCRRuntimeError(
+            f"Tesseract timed out after {OCR_TIMEOUT_SECONDS}s"
+        ) from exc
+    except OSError as exc:
+        raise OCRRuntimeError(f"Could not run tesseract: {exc}") from exc
+    if proc.returncode != 0:
+        stderr = (proc.stderr or b"").decode("utf-8", errors="replace").strip()
+        raise OCRRuntimeError(
+            f"Tesseract failed (exit {proc.returncode})"
+            + (f": {stderr[:300]}" if stderr else "")
+        )
+    tsv = (proc.stdout or b"").decode("utf-8", errors="replace")
+    return _parse_tesseract_tsv(tsv)
+
+
+def _parse_tesseract_tsv(tsv: str):
+    """TSV rows -> (reconstructed_text, word dicts).
+
+    Columns: level page block par line word left top width height conf text.
+    Word rows are level 5; lines break on (block, par, line) changes; a
+    paragraph change inserts a blank line so multi-block receipts keep
+    their visual grouping for the line-based parsers.
+    """
+    words: list[dict] = []
+    lines: list[str] = []
+    current_key = None
+    current_words: list[str] = []
+    for row in tsv.splitlines()[1:]:
+        cols = row.split("\t")
+        if len(cols) < 12:
+            continue
+        try:
+            level = int(cols[0])
+        except ValueError:
+            continue
+        if level != 5:
+            continue
+        text = cols[11]
+        if not text.strip():
+            continue
+        try:
+            left, top, width, height = (int(c) for c in cols[6:10])
+            conf = float(cols[10])
+        except ValueError:
+            left = top = width = height = 0
+            conf = -1.0
+        key = (cols[2], cols[3], cols[4])  # block, par, line
+        if key != current_key:
+            if current_words:
+                lines.append(" ".join(current_words))
+            if current_key is not None and cols[2:4] != list(current_key[:2]):
+                lines.append("")  # block/par boundary -> blank line
+            current_key = key
+            current_words = []
+        current_words.append(text)
+        words.append(
+            {
+                "text": text,
+                "left": left,
+                "top": top,
+                "width": width,
+                "height": height,
+                "conf": conf,
+            }
+        )
+    if current_words:
+        lines.append(" ".join(current_words))
+    return "\n".join(lines), words
 
 
 # ---------------------------------------------------------------------------

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -527,8 +527,10 @@ const SettingsPage = {
             const s = await API.get('/ocr/status');
             if (s.available) {
                 const langs = (s.languages || []).join(', ') || '—';
-                el.innerHTML = '<strong style="color:#166534;">Tesseract OCR is installed</strong>'
-                    + (s.version ? ` <span style="color:var(--text-muted);">(v${escapeHtml(s.version)})</span>` : '')
+                const engineNames = { tesseract: 'Tesseract OCR', vision: 'Apple Vision (built into macOS)', winrt: 'Windows OCR (built into Windows)' };
+                const engineLabel = engineNames[s.engine] || 'OCR engine';
+                el.innerHTML = `<strong style="color:#166534;">${escapeHtml(engineLabel)} is ready</strong>`
+                    + (s.version ? ` <span style="color:var(--text-muted);">(${escapeHtml(s.version)})</span>` : '')
                     + ` &middot; languages: ${escapeHtml(langs)}`;
             } else {
                 el.innerHTML = '<strong style="color:#b45309;">Tesseract OCR is not installed — scanning is disabled.</strong>'

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -157,7 +157,9 @@ def _scan(client, monkeypatch, tmp_path, text=CANNED_RECEIPT_TEXT) -> str:
     monkeypatch.setattr(ocr_service, "INTAKE_DIR", tmp_path)
     monkeypatch.setattr(ocr_service, "tesseract_available", lambda: True)
     monkeypatch.setattr(ocr_service, "ocr_language", lambda: "eng")
-    monkeypatch.setattr(ocr_service, "ocr_image_bytes", lambda data, lang=None: text)
+    monkeypatch.setattr(
+        ocr_service, "ocr_image_words", lambda data, lang=None: (text, [])
+    )
     r = client.post(
         "/api/ocr/receipt",
         files={"file": ("receipt.png", _png_bytes(), "image/png")},
@@ -202,7 +204,9 @@ def test_scan_response_fields(client, monkeypatch, tmp_path):
     monkeypatch.setattr(ocr_service, "tesseract_available", lambda: True)
     monkeypatch.setattr(ocr_service, "ocr_language", lambda: "eng")
     monkeypatch.setattr(
-        ocr_service, "ocr_image_bytes", lambda data, lang=None: CANNED_RECEIPT_TEXT
+        ocr_service,
+        "ocr_image_words",
+        lambda data, lang=None: (CANNED_RECEIPT_TEXT, []),
     )
     r = client.post(
         "/api/ocr/receipt",
@@ -243,8 +247,8 @@ def test_scan_missing_date_defaults_today(client, monkeypatch, tmp_path):
     monkeypatch.setattr(ocr_service, "ocr_language", lambda: "eng")
     monkeypatch.setattr(
         ocr_service,
-        "ocr_image_bytes",
-        lambda data, lang=None: "MY VENDOR\nTOTAL $10.00\n",
+        "ocr_image_words",
+        lambda data, lang=None: ("MY VENDOR\nTOTAL $10.00\n", []),
     )
     r = client.post(
         "/api/ocr/receipt",
@@ -303,7 +307,9 @@ def test_scan_pdf_multi_page(client, monkeypatch, tmp_path):
     monkeypatch.setattr(ocr_service, "tesseract_available", lambda: True)
     monkeypatch.setattr(ocr_service, "ocr_language", lambda: "eng")
     monkeypatch.setattr(
-        ocr_service, "ocr_image_bytes", lambda data, lang=None: CANNED_RECEIPT_TEXT
+        ocr_service,
+        "ocr_image_words",
+        lambda data, lang=None: (CANNED_RECEIPT_TEXT, []),
     )
     monkeypatch.setattr(
         ocr_service,

--- a/tests/test_ocr_engines.py
+++ b/tests/test_ocr_engines.py
@@ -1,0 +1,133 @@
+"""Engine seam (delivery-plan step 1.5): selection, TSV word extraction,
+and the review fixes from #71 (tesseract '+' language join, 400 on
+unreadable input).
+
+The Vision/WinRT adapters are hardware-verify-pending and only their
+selection/degrade logic is testable here; the tesseract path is fully
+exercised (CI installs tesseract)."""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from app.services import ocr_engines, ocr_service
+
+_FIX_DIR = Path(__file__).parent / "fixtures" / "ocr"
+FIXTURES = sorted(
+    p for p in _FIX_DIR.glob("*") if p.suffix.lower() in (".png", ".jpg", ".pdf")
+)
+_MIME = {".png": "image/png", ".jpg": "image/jpeg", ".pdf": "application/pdf"}
+
+SAMPLE_TSV = """level\tpage_num\tblock_num\tpar_num\tline_num\tword_num\tleft\ttop\twidth\theight\tconf\ttext
+1\t1\t0\t0\t0\t0\t0\t0\t400\t600\t-1\t
+5\t1\t1\t1\t1\t1\t10\t12\t80\t20\t96.5\tACME
+5\t1\t1\t1\t1\t2\t95\t12\t90\t20\t95.0\tSUPPLY
+5\t1\t1\t1\t2\t1\t10\t40\t60\t18\t91.2\tTOTAL
+5\t1\t1\t1\t2\t2\t80\t40\t70\t18\t93.0\t$49.13
+5\t1\t2\t1\t1\t1\t10\t80\t95\t18\t88.8\tTHANKS
+"""
+
+
+def test_tsv_parser_reconstructs_lines_and_words():
+    text, words = ocr_service._parse_tesseract_tsv(SAMPLE_TSV)
+    lines = [ln for ln in text.splitlines() if ln]
+    assert lines[0] == "ACME SUPPLY"
+    assert lines[1] == "TOTAL $49.13"
+    assert lines[2] == "THANKS"
+    assert len(words) == 5
+    total_word = next(w for w in words if w["text"] == "$49.13")
+    assert (total_word["left"], total_word["top"]) == (80, 40)
+    assert total_word["conf"] == 93.0
+
+
+def test_reconstructed_text_still_parses():
+    text, _ = ocr_service._parse_tesseract_tsv(SAMPLE_TSV)
+    total, conf = ocr_service.parse_total(text)
+    assert total == "49.13" and conf == "high"
+
+
+def test_language_join_uses_plus(monkeypatch):
+    """#71 review fix: tesseract -l is '+'-separated; ',' errors out."""
+    monkeypatch.setattr(
+        ocr_service,
+        "tesseract_info",
+        lambda: {"available": True, "version": "5", "languages": ["fra", "spa"]},
+    )
+    assert ocr_service.ocr_language() == "fra+spa"
+
+
+def test_engine_selection_env_override(monkeypatch):
+    monkeypatch.setenv("SLOWBOOKS_OCR_ENGINE", "tesseract")
+    assert ocr_engines.get_engine().name == "tesseract"
+    monkeypatch.setenv("SLOWBOOKS_OCR_ENGINE", "vision")
+    engine = ocr_engines.get_engine()
+    assert engine.name == "vision"
+    # On Linux CI the Vision bridge can't import: it must degrade, not raise
+    assert engine.available() is False
+    assert engine.unavailable_reason()
+
+
+def test_engine_selection_auto_falls_back_to_tesseract(monkeypatch):
+    monkeypatch.setenv("SLOWBOOKS_OCR_ENGINE", "auto")
+    monkeypatch.setattr(
+        ocr_service,
+        "tesseract_info",
+        lambda: {"available": True, "version": "5", "languages": ["eng"]},
+    )
+    engine = ocr_engines.get_engine()
+    assert engine.name == "tesseract"
+    assert engine.available() is True
+
+
+def test_status_endpoint_reports_engine(client, monkeypatch):
+    monkeypatch.setattr(
+        ocr_service,
+        "tesseract_info",
+        lambda: {"available": True, "version": "5.5.0", "languages": ["eng"]},
+    )
+    body = client.get("/api/ocr/status").json()
+    assert body["engine"] == "tesseract"
+    assert body["available"] is True
+
+
+needs_tesseract = pytest.mark.skipif(
+    shutil.which("tesseract") is None, reason="tesseract not installed"
+)
+
+
+@needs_tesseract
+def test_unreadable_image_is_400_not_500(client, monkeypatch, tmp_path):
+    """#71 review fix: junk bytes with a valid image MIME must 400."""
+    monkeypatch.setattr(ocr_service, "INTAKE_DIR", tmp_path)
+    r = client.post(
+        "/api/ocr/receipt",
+        files={"file": ("junk.png", b"this is not a png", "image/png")},
+    )
+    assert r.status_code == 400
+    assert "read the image" in r.json()["detail"]
+
+
+@needs_tesseract
+@pytest.mark.skipif(not FIXTURES, reason="no OCR fixtures")
+def test_real_scan_returns_words_and_engine(client, monkeypatch, tmp_path):
+    fixture = FIXTURES[0]
+    if fixture.suffix.lower() == ".pdf" and shutil.which("pdftoppm") is None:
+        pytest.skip("pdf fixture but poppler not installed")
+    monkeypatch.setattr(ocr_service, "INTAKE_DIR", tmp_path)
+    r = client.post(
+        "/api/ocr/receipt",
+        files={
+            "file": (
+                fixture.name,
+                fixture.read_bytes(),
+                _MIME[fixture.suffix.lower()],
+            )
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["engine"] == "tesseract"
+    assert body["words"], "expected word boxes from the tsv path"
+    first = body["words"][0]
+    assert {"text", "left", "top", "width", "height", "conf"} <= set(first)


### PR DESCRIPTION
Delivery-plan **step 1.5** ([design doc](https://github.com/VonHoltenCodes/SlowBooks-Pro-2026/blob/feat/receipt-intake/docs/design/receipt-intake.md#ocr-engine-strategy-decided-2026-09-02-platform-native-engines)), maintainer-built, stacked cleanly on #71 (thanks @jeremy-patterson1 — your service layer refactored beautifully; the seam slots in at your single tesseract call site exactly as hoped).

## What this is

An `OcrEngine` interface with three adapters, so no user is ever pointed at an installer:

| Engine | Platform | State |
|---|---|---|
| `TesseractEngine` | Linux/Docker default; **universal detect-if-present fallback everywhere** | Fully tested (CI + e2e ground truth) |
| `VisionEngine` (Apple Vision, pyobjc) | macOS — preinstalled, line-level boxes | ⚠️ hardware-verify-pending |
| `WinRTEngine` (Windows.Media.Ocr, winsdk) | Windows 10/11 — preinstalled, word-level boxes | ⚠️ hardware-verify-pending |

Selection is native-first with tesseract fallback; `SLOWBOOKS_OCR_ENGINE` env overrides for support/testing. Native bridge deps are **frozen-build-only** — requirements.txt untouched; packaging wiring deliberately lands with the hardware laps, so this PR cannot affect any build until then.

## The v2 canvas hook ships here

The tesseract path now makes **one** subprocess call with `tsv` output: reconstructed line-text (parsers unchanged — e2e re-verified ground truth to the penny on PNG and PDF) **plus word bounding boxes**. `POST /api/ocr/receipt` gains `engine` and `words`; `/api/ocr/status` reports the active engine; the Settings row is engine-aware. Vision/WinRT return boxes natively, so the box-to-fix canvas works on all three engines with no per-engine detours.

## Folds in two #71 review findings

- `ocr_language()` joined multiple languages with `","` — tesseract's `-l` wants `+` (fired only when `eng` was absent)
- Junk bytes with a valid image MIME hit a 500; now a guided 400 ("Could not read the image")

## Test compat

Jeremy's suite runs unchanged apart from four mechanical monkeypatch swaps (`ocr_image_bytes` → `ocr_image_words`); `TesseractEngine` delegates probing to the existing monkeypatchable `ocr_service` functions by design. 8 new engine tests (TSV parser, selection/fallback/override, both review fixes, real-scan words via the committed fixtures). Full suite: **1268 passed**; black + ruff clean.

## Not in this PR (the hardware laps)

Wiring `pyobjc`/`winsdk` into the frozen builds, verifying Vision/WinRT on real hardware (WinRT is testable on the Windows box; Vision needs a Mac), and updating the Settings install-copy once native engines are confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)