### PR TITLE
Frozen builds: bundle the native OCR engines

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -104,6 +104,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-desktop.txt
+          # Built-in OCR (WinRT projection) — frozen-build-only dependency
+          pip install -r packaging/windows/requirements-ocr.txt
           pip install pyinstaller pyinstaller-hooks-contrib pillow
 
       - name: Build the .ico from the icon asset

--- a/packaging/macos/SlowBooksPro-mac.spec
+++ b/packaging/macos/SlowBooksPro-mac.spec
@@ -87,6 +87,15 @@ hiddenimports = (
     ]
 )
 
+# Built-in OCR: Apple Vision via pyobjc (requirements-build.txt), imported
+# lazily inside VisionEngine._bridge — invisible to the scanner. Guarded so
+# a build env without the Vision wheels still bundles (tesseract fallback).
+for _mod in ("Vision", "Quartz", "objc", "Foundation"):
+    try:
+        hiddenimports += collect_submodules(_mod)
+    except Exception:
+        pass
+
 a = Analysis(
     [os.path.join(ROOT, "desktop_launcher.py")],
     pathex=[ROOT],

--- a/packaging/macos/requirements-build.txt
+++ b/packaging/macos/requirements-build.txt
@@ -3,3 +3,7 @@
 pyinstaller==6.22.0
 pyinstaller-hooks-contrib==2026.6
 pillow==12.3.0
+# Built-in OCR engine (receipt intake 1.5): Apple Vision via pyobjc,
+# bundled ONLY into the frozen mac build (see app/services/ocr_engines.py).
+pyobjc-framework-Vision==12.2.2
+pyobjc-framework-Quartz==12.2.2

--- a/packaging/windows/SlowBooksPro.spec
+++ b/packaging/windows/SlowBooksPro.spec
@@ -70,6 +70,15 @@ hiddenimports = (
     ]
 )
 
+# Built-in OCR: the WinRT projection (packaging/windows/requirements-ocr.txt)
+# is imported lazily inside WinRTEngine._bridge, invisible to the scanner.
+# Guarded so a local `pyinstaller SlowBooksPro.spec` without winrt installed
+# still produces a testable (tesseract-fallback) bundle.
+try:
+    hiddenimports += collect_submodules("winrt")
+except Exception:
+    pass
+
 a = Analysis(
     [os.path.join(ROOT, "desktop_launcher.py")],
     pathex=[ROOT],

--- a/packaging/windows/requirements-ocr.txt
+++ b/packaging/windows/requirements-ocr.txt
@@ -1,0 +1,13 @@
+# Built-in OCR engine (receipt intake 1.5): the WinRT projection of
+# Windows.Media.Ocr, bundled ONLY into the frozen Windows build — dev/server
+# installs use tesseract (see app/services/ocr_engines.py). Pin exact
+# versions; all winrt-* wheels must share one version. This set is
+# hardware-validated (real Windows 11, 2026-09-02): Foundation.Collections
+# is a separate wheel and iterating OcrResult.lines fails without it.
+winrt-runtime==3.2.1
+winrt-Windows.Media.Ocr==3.2.1
+winrt-Windows.Graphics.Imaging==3.2.1
+winrt-Windows.Storage.Streams==3.2.1
+winrt-Windows.Foundation==3.2.1
+winrt-Windows.Foundation.Collections==3.2.1
+winrt-Windows.Globalization==3.2.1


### PR DESCRIPTION
Wires the receipt-intake engine seam's native dependencies into the desktop packaging — the last code step before the hardware laps.

- **Windows**: `packaging/windows/requirements-ocr.txt` pins the `winrt-*` 3.2.1 wheel set (the exact set hardware-validated on real Windows 11, including the separately-wheeled `Windows.Foundation.Collections` that `OcrResult.lines` iteration needs). Installed by the workflow, collected via guarded `collect_submodules("winrt")`.
- **macOS**: `pyobjc-framework-Vision` / `Quartz` 12.2.2 pinned in `requirements-build.txt`, collected the same way.
- Both spec guards keep a local `pyinstaller` run working without the OCR wheels — the engine seam just falls back to tesseract detection at runtime.

Not touched: `requirements.txt` (dev/server installs stay zero-new-deps, per the design doc's never-bundled policy — these ship only inside the frozen bundles).

Validation plan: `workflow_dispatch` a Windows build off the integration branch → install on vonholten308 → `/api/ocr/status` must report `engine: winrt` with no tesseract present; Vision equivalent is Keith's mac lap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoFRzFKT5uxL15dkfARN6L