### PR TITLE
test: default the OCR suite to tesseract so native engines don't bypass monkeypatches

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,10 @@ os.environ["ALLOWED_ORIGINS"] = "http://testserver,http://localhost:3001"
 os.environ["CORS_ALLOW_ORIGINS"] = "http://testserver,http://localhost:3001"
 os.environ["RATE_LIMIT_ENABLED"] = "0"
 os.environ["SESSION_IDLE_TIMEOUT_SECONDS"] = "0"  # Disable idle expiry in tests
+# The suite is written against tesseract; on a Mac/Windows dev box with the
+# native OCR bridge installed, auto-selection would pick Vision/WinRT and
+# bypass the ocr_service monkeypatches. Selection tests override per-test.
+os.environ.setdefault("SLOWBOOKS_OCR_ENGINE", "tesseract")
 # Point the app at an in-memory DB by default; fixtures override per-test.
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 

--- a/tests/test_ocr_engines.py
+++ b/tests/test_ocr_engines.py
@@ -63,13 +63,17 @@ def test_engine_selection_env_override(monkeypatch):
     monkeypatch.setenv("SLOWBOOKS_OCR_ENGINE", "vision")
     engine = ocr_engines.get_engine()
     assert engine.name == "vision"
-    # On Linux CI the Vision bridge can't import: it must degrade, not raise
+    # Without the pyobjc bridge (Linux CI) it must degrade, not raise; on a
+    # Mac with the bridge installed it is genuinely available.
+    monkeypatch.setattr(engine, "_bridge", lambda: (_ for _ in ()).throw(ImportError()))
     assert engine.available() is False
     assert engine.unavailable_reason()
 
 
 def test_engine_selection_auto_falls_back_to_tesseract(monkeypatch):
     monkeypatch.setenv("SLOWBOOKS_OCR_ENGINE", "auto")
+    # Pretend no native engine exists on this platform (true on Linux CI)
+    monkeypatch.setattr(ocr_engines, "_native_engine_for_platform", lambda: None)
     monkeypatch.setattr(
         ocr_service,
         "tesseract_info",


### PR DESCRIPTION
Finding 2 from the [#73 macOS hardware lap](https://github.com/VonHoltenCodes/SlowBooks-Pro-2026/pull/73#issuecomment-5510020294), opened as requested.

## What

- `tests/conftest.py`: `os.environ.setdefault("SLOWBOOKS_OCR_ENGINE", "tesseract")` before any app import. The suite is written against tesseract; on a Mac/Windows box with the pyobjc/winsdk bridge installed, `auto` picks Vision/WinRT and skips the `ocr_service` monkeypatches.
- `test_engine_selection_env_override`: patch `_bridge` to raise `ImportError` so the degrade path is exercised on every platform, not only where the bridge can't import.
- `test_engine_selection_auto_falls_back_to_tesseract`: patch `_native_engine_for_platform` to `None` so the fallback is forced rather than assumed.

`setdefault` means the env var still wins, so nothing changes for CI (Linux has no native engine anyway) or for anyone running the suite with an explicit engine.

## Test plan

Rebased on current `feat/receipt-intake` head (512b9c1, includes the skew fix). Apple Silicon, macOS 26.6.2, Python 3.13, pyobjc 12.2.2 pins from `requirements-build.txt`, Vision live.

`pytest tests -k "ocr or intake or receipt"`:

| | Result |
|---|---|
| Before | 20 failed / 132 passed |
| After | 1 failed / 151 passed |

black + ruff clean on both files.

The one remaining failure is pre-existing and unrelated: `test_ocr.py::test_tesseract_cmd_falls_back_to_stock_install_dir` empties `PATH` but the resolver's stock-location check still finds `/opt/homebrew/bin/tesseract` on any Homebrew Mac. Same "assumes the machine" class as this PR, but it lives in the resolver test so I left it alone. Happy to follow up if you want the stock dirs monkeypatched too.