### PR TITLE
Release notes on the splash; company name on the Snapshot and toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
+_Nothing yet._
+
+### v2.8.0 — Benefits, all-state payroll, and an overview you can arrange
+
 ### Export parity with import (#70)
 
 **What comes in from QuickBooks can go back out.** IIF export now writes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,54 @@ Every card loads independently, so one card with a problem shows its
 error in place instead of taking the page down. The overdue-invoices card
 now names who owes what and by how many days.
 
+### Benefits engine
+
+**A benefit is a code with a rule.** Payroll evaluates whatever codes are
+attached to an employee: kind (deduction, benefit, both), calculation
+method, which wage bases the pre-tax side reduces, an explicit sequence
+(pre-tax codes apply in order and each changes the taxable base for the
+next), and three separate limits — per period, annual, and a wage-base
+ceiling. Rates are effective-dated and resolve against the pay-period end
+date; processed runs snapshot the rules they used so a later change never
+rewrites history. The employer side has its own rate and method including
+tiered 401(k) matching, an expense and liability account per code, and a
+remittance vendor — the Remittance tab totals what is owed and creates the
+vendor bill. Employee groups are templates; an enrollment overrides them.
+Loan-style codes carry a balance and stop at zero. PTO banks now carry
+dollars and can post the accrued liability. The Deductions page became
+Benefits; garnishments have their own page. Existing deduction types and
+elections migrate onto codes and enrollments.
+
+### Actual labor burden on jobs
+
+Set the Labor cost type's burden method to **payroll** and the pay run
+distributes real employer taxes plus job-routed benefit codes across the
+jobs each employee's time entries hit, by hours, P&L-neutral. Time entries
+then post base labor only. Replaces the flat percent from v2.7.0.
+
+### State withholding for all 50 states and DC
+
+Every state resolves to a payroll engine (Washington, California, New York
+and Oregon keep their dedicated ones). The figures are the 2026 published
+values with the source named per state in `docs/state-withholding.md`.
+Employees gain the state W-4 inputs: allowances, extra state withholding,
+an elected rate (Arizona), and a flat local rate for county and city taxes.
+Verify against your state before filing; the table is re-checked every
+January.
+
+### Employee portal link
+
+On the desktop the link now opens in the employee's browser instead of
+inside SlowBooks, and Copy Link / Email to Employee give a full address.
+The Details view says where that address is reachable from.
+
+### Small things
+
+- `GET /api/sales-receipts` lists receipts for API clients.
+- The Company Snapshot is titled with your company name, which also sits
+  in the toolbar and the window title.
+- The splash shows what's new in the version you're running.
+
 ### Benefits engine — from the first macOS lap
 
 - A post-tax deduction larger than the check used to leave a negative net

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 # Single source of truth for the application version: app/main.py reports
 # it on the FastAPI app and /health, /api/system serves it to the frontend
 # footer, and the Windows release workflow parses it for the installer.
-__version__ = "2.7.0"
+__version__ = "2.8.0"

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -125,6 +125,18 @@ body {
     z-index: 110;
 }
 
+.topbar-company {
+    font-weight: 700;
+    font-size: 12px;
+    padding: 0 10px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 260px;
+}
+.topbar-company:empty { display: none; }
+.topbar-company:empty + .tb-sep { display: none; }
+
 .topbar-brand {
     font-size: 13px;
     font-weight: 700;
@@ -1004,6 +1016,21 @@ tr.clickable { cursor: pointer; }
 .splash-info strong {
     color: rgba(255,255,255,0.7);
 }
+
+.splash-whatsnew {
+    text-align: left;
+    margin: 10px 0 4px;
+    padding: 8px 10px;
+    border: 1px solid var(--gray-300, #d1d5db);
+    background: rgba(255, 255, 255, 0.55);
+    font-size: 11px;
+    line-height: 1.35;
+    max-height: 170px;
+    overflow-y: auto;
+}
+.splash-whatsnew-title { font-weight: 700; margin-bottom: 4px; }
+.splash-whatsnew ul { margin: 0; padding-left: 16px; }
+.splash-whatsnew li { margin: 2px 0; }
 
 .splash-legal {
     font-size: 8px;

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -481,6 +481,10 @@ const App = {
             const companyEl = $('#status-company');
             if (companyEl && s.company_name && s.company_name !== 'My Company') {
                 companyEl.textContent = `Company: ${s.company_name}`;
+                // the window / tab title and the topbar brand say whose books these are
+                document.title = `${s.company_name} — Slowbooks Pro 2026`;
+                const brand = $('#topbar-company');
+                if (brand) brand.textContent = s.company_name;
             }
         } catch (e) { /* ignore on load */ }
     },

--- a/app/static/js/bootstrap.js
+++ b/app/static/js/bootstrap.js
@@ -21,6 +21,37 @@
         });
     }
 
+    // --- What's new on the splash ------------------------------------------
+    // /static/whats-new.json ships with the build (edited at release time,
+    // see docs/release-checklist.md); /health gives the running version.
+    // Both are public, so this works before login and in the About dialog.
+    (async () => {
+        try {
+            const [notesRes, healthRes] = await Promise.all([
+                fetch('/static/whats-new.json', { credentials: 'same-origin' }),
+                fetch('/health', { credentials: 'same-origin' }),
+            ]);
+            if (!notesRes.ok) return;
+            const notes = await notesRes.json();
+            const version = healthRes.ok ? (await healthRes.json()).version : null;
+            const key = (version && notes[version]) ? version : Object.keys(notes)[0];
+            const entry = notes[key];
+            if (!entry || !entry.items || !entry.items.length) return;
+            const box = document.getElementById('splash-whatsnew');
+            const title = document.getElementById('splash-whatsnew-title');
+            const list = document.getElementById('splash-whatsnew-list');
+            if (!box || !title || !list) return;
+            title.textContent = `What's new in ${key}${entry.title ? ' — ' + entry.title : ''}`;
+            list.innerHTML = '';
+            entry.items.forEach(text => {
+                const li = document.createElement('li');
+                li.textContent = text;
+                list.appendChild(li);
+            });
+            box.hidden = false;
+        } catch (e) { /* splash stays as shipped */ }
+    })();
+
     // --- About / theme / modal close --------------------------------------
     const about = document.getElementById('about-btn');
     if (about) about.addEventListener('click', () => window.App && App.showAbout && App.showAbout());

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -31,16 +31,28 @@ const DashboardPage = {
         return DashboardPage._pageHtml();
     },
 
+    _company: '',
+
     async _load() {
         const ids = DashboardPage._order.join(',');
-        DashboardPage._data = ids ? await API.get(`/dashboard/data?ids=${encodeURIComponent(ids)}`) : {};
+        const [data, settings] = await Promise.all([
+            ids ? API.get(`/dashboard/data?ids=${encodeURIComponent(ids)}`) : Promise.resolve({}),
+            API.get('/settings').catch(() => ({})),
+        ]);
+        DashboardPage._data = data;
+        const name = (settings && settings.company_name) || '';
+        DashboardPage._company = name && name !== 'My Company' ? name : '';
+    },
+
+    _title() {
+        return DashboardPage._company ? `${escapeHtml(DashboardPage._company)} Snapshot` : 'Company Snapshot';
     },
 
     _pageHtml() {
         const editing = DashboardPage._editing;
         return `
             <div class="page-header">
-                <h2>Company Snapshot</h2>
+                <h2>${DashboardPage._title()}</h2>
                 <div style="display:flex; gap:8px; align-items:center;">
                     ${editing ? `
                         <button class="btn btn-sm btn-secondary" onclick="DashboardPage.showAdd()">+ Add a card</button>

--- a/app/static/whats-new.json
+++ b/app/static/whats-new.json
@@ -1,0 +1,23 @@
+{
+  "2.8.0": {
+    "title": "Benefits, all-state payroll, and an overview you can arrange",
+    "items": [
+      "Benefits engine: benefit codes with rules, effective-dated rates, employer matching, employee groups, per-code GL and remittance bills",
+      "State withholding for all 50 states + DC with verified 2026 figures; state W-4 fields on the employee",
+      "PTO banks carry dollars and post a liability; actual payroll burden can flow to jobs by hours",
+      "Company Snapshot: pick, hide and reorder the cards per user, with five new cards",
+      "Sales tax per line: untaxed labor and taxed parts on one invoice",
+      "IIF and CSV export now carry classes, jobs, bills, deposits and sales receipts (#70)",
+      "Accessibility pass: real dialogs, table headers, contrast, tagged PDFs",
+      "Employee portal link opens in the employee's browser with a full address"
+    ]
+  },
+  "2.7.0": {
+    "title": "Jobs, job costing, and receipt intake",
+    "items": [
+      "Jobs under customers with cost codes, budgets and a drill-down cost tree",
+      "Job Cost Entry, time-to-job labor at loaded rates, allocations",
+      "Receipt intake: scan a receipt into a bill or expense"
+    ]
+  }
+}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,6 +4,10 @@ Before exposing SlowBooks Pro 2026 to anyone other than localhost, walk
 this list. Everything here is enforced or documented somewhere in the
 codebase — this file is the index, not the source of truth.
 
+## Before tagging
+
+- Add the release's entry to `app/static/whats-new.json` (version key must equal `app/__init__.py` `__version__`; one line per headline change — the splash and About dialog show it) and move the CHANGELOG `[Unreleased]` items under the version.
+
 ## 1. Secrets — generate fresh, never commit
 
 ```bash

--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
                 Born as a clean-room replacement for QuickBooks&nbsp;Pro&nbsp;2003<br>
                 after Intuit&rsquo;s activation servers died.
             </div>
+            <div class="splash-whatsnew" id="splash-whatsnew" hidden>
+                <div class="splash-whatsnew-title" id="splash-whatsnew-title"></div>
+                <ul id="splash-whatsnew-list"></ul>
+            </div>
             <div class="splash-legal">
                 Independent reimplementation built from published SDK<br>
                 documentation (QBFC 5.0) and 14 years as a paying customer.<br>
@@ -39,6 +43,9 @@
         <!-- Toolbar -->
         <div id="topbar">
             <div class="topbar-brand">Slowbooks Pro <span>2026</span></div>
+            <div class="tb-sep"></div>
+            <!-- whose books: filled from Settings → company name (app.js loadCompanyName) -->
+            <div class="topbar-company" id="topbar-company" title="Company file in use"></div>
             <div class="tb-sep"></div>
             <button class="tb-btn" data-nav="#/">Home</button>
             <button class="tb-btn" data-action="CustomersPage.showForm">New Customer</button>

--- a/tests/test_whats_new.py
+++ b/tests/test_whats_new.py
@@ -1,0 +1,23 @@
+"""The splash's what's-new feed ships with the build and stays well-formed."""
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_whats_new_feed_is_valid_and_wired():
+    notes = json.loads((ROOT / "app/static/whats-new.json").read_text())
+    assert notes, "at least one release"
+    for version, entry in notes.items():
+        assert version.count(".") == 2, version
+        assert entry["items"] and all(isinstance(i, str) and i for i in entry["items"])
+    html = (ROOT / "index.html").read_text()
+    assert 'id="splash-whatsnew"' in html and 'id="topbar-company"' in html
+    js = (ROOT / "app/static/js/bootstrap.js").read_text()
+    assert "/static/whats-new.json" in js
+
+
+def test_whats_new_is_public(client):
+    r = client.get("/static/whats-new.json")
+    assert r.status_code == 200 and "2.8.0" in r.json()


### PR DESCRIPTION
Two pre-release asks from the SkyTech lap.

**What's new on the splash.** The splash was static. `app/static/whats-new.json` now ships with the build and the splash / About dialog shows the entry for the running version (public paths, so it works before login). Release checklist step added; 2.8.0 written. CHANGELOG `[Unreleased]` now actually lists the benefits engine, the burden seam, all-state withholding and the portal fix.

**Company name where you look.** "NEON pulse Techshop Snapshot" on the dashboard header, the name in the toolbar next to the brand, and in the window title. The status-bar line was already there; now it's not the only place.

Tests: `tests/test_whats_new.py`; accessibility, wiring, dashboard suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKHh4ur44kz4YNjbQd85kW