### PR TITLE
Settings: OCR engine preference (auto | prefer Tesseract)

### DIFF
--- a/app/models/settings.py
+++ b/app/models/settings.py
@@ -23,6 +23,11 @@ class Settings(Base):
 
 # Default settings keys
 DEFAULT_SETTINGS = {
+    # Receipt-scanning engine preference: "auto" = platform-native engine
+    # first (Windows OCR / Apple Vision), tesseract fallback; "tesseract"
+    # = prefer tesseract when installed (sharper region reads). The
+    # SLOWBOOKS_OCR_ENGINE env var (support tool) outranks this.
+    "ocr_engine": "auto",
     "company_name": "My Company",
     "company_address1": "",
     "company_address2": "",

--- a/app/routes/ocr.py
+++ b/app/routes/ocr.py
@@ -38,6 +38,7 @@ from app.services import (
     storage,
 )
 from app.services.rate_limit import limiter
+from app.services.settings_service import get_setting_raw
 from app.services.upload_limits import MAX_IMPORT_BYTES, read_limited
 
 logger = logging.getLogger(__name__)
@@ -67,10 +68,10 @@ def _sanitize_filename(raw: str) -> str:
 
 
 @router.get("/status", response_model=OcrStatusResponse)
-def ocr_status():
+def ocr_status(db: Session = Depends(get_db)):
     """Frontend gating + Settings-page status row (spec §6.6). Reports the
     active engine for this platform (engine seam, design doc §engines)."""
-    info = ocr_engines.engine_status()
+    info = ocr_engines.engine_status(get_setting_raw(db, "ocr_engine"))
     return OcrStatusResponse(
         available=info["available"],
         version=info["version"],
@@ -103,7 +104,7 @@ async def scan_receipt(
             status_code=400, detail=f"File extension '{extension}' not allowed"
         )
 
-    engine = ocr_engines.get_engine()
+    engine = ocr_engines.get_engine(get_setting_raw(db, "ocr_engine"))
     reason = engine.unavailable_reason()
     if reason:
         return OcrReceiptResponse(ocr_available=False, message=reason)
@@ -328,7 +329,7 @@ def ocr_intake_region(
             status_code=404,
             detail="Scan not found or expired — scan the receipt again",
         )
-    engine = ocr_engines.get_engine()
+    engine = ocr_engines.get_engine(get_setting_raw(db, "ocr_engine"))
     reason = engine.unavailable_reason()
     if reason:
         raise HTTPException(status_code=400, detail=reason)

--- a/app/services/ocr_engines.py
+++ b/app/services/ocr_engines.py
@@ -307,12 +307,20 @@ def _native_engine_for_platform():
     return None
 
 
-def get_engine():
+def get_engine(preference: str | None = None):
     """The engine to use right now. Never raises; the returned engine may
-    report unavailable (routes turn that into the guidance envelope)."""
+    report unavailable (routes turn that into the guidance envelope).
+
+    `preference` is the stored Settings choice ("auto"/"tesseract"/...);
+    the SLOWBOOKS_OCR_ENGINE env var (support tool) outranks it, and
+    anything unrecognized falls through to auto-selection.
+    """
     override = os.environ.get("SLOWBOOKS_OCR_ENGINE", "auto").strip().lower()
     if override in _ENGINES:
         return _ENGINES[override]()
+    pref = (preference or "auto").strip().lower()
+    if pref in _ENGINES:
+        return _ENGINES[pref]()
     native = _native_engine_for_platform()
     if native is not None and native.available():
         return native
@@ -324,9 +332,9 @@ def get_engine():
     return tess
 
 
-def engine_status() -> dict:
+def engine_status(preference: str | None = None) -> dict:
     """For /api/ocr/status: the active engine's info + which engine it is."""
-    engine = get_engine()
+    engine = get_engine(preference)
     info = engine.info()
     info["engine"] = engine.name
     return info

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -14,6 +14,7 @@ const SettingsPage = {
             SettingsPage.loadUsers();
             SettingsPage.loadApiTokens();
             SettingsPage.loadOcrStatus();
+            SettingsPage.loadOcrEnginePref();
             SettingsPage.scrollToFocus();
         }, 0);
         return `
@@ -237,10 +238,26 @@ const SettingsPage = {
                     <h3>Receipt Scanning</h3>
                     <div style="font-size:10px; color:var(--text-muted); margin-bottom:8px;">
                         Local OCR for the Scan Receipt button on the Enter Sales Receipt and Enter Bill forms.
-                        Runs on this computer via the Tesseract binary — no cloud, no data leaves the machine.
-                        Tesseract is never bundled with the app; it is installed separately.
+                        Everything runs on this computer — no cloud, no data leaves the machine.
+                        The desktop app ships with a built-in engine (Windows OCR / Apple Vision), so scanning
+                        works out of the box; Tesseract is an optional extra engine you can install yourself.
                     </div>
                     <div id="ocr-status" style="font-size:12px;">Checking…</div>
+                    <div style="margin-top:8px; display:flex; align-items:center; gap:8px;">
+                        <label for="ocr-engine-pref" style="font-size:11px;">OCR engine:</label>
+                        <select id="ocr-engine-pref" style="font-size:11px;"
+                            onchange="SettingsPage.saveOcrEngine(this.value)">
+                            <option value="auto">Automatic (recommended) — built-in engine first</option>
+                            <option value="tesseract">Prefer Tesseract (if installed)</option>
+                        </select>
+                    </div>
+                    <div style="font-size:10px; color:var(--text-muted); margin-top:4px;">
+                        Optional: Tesseract can sharpen box re-reads on faded receipts. Install it with
+                        <code>sudo apt-get install tesseract-ocr</code> (Ubuntu),
+                        <code>brew install tesseract</code> (macOS), or the
+                        UB&nbsp;Mannheim build from
+                        <code>github.com/UB-Mannheim/tesseract</code> (Windows), then choose it here.
+                    </div>
                 </div>
 
                 <div class="settings-section">
@@ -518,6 +535,23 @@ const SettingsPage = {
             await API.post('/settings/test-email');
             toast('Test email sent');
         } catch (err) { toast(err.message, 'error'); }
+    },
+
+    async saveOcrEngine(value) {
+        try {
+            await API.put('/settings', { ocr_engine: value });
+            toast('OCR engine preference saved');
+            this.loadOcrStatus();
+        } catch (err) { toast(err.message, 'error'); }
+    },
+
+    async loadOcrEnginePref() {
+        const sel = $('#ocr-engine-pref');
+        if (!sel) return;
+        try {
+            const settings = await API.get('/settings');
+            if (settings.ocr_engine) sel.value = settings.ocr_engine;
+        } catch (e) { /* leave the default selected */ }
     },
 
     async loadOcrStatus() {

--- a/tests/test_ocr_engines.py
+++ b/tests/test_ocr_engines.py
@@ -180,3 +180,42 @@ def test_recognize_rescales_boxes_to_original_space(monkeypatch):
 def test_preprocess_page_survives_junk_bytes():
     data, factor = ocr_service.preprocess_page(b"not an image at all")
     assert data == b"not an image at all" and factor == 1
+
+
+def test_engine_preference_from_settings(monkeypatch):
+    """The stored ocr_engine setting steers selection; the env override
+    (support tool) still outranks it; junk values fall through to auto."""
+    from app.services import ocr_engines
+
+    monkeypatch.delenv("SLOWBOOKS_OCR_ENGINE", raising=False)
+    assert ocr_engines.get_engine("tesseract").name == "tesseract"
+    # Unrecognized preference -> auto path (never raises)
+    assert ocr_engines.get_engine("copperplate").name in (
+        "tesseract",
+        "vision",
+        "winrt",
+    )
+    # Env override wins over the stored preference
+    monkeypatch.setenv("SLOWBOOKS_OCR_ENGINE", "tesseract")
+    assert ocr_engines.get_engine("winrt").name == "tesseract"
+
+
+def test_status_endpoint_honors_setting(client, db_session, monkeypatch):
+    """Setting ocr_engine=tesseract makes /api/ocr/status report tesseract
+    even where a native engine would win auto-selection."""
+    from app.services import ocr_service
+    from app.services.settings_service import set_setting
+
+    monkeypatch.setattr(ocr_service, "tesseract_available", lambda: True)
+    monkeypatch.setattr(
+        ocr_service,
+        "tesseract_info",
+        lambda: {"available": True, "version": "5.0-test", "languages": ["eng"]},
+    )
+
+    set_setting(db_session, "ocr_engine", "tesseract")
+    db_session.commit()
+
+    r = client.get("/api/ocr/status")
+    assert r.status_code == 200
+    assert r.json()["engine"] == "tesseract"


### PR DESCRIPTION
Adds the engine dropdown to Settings → Receipt Scanning, per the refined pointer doctrine: **the standard is ships-with-a-default** — the frozen builds carry a built-in engine so scanning works out of the box, and Tesseract is offered as an optional extra with a small install pointer in the UI (apt / brew / UB Mannheim), for users who want its sharper whitelist-driven region reads.

- `ocr_engine` in `DEFAULT_SETTINGS` (default `auto` = native-first). `get_engine()` precedence: `SLOWBOOKS_OCR_ENGINE` env (support tool) → stored setting → auto-selection; unrecognized values fall through safely.
- Status, scan, and region endpoints all read the setting.
- Section copy updated — the old "Tesseract is never bundled" text predates the engine seam.
- Dropdown saves on change and immediately re-checks the status row.

70 OCR-suite tests green (2 new: precedence, status-honors-setting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoFRzFKT5uxL15dkfARN6L