### PR TITLE
Region OCR on the native engines — full stack without tesseract

### DIFF
--- a/app/routes/ocr.py
+++ b/app/routes/ocr.py
@@ -152,18 +152,18 @@ async def scan_receipt(
         partial_reasons.append("date not found — today's date used")
 
     # v3 template memory: if this merchant has a saved layout, region-OCR the
-    # remembered boxes and prefer those reads. Tesseract-only today (region
-    # OCR is tesseract-config-driven); fails closed to the v1 parse + canvas.
+    # remembered boxes and prefer those reads (any engine — native engines
+    # read prepared crops too). Fails closed to the v1 parse + canvas.
     template_fields: list[str] = []
     template_applied = False
-    if result.words and engine.name == "tesseract":
+    if result.words:
         word_dicts = [vars(w) for w in result.words]
         template = ocr_template_store.find_for_scan(
             db, extracted["merchant"]["value"], raw_text
         )
         if template is not None:
             reads = ocr_template_store.apply_template(
-                db, template, ocr_input, word_dicts
+                db, template, ocr_input, word_dicts, engine=engine
             )
             template_fields = sorted(reads)
             for key in ("total", "subtotal", "tax"):
@@ -330,9 +330,7 @@ def ocr_intake_region(
         )
     engine = ocr_engines.get_engine()
     reason = engine.unavailable_reason()
-    if reason and engine.name == "tesseract":
-        # Region OCR is tesseract-config-driven today; native-engine region
-        # support arrives with the hardware laps (design doc).
+    if reason:
         raise HTTPException(status_code=400, detail=reason)
     try:
         image_data = _intake_image_bytes(intake)
@@ -343,6 +341,7 @@ def ocr_intake_region(
             width=body.width,
             height=body.height,
             field_type=body.field_type,
+            engine=engine,
         )
     except ocr_regions.RegionError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
@@ -358,13 +357,7 @@ def ocr_intake_region(
     # template (anchor-relative box). Fails closed — a save miss never
     # breaks the read that just succeeded.
     template_saved = False
-    if (
-        body.save_template
-        and body.merchant
-        and body.field_key
-        and result.get("value")
-        and engine.name == "tesseract"
-    ):
+    if body.save_template and body.merchant and body.field_key and result.get("value"):
         try:
             page = engine.recognize(image_data)
             words = [vars(w) for w in page.words]

--- a/app/services/ocr_regions.py
+++ b/app/services/ocr_regions.py
@@ -9,8 +9,10 @@
 # low-contrast answer — a known-type crop reads far better than a full page.
 #
 # Pillow is already in the dependency tree (WeasyPrint); no new pins.
-# Region OCR is tesseract-config-driven today; when the native engines get
-# region support they slot in behind the same service function.
+# Two read paths behind one function: tesseract (PSM + charset whitelist,
+# the sharpest option when it's installed) and the native engines (Vision /
+# WinRT recognize a prepared crop — no whitelist, but the field normalizer
+# filters the noise). Frozen builds without tesseract stay fully featured.
 # ============================================================================
 
 import io
@@ -49,8 +51,14 @@ def _load_image(data: bytes):
     return img
 
 
-def _prepare_region(img, left: int, top: int, width: int, height: int) -> bytes:
-    """Crop -> grayscale -> upscale -> autocontrast -> binarize -> PNG bytes."""
+def _prepare_region(
+    img, left: int, top: int, width: int, height: int, binarize: bool = True
+) -> bytes:
+    """Crop -> grayscale -> upscale -> autocontrast [-> binarize] -> PNG.
+
+    The hard threshold helps tesseract; the native engines do their own
+    binarization and read the contrast-stretched grayscale better, so they
+    get binarize=False."""
     from PIL import Image, ImageOps
 
     iw, ih = img.size
@@ -69,7 +77,8 @@ def _prepare_region(img, left: int, top: int, width: int, height: int) -> bytes:
     # midpoint threshold after that is a serviceable Otsu stand-in without
     # adding a CV dependency.
     region = ImageOps.autocontrast(region, cutoff=1)
-    region = region.point(lambda p: 255 if p > 140 else 0)
+    if binarize:
+        region = region.point(lambda p: 255 if p > 140 else 0)
     out = io.BytesIO()
     region.save(out, format="PNG")
     return out.getvalue()
@@ -83,13 +92,19 @@ def ocr_region(
     height: int,
     field_type: str = "text",
     lang: Optional[str] = None,
+    engine=None,
 ) -> dict:
     """OCR one typed region of a scanned image.
 
     Returns {"text", "value", "field_type", "confidence"} where `value` is
     the field-normalized reading (amounts -> '1234.56', dates -> ISO) and
     `text` is the raw region text. Raises RegionError for geometry/image
-    problems and ocr_service.OCRRuntimeError when tesseract fails.
+    problems and ocr_service.OCRRuntimeError when OCR fails.
+
+    `engine` is the active OcrEngine; a native engine (vision/winrt) reads
+    the prepared crop itself, so frozen builds without tesseract keep the
+    canvas and template features. None or a tesseract engine uses the
+    subprocess path with PSM + charset whitelist (sharpest when present).
     """
     config = FIELD_CONFIGS.get(field_type)
     if config is None:
@@ -98,6 +113,19 @@ def ocr_region(
             f"(expected one of {sorted(FIELD_CONFIGS)})"
         )
     img = _load_image(image_data)
+
+    if engine is not None and engine.name != "tesseract":
+        png = _prepare_region(img, left, top, width, height, binarize=False)
+        result = engine.recognize(png)
+        text = " ".join((result.text or "").split())
+        value, confidence = _normalize(text, field_type)
+        return {
+            "text": text,
+            "value": value,
+            "field_type": field_type,
+            "confidence": confidence,
+        }
+
     png = _prepare_region(img, left, top, width, height)
 
     lang = lang or ocr_service.ocr_language()

--- a/app/services/ocr_template_store.py
+++ b/app/services/ocr_template_store.py
@@ -89,6 +89,7 @@ def apply_template(
     template: OcrTemplate,
     image_data: bytes,
     words: list[dict],
+    engine=None,
 ) -> dict:
     """Region-OCR every remembered field box against a new scan. Returns
     {field_key: {"value": str, "confidence": str}} for the boxes that both
@@ -106,6 +107,7 @@ def apply_template(
                 width=box["width"],
                 height=box["height"],
                 field_type=FIELD_OCR_TYPE.get(field_key, "text"),
+                engine=engine,
             )
         except Exception as exc:  # fail closed, canvas takes over
             logger.debug("template region read failed for %s: %s", field_key, exc)

--- a/tests/test_ocr_regions.py
+++ b/tests/test_ocr_regions.py
@@ -139,3 +139,78 @@ def test_region_endpoint_end_to_end(client, monkeypatch, tmp_path):
         json={"left": 0, "top": 0, "width": 2, "height": 2, "field_type": "text"},
     )
     assert bad.status_code == 400
+
+
+class _FakeNativeEngine:
+    """Native-engine stand-in: name != tesseract, recognizes a prepared crop."""
+
+    name = "winrt"
+
+    def __init__(self, text):
+        self._text = text
+        self.saw = None
+
+    def recognize(self, data):
+        from app.services.ocr_engines import OcrResult
+
+        self.saw = data
+        return OcrResult(text=self._text, words=[], language="en-US", engine=self.name)
+
+
+def test_native_engine_region_path_skips_tesseract(monkeypatch):
+    """With a native engine, ocr_region must read via engine.recognize and
+    never spawn tesseract (frozen builds without it stay fully featured)."""
+    import subprocess as sp
+
+    def boom(*a, **k):
+        raise AssertionError("tesseract must not be spawned on the native path")
+
+    monkeypatch.setattr(sp, "run", boom)
+
+    import io as _io
+
+    from PIL import Image
+
+    buf = _io.BytesIO()
+    Image.new("L", (200, 80), 255).save(buf, format="PNG")
+
+    eng = _FakeNativeEngine("$1,234.56")
+    result = ocr_regions.ocr_region(
+        buf.getvalue(), 10, 10, 120, 40, field_type="amount", engine=eng
+    )
+    assert result["value"] == "1234.56"
+    assert result["confidence"] == "high"
+    assert eng.saw is not None  # the engine really was handed the crop
+    with Image.open(_io.BytesIO(eng.saw)) as crop:
+        assert crop.size == (120 * ocr_regions.UPSCALE, 40 * ocr_regions.UPSCALE)
+
+
+def test_tesseract_engine_still_uses_subprocess_path(monkeypatch):
+    """A tesseract engine (or engine=None) keeps the PSM/whitelist path."""
+
+    class _Tess:
+        name = "tesseract"
+
+        def recognize(self, data):  # pragma: no cover — must not be called
+            raise AssertionError("tesseract engine must use the subprocess path")
+
+    import subprocess as sp
+
+    class _Proc:
+        returncode = 0
+        stdout = b"49.13"
+        stderr = b""
+
+    monkeypatch.setattr(sp, "run", lambda *a, **k: _Proc())
+    monkeypatch.setattr(ocr_service, "ocr_language", lambda: "eng")
+
+    import io as _io
+
+    from PIL import Image
+
+    buf = _io.BytesIO()
+    Image.new("L", (200, 80), 255).save(buf, format="PNG")
+    result = ocr_regions.ocr_region(
+        buf.getvalue(), 10, 10, 120, 40, field_type="amount", engine=_Tess()
+    )
+    assert result["value"] == "49.13"

--- a/tests/test_ocr_template_store.py
+++ b/tests/test_ocr_template_store.py
@@ -63,7 +63,7 @@ def _fake_region_reader(words):
     """Region OCR fake: return the text of the word whose center falls in
     the requested box — position-faithful, no tesseract."""
 
-    def fake(image_data, left, top, width, height, field_type):
+    def fake(image_data, left, top, width, height, field_type, engine=None):
         for w in words:
             cx = w["left"] + w["width"] / 2
             cy = w["top"] + w["height"] / 2


### PR DESCRIPTION
Gap found while planning the Windows hardware lap: the v2 canvas and v3 template application spawned tesseract directly, so a frozen build running on Windows OCR / Apple Vision alone would lose both features (400s on every region read). That contradicts the whole "OCR should be built in" premise.

- `ocr_region()` gains an `engine` parameter. A native engine reads the prepared crop itself — same crop/3× upscale/autocontrast pipeline, minus the hard threshold (native engines binarize internally and prefer grayscale). The field normalizer replaces the charset whitelist for noise filtering.
- Tesseract path unchanged — PSM + whitelist is still the sharpest read and is used whenever the tesseract engine is active.
- Scan-path template application, the region endpoint, and the teach hook all lose their tesseract-only guards.
- 2 new tests prove path selection both ways (native path must never spawn a subprocess; tesseract engine must never call `recognize` on a crop). 75 OCR-suite tests green.

Native-path crop quality gets its real verdict on the VH308 lap (build already dispatched off the integration branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoFRzFKT5uxL15dkfARN6L