### PR TITLE
docs(macos): document in-fleet local signing on Macbase1

### DIFF
--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -136,3 +136,29 @@ After owner-approved merge, rebuild from the exact release-tag commit. Never
 publish a development-branch artifact under an existing tag. Upload only the
 signed, notarized, stapled DMG, then independently re-download it and repeat
 the checksum, Gatekeeper, mount, and launch checks.
+
+## In-fleet local signing on Macbase1 (VonHolten fleet)
+
+The VonHolten fleet has a dedicated macOS signer, **Macbase1** (M1 Mac mini,
+`ssh macbase1`), that signs + notarizes under the owner's Developer ID —
+the in-fleet stand-in for the maintainer's Mac. Proven for SlowBooks v2.8.0 on
+2026-09-04 (.app + .dmg notarized + stapled, `spctl` = "Notarized Developer ID").
+
+Full operational runbook: **`devbase1:~/CLAUDE.md`** → "Local macOS build → sign →
+notarize on Macbase1", and `/Users/macbase1/CLAUDE.md` on the box. In brief: run
+this repo's `.github/workflows/macos.yml` build steps locally (venv off brew
+`python3`, `export DYLD_FALLBACK_LIBRARY_PATH="$(brew --prefix)/lib"`, install the
+three requirements files, `pyinstaller … SlowBooksPro-mac.spec`), then Developer-ID
+sign inside-out and notarize with the shared `fleet-signing.keychain-db` identity.
+
+Fleet-specific gotchas that differ from a normal dev Mac:
+- **Pass `--keychain ~/Library/Keychains/fleet-signing.keychain-db` to every
+  `notarytool` call** — over SSH the default *login* keychain is locked.
+- **`create-dmg` hangs headless** (its Finder AppleScript needs a GUI). Build the
+  DMG with `hdiutil create -format UDZO`, then codesign it.
+- The `--smoke-test` writes to `SLOWBOOKS_DATA_DIR`; keep that OUTSIDE the `.app`
+  and sign **after** any launch — anything written into the bundle post-signing
+  breaks the seal and Apple rejects notarization.
+
+These are proof-of-pipeline builds; a real release still follows the tag-commit
+rebuild + installed-app acceptance gates documented above.


### PR DESCRIPTION
## What

Adds an **In-fleet local signing on Macbase1** section to `packaging/macos/README.md`.

The VonHolten fleet now has a dedicated macOS signer (Macbase1, an M1 Mac mini) that builds, Developer-ID signs, notarizes, and staples SlowBooks under the owner's own identity — the in-fleet stand-in for the maintainer's Mac. This was proven end to end for v2.8.0 on 2026-09-04 (app + DMG both notarized and stapled, `spctl` = "Notarized Developer ID").

## Why

The existing README documents the maintainer's-Mac path; this records the parallel local path on the fleet's own hardware, so a release can be signed without borrowing a Mac. It complements, and does not replace, the CI and tag-commit acceptance gates already documented.

## Notes

- **No secrets.** The section references the keychain by name and points to the full operational runbook in the fleet docs (`devbase1:~/CLAUDE.md`); no passwords, keys, Apple ID, or IPs are included.
- Captures the SSH-specific gotchas that cost real time: pass `--keychain` to `notarytool` (login keychain is locked over SSH), build the DMG with `hdiutil` (`create-dmg` hangs headless), set `DYLD_FALLBACK_LIBRARY_PATH` for WeasyPrint, and sign after any launch so nothing written into the bundle breaks the seal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ofkoan2B7WnoDtLEJYfR2