### PR TITLE
fix: post-tax deductions take what is left of the check; remittance follows the code's vendor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,15 @@ Every card loads independently, so one card with a problem shows its
 error in place instead of taking the page down. The overdue-invoices card
 now names who owes what and by how many days.
 
+### Benefits engine — from the first macOS lap
+
+- A post-tax deduction larger than the check used to leave a negative net
+  pay on the stub and an unbalanced payroll entry on processing. Post-tax
+  codes now take what is left after taxes and garnishments, in sequence,
+  with the shortfall noted on the stub; net pay never goes below zero.
+- The remittance report and bill follow a code's current vendor when the
+  run was processed before the vendor was assigned.
+
 ### v2.7.0 — Jobs, job costing, and receipt intake
 
 The two most-requested features since Server Edition, each field-tested on

--- a/app/routes/payroll/runs.py
+++ b/app/routes/payroll/runs.py
@@ -259,6 +259,30 @@ def create_pay_run(data: PayRunCreate, db: Session = Depends(get_db)):
         )
         garnish_total = total_garnished(garn_results)
 
+        # Post-tax deductions come out of what is left after pre-tax codes,
+        # taxes and garnishments (court orders outrank voluntary codes).
+        # The first pass could not know the taxes; when the post-tax total
+        # would overdraw the check, evaluate the codes again with the real
+        # room and trim the ad-hoc amount to whatever remains. Pre-tax
+        # amounts are identical on both passes, so the withholdings stand.
+        available = _q(gross - pretax - result["total_employee_tax"] - garnish_total)
+        if posttax > available:
+            ben = benefits_engine.compute(
+                db,
+                emp,
+                gross,
+                total_hours,
+                data.period_start,
+                data.period_end,
+                year,
+                ytd_gross_before=ytd["gross"],
+                posttax_available=available,
+            )
+            adhoc_posttax = _q(
+                max(Decimal("0"), min(adhoc_posttax, available - ben.posttax_total))
+            )
+            posttax = ben.posttax_total + adhoc_posttax
+
         # Net: gross less every tax, every employee-side benefit amount
         # (pre- and post-tax, engine and ad-hoc), garnishments; plus
         # non-taxable reimbursements. Computed here rather than from the
@@ -286,6 +310,18 @@ def create_pay_run(data: PayRunCreate, db: Session = Depends(get_db)):
                 detail[f"benefit:{ln.code.code}"] = str(ln.employee_amount)
             if ln.employer_amount:
                 detail[f"employer_benefit:{ln.code.code}"] = str(ln.employer_amount)
+            if ln.note:
+                detail[f"benefit:{ln.code.code}:note"] = ln.note
+        if net < 0:
+            # Only a garnishment stack beyond disposable earnings can get
+            # here now; refuse rather than post an unbalanced payroll entry.
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"{emp.full_name}: deductions and garnishments exceed pay "
+                    f"(net would be {net}). Reduce them before running payroll."
+                ),
+            )
         if adhoc_pretax:
             detail["other_pretax_deductions"] = str(adhoc_pretax)
         if adhoc_posttax:

--- a/app/services/benefits_engine.py
+++ b/app/services/benefits_engine.py
@@ -468,13 +468,22 @@ def compute(
     year: int,
     ytd_gross_before: Decimal = ZERO,
     resolved: Optional[list[Resolved]] = None,
+    posttax_available: Optional[Decimal] = None,
 ) -> CalcResult:
+    """Evaluate every code in sequence. `posttax_available` is what is left
+    of the check after pre-tax codes, taxes and garnishments; when the run
+    passes it (second pass), post-tax codes take at most that much, in
+    sequence, and a line that came up short says so in `note`. Voluntary
+    post-tax deductions never drive net pay negative."""
     gross = _q(_d(gross))
     hours = _d(hours)
     if resolved is None:
         resolved = resolve_for_employee(db, emp, period_start, period_end)
     fed_base = state_base = fica_base = gross
     remaining_pay = gross
+    posttax_left = (
+        max(ZERO, _q(_d(posttax_available))) if posttax_available is not None else None
+    )
     lines: list[Line] = []
     for r in resolved:
         code = r.code
@@ -508,6 +517,14 @@ def compute(
                 if bal is not None:
                     emp_amt = min(emp_amt, max(ZERO, _d(bal)))
             emp_amt = _q(max(ZERO, min(emp_amt, remaining_pay)))
+            if code.category != "pretax" and posttax_left is not None:
+                if emp_amt > posttax_left:
+                    line.note = (
+                        f"reduced from {emp_amt} to {_q(posttax_left)}: "
+                        "not enough net pay"
+                    )
+                    emp_amt = _q(posttax_left)
+                posttax_left -= emp_amt
             remaining_pay -= emp_amt
             if code.category == "pretax":
                 if code.reduces_federal:
@@ -708,12 +725,22 @@ def remittance_rows(db: Session, start: date, end: date) -> list[dict]:
     from app.models.contacts import Vendor
 
     vendors = {v.id: v.name for v in db.query(Vendor).all()}
+    # The vendor is snapshotted on the stub with the rule, but assigning a
+    # remittance vendor after the fact changes who gets paid, not what was
+    # withheld — so a snapshot with no vendor follows the code's current one.
+    code_vendor = {
+        c.id: c.remittance_vendor_id
+        for c in db.query(BenefitCode).filter(
+            BenefitCode.remittance_vendor_id.isnot(None)
+        )
+    }
     out = []
     for vid, cid, code, name, liab, ea, ra, n in rows:
         ea = _q(_d(ea))
         ra = _q(_d(ra))
         if ea == 0 and ra == 0:
             continue
+        vid = vid or code_vendor.get(cid)
         out.append(
             {
                 "vendor_id": vid,

--- a/docs/design/benefits-engine.md
+++ b/docs/design/benefits-engine.md
@@ -47,6 +47,16 @@ Decisions made while building:
   P&L is unchanged and the job carries the real cost.
 - **Employer-taxable benefits** (GTL over $50k) are flagged and reported
   in the stub detail; imputed-income withholding is not computed.
+- **Post-tax codes take what is left** (first macOS lap, 2026-09-04): the
+  engine runs once for the pre-tax codes and the wage bases, taxes and
+  garnishments are computed, and if the post-tax total would overdraw the
+  check the engine runs again with the real room (`posttax_available`).
+  Post-tax codes are trimmed in sequence, the shortfall is noted on the
+  stub, and net pay never goes negative; a garnishment stack that still
+  exceeds pay is refused with a 422 instead of posting an unbalanced entry.
+- **Remittance vendor follows the code** when the stub snapshot has none:
+  the vendor changes who gets paid, not what was withheld, so assigning
+  one after a run still lets the report and the bill find that run.
 
 Source: field ask from a Sage 50 evaluator (Matt Beebe, @TheMattBeebe)
 who has "been thinking about this for a long time across several

--- a/tests/test_benefits_engine.py
+++ b/tests/test_benefits_engine.py
@@ -857,3 +857,79 @@ def test_flat_burden_method_leaves_the_pay_run_alone(
     )  # 400 + 20%
     run = _run(client, emp["id"], use_time_entries=True, process=True)
     assert run["burden_job_cost_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Review fixes (macOS lap of the v2.8 stage, 2026-09-04)
+# ---------------------------------------------------------------------------
+
+
+def test_posttax_deduction_takes_what_is_left_never_a_negative_check(
+    client, db_session, seed_accounts
+):
+    """A post-tax code bigger than the check used to produce a negative net
+    and an unbalanced payroll entry (500 on process). It now takes what is
+    left after taxes, says so on the stub, and the run posts."""
+    emp = _emp(client, rate=20)
+    dues = _code(
+        client,
+        "DUES",
+        category="posttax",
+        reduces_federal=False,
+        reduces_state=False,
+        rate={"employee_rate": 5000},
+    )
+    _enroll(client, emp["id"], dues["id"])
+    run = _run(client, emp["id"], hours=10, process=True)
+    stub = run["stubs"][0]
+    gross = Decimal(str(stub["gross_pay"]))
+    taxes = (
+        gross - Decimal(str(stub["net_pay"])) - Decimal(str(stub["posttax_deductions"]))
+    )
+    assert gross == Decimal("200")
+    assert taxes > 0
+    assert Decimal(str(stub["net_pay"])) == Decimal("0")
+    assert Decimal(str(stub["posttax_deductions"])) == gross - taxes
+    assert _benefit(stub, "DUES")["employee_amount"] == float(gross - taxes)
+    import json
+
+    from app.models.payroll import PayStub
+
+    detail = json.loads(db_session.get(PayStub, stub["id"]).detail_json or "{}")
+    assert "not enough net pay" in detail["benefit:DUES:note"]
+    lines = _je_lines(db_session, run["_process"]["transaction_id"])
+    assert sum(Decimal(str(ln.debit)) for ln in lines) == sum(
+        Decimal(str(ln.credit)) for ln in lines
+    )
+
+
+def test_remittance_follows_the_codes_vendor_when_the_snapshot_has_none(
+    client, seed_accounts
+):
+    """Assigning a remittance vendor after a run was processed changes who
+    gets paid, not what was withheld, so the report and the bill pick it up."""
+    emp = _emp(client)
+    plan = _code(client, "PLAN", rate={"employee_rate": 50})
+    _enroll(client, emp["id"], plan["id"])
+    _run(client, emp["id"], process=True)
+    vendor = client.post("/api/vendors", json={"name": "Plan Admin"}).json()
+    r = client.put(
+        f"/api/benefits/codes/{plan['id']}", json={"remittance_vendor_id": vendor["id"]}
+    )
+    assert r.status_code == 200, r.text
+    rows = client.get(
+        "/api/benefits/remittance",
+        params={"start_date": "2026-07-17", "end_date": "2026-07-17"},
+    ).json()["rows"]
+    row = next(x for x in rows if x["code"] == "PLAN")
+    assert row["vendor_id"] == vendor["id"] and row["total"] == 50.0
+    bill = client.post(
+        "/api/benefits/remittance/bill",
+        json={
+            "vendor_id": vendor["id"],
+            "start_date": "2026-07-17",
+            "end_date": "2026-07-17",
+        },
+    )
+    assert bill.status_code == 201, bill.text
+    assert bill.json()["total"] == 50.0


### PR DESCRIPTION
Two fixes from the macOS lap of #88, opened against `feat/v2.8` per the stage rules. Both reproduced on a fresh company file first; the lap tables are in the #88 review.

## Post-tax deductions can't overdraw the check

`compute()` capped post-tax codes at `remaining_pay`, which only knew about pre-tax codes; taxes are computed afterwards in the run. A $5,000 fixed post-tax code on a 10h @ 20 stub produced gross 200.00, post-tax 200.00, **net −15.30**, and processing 500'd on `Journal entry not balanced: debits=218.90, credits=234.20` because the negative net line is skipped.

Now `compute()` takes an optional `posttax_available`. The run computes pre-tax codes, taxes and garnishments as before, and only when the post-tax total would overdraw the check does it evaluate the codes again with the real room. Post-tax codes take what's left in sequence (court-ordered garnishments outrank voluntary codes), a line that came up short says so in the stub detail (`benefit:CODE:note`), the ad-hoc post-tax amount is trimmed to the remainder, and a garnishment stack that still exceeds pay is refused with a 422 instead of posting an unbalanced entry. Pre-tax amounts are identical on both passes, so the withholdings stand. Same stub after the fix: post-tax 184.70, net 0.00, processes, JE balanced.

## Remittance follows the code's vendor when the snapshot has none

`remittance_rows` grouped on the stub snapshot's vendor, so assigning a remittance vendor after a run was processed left that run unbillable ("No processed payroll for that vendor in the period"). The vendor decides who gets paid, not what was withheld, so a snapshot with no vendor now follows the code's current one; snapshots that had a vendor keep it. On the lap: the 401(k) run billed 216.00 to the vendor and 2380 dropped from 316.00 to 100.00.

Docs: `benefits-engine.md` decisions and the changelog.

## Test plan

- Apple Silicon, macOS 26.6.2, Python 3.13. Full suite: **1697 passed**, Homebrew tesseract stock-dir test deselected.
- 2 new tests in `tests/test_benefits_engine.py`: the oversized post-tax code (net 0, note on the stub, balanced JE) and the vendor-after-run remittance bill.
- black + ruff clean. No schema change.