### PR TITLE
OCR: rebuild reading order from word geometry (WinRT hardware finding)

### DIFF
--- a/app/services/ocr_engines.py
+++ b/app/services/ocr_engines.py
@@ -16,6 +16,7 @@
 
 import asyncio
 import os
+import re
 import sys
 from dataclasses import dataclass, field
 from typing import Optional
@@ -42,6 +43,58 @@ class OcrResult:
     words: list[WordBox] = field(default_factory=list)
     engine: str = "tesseract"
     language: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Reading order. Native engines report lines in *region* order, not page
+# order — hardware finding on Windows.Media.Ocr (2026-09-02): a receipt's
+# header line came back AFTER the amounts column, so "merchant = first
+# line" picked the street address and every "TOTAL" anchor sat a dozen
+# lines away from its amount. The text parsers were tuned on tesseract's
+# top-to-bottom output, so rebuild that ordering from box geometry instead
+# of trusting the engine's sequence. Tesseract keeps its own assembly.
+# ---------------------------------------------------------------------------
+
+# WinRT tokenizes a decimal point as its own tiny word ("49 . 13", "24 .50").
+_SPLIT_DECIMAL_RE = re.compile(r"(\d)\s*\.\s*(\d{2})\b")
+
+
+def lines_from_words(words: list[WordBox]) -> str:
+    """Rebuild top-to-bottom, left-to-right text from word boxes.
+
+    A word joins the current row when its vertical centre lies within ~60%
+    of a line height of the row's centre; rows are then read left to
+    right. Tolerant of the small skew a phone photo introduces.
+    """
+    if not words:
+        return ""
+    ordered = sorted(words, key=lambda w: (w.top + w.height / 2.0, w.left))
+    rows: list[list[WordBox]] = []
+    centres: list[float] = []
+    heights: list[float] = []
+    for w in ordered:
+        cy = w.top + w.height / 2.0
+        if rows:
+            tol = 0.6 * max(heights[-1], float(w.height), 1.0)
+            if abs(cy - centres[-1]) <= tol:
+                row = rows[-1]
+                row.append(w)
+                n = len(row)
+                centres[-1] += (cy - centres[-1]) / n
+                # Tiny punctuation boxes must not shrink the row height.
+                heights[-1] = max(heights[-1], float(w.height))
+                continue
+        rows.append([w])
+        centres.append(cy)
+        heights.append(float(w.height))
+    out = []
+    for row in rows:
+        row.sort(key=lambda w: w.left)
+        line = " ".join(w.text.strip() for w in row if w.text and w.text.strip())
+        line = _SPLIT_DECIMAL_RE.sub(r"\1.\2", line)
+        if line:
+            out.append(line)
+    return "\n".join(out)
 
 
 class EngineUnavailable(Exception):
@@ -182,9 +235,10 @@ class VisionEngine:
             )
             lines.append((top, text, box))
         lines.sort(key=lambda item: item[0])
+        boxes = [item[2] for item in lines]
         return OcrResult(
-            text="\n".join(item[1] for item in lines),
-            words=[item[2] for item in lines],
+            text=lines_from_words(boxes),
+            words=boxes,
             engine=self.name,
             language=lang,
         )
@@ -284,10 +338,8 @@ class WinRTEngine:
             return await engine.recognize_async(bitmap)
 
         result = _run_winrt_coroutine(_run)
-        text_lines = []
         words: list[WordBox] = []
         for line in result.lines:
-            text_lines.append(str(line.text))
             for word in line.words:
                 r = word.bounding_rect
                 words.append(
@@ -300,7 +352,7 @@ class WinRTEngine:
                     )
                 )
         return OcrResult(
-            text="\n".join(text_lines),
+            text=lines_from_words(words),
             words=words,
             engine=self.name,
             language=lang,

--- a/tests/test_ocr_engines.py
+++ b/tests/test_ocr_engines.py
@@ -241,3 +241,83 @@ def test_run_winrt_coroutine_inside_and_outside_event_loop():
         return _run_winrt_coroutine(op)
 
     assert asyncio.run(caller()) == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Reading order rebuilt from geometry (hardware finding, WinRT 2026-09-02)
+# ---------------------------------------------------------------------------
+
+
+def _wb(text, left, top, width=60, height=18):
+    return ocr_engines.WordBox(
+        text=text, left=left, top=top, width=width, height=height
+    )
+
+
+def test_lines_from_words_restores_page_order_from_region_order():
+    # Exactly the shape Windows.Media.Ocr returned on hardware: left column,
+    # then the amounts column, then the header line LAST, with the decimal
+    # points tokenized as their own 5x4 boxes.
+    words = [
+        _wb("SUBTOTAL", 40, 432, 134),
+        _wb("TAX", 41, 476, 50),
+        _wb("6.25%", 108, 476, 83),
+        _wb("TOTAL", 41, 520, 82),
+        _wb("NEON", 42, 36, 63),
+        _wb("PULSE", 126, 36, 81),
+        _wb("TECHSHOP", 226, 36, 132),
+        _wb("46.24", 343, 432, 83),
+        _wb("2.89", 360, 476, 65),
+        _wb("49", 343, 520, 31),
+        _wb(".", 382, 534, 5, 4),
+        _wb("13", 395, 520, 31),
+    ]
+    text = ocr_engines.lines_from_words(words)
+    assert text.splitlines() == [
+        "NEON PULSE TECHSHOP",
+        "SUBTOTAL 46.24",
+        "TAX 6.25% 2.89",
+        "TOTAL 49.13",
+    ]
+    # ...and the downstream parsers see what they were tuned on.
+    assert ocr_service.parse_total(text)[0] == "49.13"
+    assert ocr_service.parse_tax(text) == ("2.89", "46.24")
+    assert ocr_service.parse_merchant(text)[0] == "NEON PULSE TECHSHOP"
+
+
+def test_lines_from_words_tolerates_skew_and_empty_input():
+    assert ocr_engines.lines_from_words([]) == ""
+    # A phone photo tilts the row: the right-hand amount sits 8px lower than
+    # the anchor but still belongs to the same line.
+    words = [_wb("TOTAL", 40, 100), _wb("12.34", 300, 108), _wb("THANKS", 40, 150)]
+    assert ocr_engines.lines_from_words(words) == "TOTAL 12.34\nTHANKS"
+
+
+def test_winrt_adapter_text_is_rebuilt_from_words(monkeypatch):
+    class _Rect:
+        def __init__(self, x, y, w, h):
+            self.x, self.y, self.width, self.height = x, y, w, h
+
+    class _Word:
+        def __init__(self, text, x, y, w=60, h=18):
+            self.text, self.bounding_rect = text, _Rect(x, y, w, h)
+
+    class _Line:
+        def __init__(self, *words):
+            self.words = list(words)
+            self.text = " ".join(w.text for w in words)
+
+    class _Result:
+        # Engine order: amounts column first, header last.
+        lines = [
+            _Line(_Word("TOTAL", 40, 100)),
+            _Line(_Word("9.99", 300, 100)),
+            _Line(_Word("SHOP", 40, 20)),
+        ]
+
+    engine = ocr_engines.WinRTEngine()
+    monkeypatch.setattr(engine, "_bridge", lambda: (None, None, None, None))
+    monkeypatch.setattr(ocr_engines, "_run_winrt_coroutine", lambda factory: _Result())
+    result = engine.recognize(b"not-a-real-png")
+    assert result.text == "SHOP\nTOTAL 9.99"
+    assert [w.text for w in result.words] == ["TOTAL", "9.99", "SHOP"]


### PR DESCRIPTION
## Hardware finding
On VH308 (build #40, WinRT engine) a receipt with a tighter layout came back with the **header line last**: Windows.Media.Ocr emits lines in region order (left column → amounts column → header). Result: merchant = street address, tax/subtotal = None, total = 46.24 (wrong), \`template_applied=False\`. Tesseract read the same image perfectly because it assembles lines itself.

## Fix
\`lines_from_words()\` rebuilds top-to-bottom / left-to-right text from word boxes (rows by vertical overlap, tolerant of phone-photo skew) and re-joins WinRT's split decimal tokens ("49 . 13" → "49.13"). WinRT and Vision adapters both build \`OcrResult.text\` through it. Word boxes are untouched, so the canvas is unaffected.

Replaying the exact 38 word boxes WinRT returned on hardware now yields text identical to tesseract's; \`parse_total/tax/merchant\` all correct.

## Tests
+3 in \`tests/test_ocr_engines.py\` (region-order replay incl. parsers, skew tolerance + empty input, WinRT adapter text rebuilt from words). OCR suite 84 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoFRzFKT5uxL15dkfARN6L