### PR TITLE
fix: job costing review — P&L-neutral labor offset, seed-chart cost accounts, reject voids, budgets keep manual rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,10 +41,12 @@ edge-case costs onto them. Now:
   internal labor at an employee's loaded rate, owned-equipment hours from
   an Equipment list, mileage, small tools, burden, corrections. It debits
   job cost (tagged to job, code and type) and credits an offset account
-  (payroll clearing, applied equipment, applied overhead) — the applied-
-  cost pattern, so the company P&L is unchanged while every job carries
-  its share. Settings → Cost Types → **Create default offset accounts**
-  sets all of that up in one click. **Allocate a Cost** spreads one amount
+  (applied labor, applied equipment, applied overhead — all contra-expense
+  accounts on the P&L) — the applied-cost pattern, so the company P&L is
+  unchanged while every job carries its share. Settings → Cost Types →
+  **Create default offset accounts** sets all of that up in one click,
+  pointing each cost type at the chart's own COGS account (Materials,
+  Labor, Subcontractor) so the P&L keeps its cost categories. **Allocate a Cost** spreads one amount
   across jobs by labor hours, revenue, costs, equally, or by weights.
 - **Time entries post to jobs.** Employees get a job cost rate and a burden
   %; approved time tagged to a job posts as labor cost at that rate
@@ -65,6 +67,12 @@ edge-case costs onto them. Now:
   Actual** report lists every job's headline figures.
 - Also fixed on the way: the Time Entry form was sending hours under the
   wrong field names, so every entry saved with zero hours.
+- From the first macOS lap: the labor offset was a balance-sheet account,
+  so labor landed on the P&L twice once payroll ran — it is a P&L contra
+  now, like the other offsets. Rejecting a time entry that was already
+  posted to a job voids that job cost. Re-seeding a budget from an
+  estimate leaves hand-edited rows alone, and an estimate line with no
+  unit cost budgets zero cost (unknown) rather than the sale price.
 
 **Cost codes, billable costs and committed cost (milestone 2).** Settings
 gained a **Cost Codes** chart — which part of a job a cost belongs to ("03

--- a/app/routes/job_costing.py
+++ b/app/routes/job_costing.py
@@ -129,13 +129,51 @@ _OFFSET_ACCOUNTS = (
     # (key, name, type, number) — the applied-cost pattern: job cost is debited,
     # the applied account is credited, and the real payroll / equipment /
     # overhead expense sits alongside it, so the company P&L is unchanged
-    # while every job carries its share.
-    ("payroll_clearing", "Payroll Clearing", AccountType.LIABILITY, "2150"),
+    # while every job carries its share. Every offset must therefore be a
+    # P&L (contra-expense) account: a balance-sheet offset would leave the
+    # job cost on the P&L a second time once the real expense posts (the
+    # pay run still debits Wages for the same hours).
+    ("applied_labor", "Applied Labor Cost", AccountType.EXPENSE, "6900"),
     ("applied_burden", "Applied Labor Burden", AccountType.EXPENSE, "6910"),
     ("applied_equipment", "Applied Equipment Cost", AccountType.EXPENSE, "6920"),
     ("applied_overhead", "Applied Overhead", AccountType.EXPENSE, "6930"),
-    ("job_cost", "Job Costs", AccountType.COGS, "5100"),
 )
+
+# Default cost (debit) account per cost type, by seed-chart number, so a
+# stock company shows Materials / Labor / Subs on its P&L instead of one
+# lump. Anything unmapped (or a chart without these) falls through to
+# Cost of Goods Sold, then to a "Job Costs" COGS account created on demand.
+_DEFAULT_COST_ACCOUNTS = {
+    "material": "5100",  # Materials Cost
+    "labor": "5200",  # Labor Cost
+    "subcontract": "5300",  # Subcontractor Costs
+}
+_COGS_UMBRELLA = "5000"
+_JOB_COSTS_FALLBACK = ("Job Costs", AccountType.COGS, "5100")
+
+
+def _default_cost_account(db: Session, ct: CostType, cache: dict) -> Account:
+    """Seed-chart COGS account for the cost type, else the COGS umbrella,
+    else one shared 'Job Costs' account (created once)."""
+    for number in (_DEFAULT_COST_ACCOUNTS.get(ct.code), _COGS_UMBRELLA):
+        if number:
+            acct = db.query(Account).filter(Account.account_number == number).first()
+            if acct and acct.account_type == AccountType.COGS:
+                return acct
+    if "job_cost" not in cache:
+        name, atype, number = _JOB_COSTS_FALLBACK
+        acct = db.query(Account).filter(Account.name == name).first()
+        if not acct:
+            taken = (
+                db.query(Account.id).filter(Account.account_number == number).first()
+            )
+            acct = Account(
+                name=name, account_type=atype, account_number=None if taken else number
+            )
+            db.add(acct)
+            db.flush()
+        cache["job_cost"] = acct
+    return cache["job_cost"]
 
 
 @cost_types_router.post("/setup-offsets", response_model=list[CostTypeResponse])
@@ -158,12 +196,13 @@ def setup_offset_accounts(db: Session = Depends(get_db)):
             db.add(acct)
             db.flush()
         found[key] = acct
+    cache: dict = {}
     for ct in db.query(CostType).all():
         if not ct.default_account_id:
-            ct.default_account_id = found["job_cost"].id
+            ct.default_account_id = _default_cost_account(db, ct, cache).id
         if not ct.offset_account_id:
             if ct.is_labor:
-                ct.offset_account_id = found["payroll_clearing"].id
+                ct.offset_account_id = found["applied_labor"].id
             elif ct.code == "equipment":
                 ct.offset_account_id = found["applied_equipment"].id
             else:

--- a/app/routes/time_entries.py
+++ b/app/routes/time_entries.py
@@ -197,6 +197,21 @@ def reject_time_entry(entry_id: int, db: Session = Depends(get_db)):
     entry = db.query(TimeEntry).filter(TimeEntry.id == entry_id).first()
     if not entry:
         raise HTTPException(status_code=404, detail="Time entry not found")
+    # A submitted entry may already be posted to its job; rejecting it has
+    # to take that labor cost back off the job, not leave it behind.
+    if entry.job_cost_id:
+        from app.models.job_costing import JobCost
+        from app.services.closing_date import check_closing_date
+        from app.services.job_costing import void_job_cost
+
+        jc = db.get(JobCost, entry.job_cost_id)
+        if jc is not None and jc.status != "void":
+            check_closing_date(db, jc.date)  # the reversal posts on that date
+            try:
+                void_job_cost(db, jc)
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc))
+        entry.job_cost_id = None
     entry.status = TimeEntryStatus.REJECTED
     db.commit()
     db.refresh(entry)

--- a/app/services/job_costing.py
+++ b/app/services/job_costing.py
@@ -572,49 +572,49 @@ def allocate_cost(
 
 def budgets_from_estimate(db: Session, job: Job, estimate: Estimate) -> list[JobBudget]:
     """One budget row per cost code on the estimate: cost = qty × unit cost
-    (falling back to the line amount when no cost is entered), revenue =
-    the line amount. Lines without a code roll into a whole-job row."""
+    (0 when no cost is entered — budgeting the sale price as cost would
+    hide the margin), revenue = the line amount. Lines without a code roll
+    into a whole-job row. Re-seeding replaces the estimate rows; a row the
+    operator edited by hand (source "manual") wins and is left alone."""
     totals: dict[Optional[int], list[Decimal]] = {}
     for ln in estimate.lines:
         qty = Decimal(str(ln.quantity or 0))
         cost = (
             _q(qty * Decimal(str(ln.unit_cost)))
             if ln.unit_cost is not None
-            else _q(ln.amount or 0)
+            else Decimal("0")
         )
         rev = _q(ln.amount or 0)
         bucket = totals.setdefault(ln.cost_code_id, [Decimal("0"), Decimal("0")])
         bucket[0] += cost
         bucket[1] += rev
-    rows = []
     db.query(JobBudget).filter(
         JobBudget.job_id == job.id, JobBudget.source == "estimate"
     ).delete()
-    for code_id, (cost, rev) in totals.items():
-        existing = (
-            db.query(JobBudget)
-            .filter(
-                JobBudget.job_id == job.id,
-                JobBudget.cost_code_id == code_id,
-                JobBudget.cost_type.is_(None),
-            )
-            .first()
+    manual_codes = {
+        r.cost_code_id
+        for r in db.query(JobBudget)
+        .filter(
+            JobBudget.job_id == job.id,
+            JobBudget.cost_type.is_(None),
+            JobBudget.source == "manual",
         )
-        if existing:
-            existing.amount, existing.revenue_amount = cost, rev
-            existing.source, existing.estimate_id = "estimate", estimate.id
-            rows.append(existing)
-        else:
-            row = JobBudget(
-                job_id=job.id,
-                cost_code_id=code_id,
-                amount=cost,
-                revenue_amount=rev,
-                source="estimate",
-                estimate_id=estimate.id,
-            )
-            db.add(row)
-            rows.append(row)
+        .all()
+    }
+    rows = []
+    for code_id, (cost, rev) in totals.items():
+        if code_id in manual_codes:
+            continue
+        row = JobBudget(
+            job_id=job.id,
+            cost_code_id=code_id,
+            amount=cost,
+            revenue_amount=rev,
+            source="estimate",
+            estimate_id=estimate.id,
+        )
+        db.add(row)
+        rows.append(row)
     db.flush()
     return rows
 

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -320,7 +320,7 @@ const SettingsPage = {
                         <input type="text" id="new-ct-name" placeholder="Name" style="width:200px;">
                         <label style="font-weight:normal;font-size:11px;"><input type="checkbox" id="new-ct-labor"> labor-type (burden applies)</label>
                         <button type="button" class="btn btn-primary" onclick="SettingsPage.addCostType()">Add Cost Type</button>
-                        <button type="button" class="btn btn-secondary" onclick="SettingsPage.setupOffsets()" title="Creates Payroll Clearing, Applied Labor Burden, Applied Equipment Cost, Applied Overhead and Job Costs if missing, and fills in any blank accounts">Create default offset accounts</button>
+                        <button type="button" class="btn btn-secondary" onclick="SettingsPage.setupOffsets()" title="Creates Applied Labor Cost, Applied Labor Burden, Applied Equipment Cost and Applied Overhead if missing, points each cost type at the matching COGS account (Materials, Labor, Subcontractor) and fills in any blank accounts">Create default offset accounts</button>
                     </div>
                     <div id="cost-types-list"></div>
                 </div>

--- a/docs/design/projects.md
+++ b/docs/design/projects.md
@@ -156,10 +156,17 @@ lesson: synthetic inputs hide every real fault).
 - **Applied-cost pattern for non-bill costs.** A Job Cost Entry debits the
   cost account (tagged to the job) and credits an offset that is *not*
   tagged, so the credit lands in "No job" and Job Profitability still
-  totals to the P&L. Offsets: Payroll Clearing (labor), Applied Labor
-  Burden, Applied Equipment Cost, Applied Overhead; `setup-offsets` creates
-  them (keeping the suggested number only if the chart hasn't used it) and
-  never overrides a choice already made.
+  totals to the P&L. Offsets: Applied Labor Cost, Applied Labor Burden,
+  Applied Equipment Cost, Applied Overhead; `setup-offsets` creates them
+  (keeping the suggested number only if the chart hasn't used it) and
+  never overrides a choice already made. Every offset is a contra-expense
+  on the P&L, never a balance-sheet account: the first Mac lap (2026-09-03)
+  showed a liability offset (Payroll Clearing) leaves labor on the P&L
+  twice once the pay run debits Wages for the same hours, and the clearing
+  balance never clears. A true clearing entry belongs to M4, when pay runs
+  learn to debit it. Default cost accounts follow the seed chart (5100
+  Materials, 5200 Labor, 5300 Subcontractor, else 5000), so a stock
+  company sees its cost categories on the P&L rather than one lump.
 - **Labor cost rate** = employee cost_rate, else pay rate (salary ÷ 2080);
   OT × 1.5, DT × 2; burden % = employee's, else the labor type's. Only
   submitted/approved entries post, once each (`time_entries.job_cost_id`).

--- a/tests/test_job_costing.py
+++ b/tests/test_job_costing.py
@@ -71,11 +71,26 @@ def test_cost_types_seed_edit_and_offset_setup(client, seed_accounts):
     assert dup.status_code == 409
 
     types = _setup(client)
-    assert types["labor"]["offset_account_name"] == "Payroll Clearing"
+    assert types["labor"]["offset_account_name"] == "Applied Labor Cost"
     assert types["labor"]["burden_offset_account_name"] == "Applied Labor Burden"
     assert types["equipment"]["offset_account_name"] == "Applied Equipment Cost"
     assert types["material"]["offset_account_name"] == "Applied Overhead"
-    assert types["labor"]["default_account_name"] == "Job Costs"
+    # every offset is a P&L contra, never a balance-sheet account
+    accounts = {a["name"]: a for a in client.get("/api/accounts").json()}
+    for name in (
+        "Applied Labor Cost",
+        "Applied Labor Burden",
+        "Applied Equipment Cost",
+        "Applied Overhead",
+    ):
+        assert accounts[name]["account_type"] == "expense", name
+    assert "Payroll Clearing" not in accounts and "Job Costs" not in accounts
+    # cost accounts follow the seed chart's COGS split, not one lump
+    assert types["material"]["default_account_name"] == "Materials Cost"
+    assert types["labor"]["default_account_name"] == "Labor Cost"
+    assert types["subcontract"]["default_account_name"] == "Subcontractor Costs"
+    assert types["equipment"]["default_account_name"] == "Cost of Goods Sold"
+    assert types["other"]["default_account_name"] == "Cost of Goods Sold"
     # idempotent, and it respects a choice already made
     labor_id = types["labor"]["id"]
     other_acct = client.get("/api/accounts").json()[0]["id"]
@@ -391,8 +406,9 @@ def test_budget_from_estimate_and_cost_tree_columns(
         float(rows[fram["id"]]["amount"]) == 2000.0
         and float(rows[fram["id"]]["revenue_amount"]) == 3000.0
     )
-    assert float(rows[trim["id"]]["amount"]) == 1500.0  # no unit cost → amount
-    assert float(rows[None]["amount"]) == 500.0  # uncoded → whole-job row
+    assert float(rows[trim["id"]]["amount"]) == 0.0  # no unit cost → unknown, not price
+    assert float(rows[None]["amount"]) == 0.0  # uncoded, no unit cost → whole-job row
+    assert float(rows[None]["revenue_amount"]) == 500.0
 
     # manual override on trim, plus a type-level budget
     saved = client.put(
@@ -484,18 +500,18 @@ def test_budget_from_estimate_and_cost_tree_columns(
     assert material["figures"]["projected"] == 1400.0
     labor = next(t for t in tree["types"] if t["cost_type"] == "labor")
     assert labor["figures"]["original"] == 4000.0 and labor["figures"]["actual"] == 0.0
-    assert tree["job_level_budget"]["original"] == 500.0
-    assert tree["totals"]["original"] == 3200.0 + 4000.0 + 500.0
+    assert tree["job_level_budget"]["original"] == 0.0
+    assert tree["totals"]["original"] == 3200.0 + 4000.0
 
     # headline report row
     bva = {r["job_id"]: r for r in client.get("/api/jobs/budget-vs-actual").json()}
     row = bva[job["id"]]
     assert (
-        row["revised"] == 7700.0
+        row["revised"] == 7200.0
         and row["actual"] == 800.0
         and row["committed"] == 600.0
     )
-    assert row["variance"] == 7700.0 - 1400.0 and row["act_revenue"] == 1000.0
+    assert row["variance"] == 7200.0 - 1400.0 and row["act_revenue"] == 1000.0
 
     # period filter: actuals honour it, budgets don't
     later = client.get(f"/api/jobs/{job['id']}/cost-tree?start_date=2026-08-01").json()
@@ -518,3 +534,150 @@ def test_estimate_unit_cost_round_trips(client, seed_accounts, seed_customer):
     )
     assert resp.status_code in (200, 201), resp.text
     assert Decimal(str(resp.json()["lines"][0]["unit_cost"])) == Decimal("30.5")
+
+
+# ── Review fixes (first Mac lap, 2026-09-03) ─────────────────────────────
+
+
+def _pl(client, start="2026-07-01", end="2026-07-31"):
+    resp = client.get(
+        "/api/reports/profit-loss", params={"start_date": start, "end_date": end}
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _hourly(client, first="Ray", last="Crew", **extra):
+    resp = client.post(
+        "/api/employees",
+        json={
+            "first_name": first,
+            "last_name": last,
+            "pay_type": "hourly",
+            "pay_rate": 30,
+            **extra,
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    return resp.json()["id"]
+
+
+def _posted_entry(client, job_id, emp_id, day="2026-07-11", hours=8):
+    te = client.post(
+        "/api/time-entries",
+        json={
+            "employee_id": emp_id,
+            "date": day,
+            "hours_regular": hours,
+            "job_id": job_id,
+        },
+    ).json()
+    client.post(f"/api/time-entries/{te['id']}/submit")
+    posted = client.post(f"/api/time-entries/{te['id']}/post-to-job")
+    assert posted.status_code == 200, posted.text
+    return te["id"], posted.json()["job_cost_id"]
+
+
+def test_labor_posting_is_pnl_neutral(client, seed_accounts, seed_customer):
+    """Time → job moves labor into COGS and credits a P&L contra, so net
+    income is unchanged; the pay run is what actually expenses the wages.
+    (A balance-sheet offset would have counted the labor twice.)"""
+    types = _setup(client)
+    client.put(f"/api/cost-types/{types['labor']['id']}", json={"burden_pct": 20})
+    job = _job(client, seed_customer.id)
+    emp_id = _hourly(client)
+    _posted_entry(client, job["id"], emp_id)
+
+    pl = _pl(client)
+    assert pl["net_income"] == 0
+    cogs = {c["account_name"]: c["amount"] for c in pl["cogs"]}
+    expenses = {e["account_name"]: e["amount"] for e in pl["expenses"]}
+    assert cogs["Labor Cost"] == 288.0  # 8h × 30 = 240 base + 20% burden
+    assert expenses["Applied Labor Cost"] == -240.0
+    assert expenses["Applied Labor Burden"] == -48.0
+
+    # the job carries the cost, "No job" carries the offsets, sum = P&L
+    prof = client.get(
+        "/api/jobs/profitability",
+        params={"start_date": "2026-07-01", "end_date": "2026-07-31"},
+    ).json()
+    by_name = {r["job_name"]: r for r in prof}
+    assert by_name["Barn"]["total_costs"] == 288.0
+    assert sum(r["income"] - r["total_costs"] for r in prof) == pl["net_income"]
+
+
+def test_rejecting_a_posted_time_entry_voids_its_job_cost(
+    client, seed_accounts, seed_customer
+):
+    _setup(client)
+    job = _job(client, seed_customer.id)
+    emp_id = _hourly(client, "Ann")
+    te_id, jc_id = _posted_entry(client, job["id"], emp_id)
+    assert (
+        client.get(f"/api/jobs/{job['id']}").json()["summary"]["total_costs"] == 240.0
+    )
+
+    rej = client.post(f"/api/time-entries/{te_id}/reject")
+    assert rej.status_code == 200, rej.text
+    assert rej.json()["status"] == "rejected" and rej.json()["job_cost_id"] is None
+    assert client.get(f"/api/job-costs/{jc_id}").json()["status"] == "void"
+    assert client.get(f"/api/jobs/{job['id']}").json()["summary"]["total_costs"] == 0
+    # an entry that was never posted still rejects cleanly
+    te2 = client.post(
+        "/api/time-entries",
+        json={"employee_id": emp_id, "date": "2026-07-12", "hours_regular": 2},
+    ).json()
+    assert client.post(f"/api/time-entries/{te2['id']}/reject").status_code == 200
+
+
+def test_reseeding_budget_keeps_manual_rows_and_zero_costs_unknown(
+    client, seed_accounts, seed_customer
+):
+    _setup(client)
+    job = _job(client, seed_customer.id)
+    fram = _code(client, "06-100", "Framing", "material")
+    trim = _code(client, "06-200", "Trim", "material")
+    est = client.post(
+        "/api/estimates",
+        json={
+            "customer_id": seed_customer.id,
+            "date": "2026-07-01",
+            "job_id": job["id"],
+            "lines": [
+                {
+                    "description": "Framing",
+                    "quantity": 10,
+                    "rate": 300,
+                    "unit_cost": 200,
+                    "cost_code_id": fram["id"],
+                },
+                {
+                    "description": "Trim",
+                    "quantity": 1,
+                    "rate": 1500,
+                    "cost_code_id": trim["id"],
+                },
+            ],
+        },
+    ).json()
+    seed = f"/api/jobs/{job['id']}/budgets/from-estimate/{est['id']}"
+    rows = {r["cost_code_id"]: r for r in client.post(seed).json()}
+    assert float(rows[fram["id"]]["amount"]) == 2000.0
+    # no unit cost entered: the cost is unknown, not equal to the sale price
+    assert float(rows[trim["id"]]["amount"]) == 0.0
+    assert float(rows[trim["id"]]["revenue_amount"]) == 1500.0
+
+    # hand-edit framing, re-seed: the manual row wins, trim is re-seeded
+    client.put(
+        f"/api/jobs/{job['id']}/budgets",
+        json={"rows": [{"cost_code_id": fram["id"], "amount": 2500}]},
+    )
+    client.post(seed)
+    rows = {
+        r["cost_code_id"]: r
+        for r in client.get(f"/api/jobs/{job['id']}/budgets").json()
+    }
+    assert float(rows[fram["id"]]["amount"]) == 2500.0
+    assert rows[fram["id"]]["source"] == "manual"
+    assert rows[trim["id"]]["source"] == "estimate"
+    assert sum(1 for r in rows.values() if r["cost_code_id"] == fram["id"]) == 1


### PR DESCRIPTION
Review fixes from the first macOS lap of #86, opened against `feat/projects` so they ride into #86 the way #85 rides into #84. All four findings were reproduced on a fresh company file before the fix; the lap output is in the #86 review.

## The accounting one

**Labor was landing on the P&L twice.** `post_time_entry_to_job` debits job cost and credits the labor offset. `setup-offsets` created that offset as **Payroll Clearing, a liability**. The other three offsets (burden, equipment, overhead) are expense contras, so they net to zero on the P&L; the liability doesn't. Then the pay run debits Wages for the same approved hours. On the lap: net income moved 361.19 when only the 31.19 of employer tax was new, and Payroll Clearing sat at 330.00 on the balance sheet with nothing ever clearing it.

Fix: the labor offset is **Applied Labor Cost (6900), an expense contra** like its siblings. Every offset is now a P&L account by construction, and the comment on `_OFFSET_ACCOUNTS` says why. A true clearing entry belongs to M4, when pay runs learn to debit it; this keeps the books right until then. New test `test_labor_posting_is_pnl_neutral` asserts net income is unchanged after a time → job posting and that Job Profitability still sums to the P&L.

## Default cost accounts

Every cost type defaulted to a new "Job Costs" COGS account, which also lost its 5100 number because the seed chart already has 5100 Materials Cost, 5200 Labor Cost, 5300 Subcontractor Costs. Now material / labor / subcontract map to those by number, equipment and other fall to 5000 Cost of Goods Sold, and "Job Costs" is only created when a custom chart has none of them. A stock company keeps its cost categories on the P&L instead of one lump.

## Reject after post

A submitted entry can post to its job; `reject` then only flipped the status, so the labor stayed on the job (visible in the lap as 150.00 of labor actuals from a rejected entry). Reject now voids the job cost (closing-date checked, since the reversal posts on the entry's date) and clears `job_cost_id`.

## Budgets from an estimate

- `budgets_from_estimate` deleted the estimate rows, then found the **manual** row for the same code and overwrote it, flipping `source` back to `estimate`. The design doc says manual rows survive. They do now: a code with a manual row is skipped on re-seed.
- A line with no unit cost budgeted its **sale amount** as cost, i.e. zero margin, silently. It budgets 0 now (cost unknown) while revenue still seeds. Judgment call; happy to revert that part if you'd rather keep the old behaviour, but from the estimator's chair a missing cost should look missing.

Docs: `projects.md` M3 decisions and the changelog updated; the Settings button tooltip matches.

## Test plan

- Apple Silicon, macOS 26.6.2, Python 3.13. Full suite: **1417 passed**, 3 environment-specific OCR tests deselected (the two #85 fixes and the Homebrew stock-dir test).
- 3 new tests; the existing offset test now asserts every offset is an expense account and the COGS mapping; the existing budget test updated for the zero-cost rule.
- black + ruff clean.
- No schema change. Companies that already ran setup-offsets on the branch keep their Payroll Clearing choice (setup never overrides a set account); flip the labor offset in Settings → Cost Types.