### PR TITLE
Fix WinRT scan 500: asyncio.run on a running event loop

### DIFF
--- a/app/services/ocr_engines.py
+++ b/app/services/ocr_engines.py
@@ -190,6 +190,27 @@ class VisionEngine:
         )
 
 
+def _run_winrt_coroutine(factory):
+    """Run a WinRT async operation to completion from ANY calling context.
+
+    asyncio.run() works only when no event loop is running — true for sync
+    routes (threadpool workers) and CLI/standalone use, but the scan route
+    is `async def` and lives ON the loop, where asyncio.run() raises. In
+    that case the operation runs on a dedicated thread with its own loop.
+    (Field-found on the VH308 hardware lap: standalone harness passed, the
+    frozen app 500'd on every scan.)
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(factory())
+
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, factory()).result()
+
+
 # ---------------------------------------------------------------------------
 # Windows.Media.Ocr (Windows 10/11) via winsdk. Word-level boxes.
 # HARDWARE-VERIFY-PENDING.
@@ -262,7 +283,7 @@ class WinRTEngine:
                 raise EngineUnavailable("No OCR language available in Windows")
             return await engine.recognize_async(bitmap)
 
-        result = asyncio.run(_run())
+        result = _run_winrt_coroutine(_run)
         text_lines = []
         words: list[WordBox] = []
         for line in result.lines:

--- a/tests/test_ocr_engines.py
+++ b/tests/test_ocr_engines.py
@@ -219,3 +219,25 @@ def test_status_endpoint_honors_setting(client, db_session, monkeypatch):
     r = client.get("/api/ocr/status")
     assert r.status_code == 200
     assert r.json()["engine"] == "tesseract"
+
+
+def test_run_winrt_coroutine_inside_and_outside_event_loop():
+    """The WinRT bridge must complete its coroutine whether or not the
+    caller already sits on a running event loop (async scan route vs sync
+    region route) — the VH308 500-on-every-scan regression."""
+    import asyncio
+
+    from app.services.ocr_engines import _run_winrt_coroutine
+
+    async def op():
+        await asyncio.sleep(0)
+        return "ok"
+
+    # No running loop (sync route / CLI context)
+    assert _run_winrt_coroutine(op) == "ok"
+
+    # From inside a running loop (async def route)
+    async def caller():
+        return _run_winrt_coroutine(op)
+
+    assert asyncio.run(caller()) == "ok"


### PR DESCRIPTION
First real catch from the VH308 hardware lap (build #38): `/api/ocr/status` reported `engine: winrt, available: true` with tesseract stripped from PATH — the frozen bundling works — but **every scan 500'd**. The scan route is `async def`, so it sits on uvicorn's event loop, where the WinRT adapter's `asyncio.run()` raises `RuntimeError`. The standalone validation harness had no running loop, which is exactly why it passed while the app failed.

`_run_winrt_coroutine()` now dispatches to a dedicated thread (own loop) when a loop is already running; sync callers (region endpoint, CLI) keep the direct path. Regression test covers both calling contexts.

Will re-run the full VH308 lap on the next dispatched build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoFRzFKT5uxL15dkfARN6L