### PR TITLE
Feat/custom AI provider

### DIFF
--- a/app/routes/analytics.py
+++ b/app/routes/analytics.py
@@ -58,6 +58,7 @@ class AIConfigUpdate(BaseModel):
     api_key: Optional[str] = None
     cloudflare_account_id: Optional[str] = None
     worker_url: Optional[str] = None
+    endpoint_url: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -339,6 +340,7 @@ _AI_MODEL_KEY = "ai_model"
 _AI_API_KEY = "ai_api_key"  # STORED ENCRYPTED
 _AI_CF_ACCOUNT_KEY = "ai_cloudflare_account_id"
 _AI_WORKER_URL_KEY = "ai_worker_url"  # HTTPS-only, validated
+_AI_ENDPOINT_URL_KEY = "ai_endpoint_url"  # custom provider: HTTPS-only, validated
 
 
 def _ai_error_detail(exc: AIProviderError) -> str:
@@ -391,6 +393,14 @@ def _require_provider_extras(provider: str, cfg: dict) -> None:
                 "paste the printed Worker URL into AI settings"
             ),
         )
+    if provider == "custom" and not cfg.get("endpoint_url"):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Custom provider requires endpoint_url — paste the OpenAI-"
+                "compatible base URL in AI settings"
+            ),
+        )
 
 
 def _read_ai_config(db: Session) -> dict:
@@ -408,6 +418,7 @@ def _read_ai_config(db: Session) -> dict:
         "api_key": api_key,
         "cloudflare_account_id": settings.get(_AI_CF_ACCOUNT_KEY, "") or "",
         "worker_url": settings.get(_AI_WORKER_URL_KEY, "") or "",
+        "endpoint_url": settings.get(_AI_ENDPOINT_URL_KEY, "") or "",
     }
 
 
@@ -425,6 +436,7 @@ def get_ai_config(db: Session = Depends(get_db)):
         "model": settings.get(_AI_MODEL_KEY, "") or "",
         "cloudflare_account_id": settings.get(_AI_CF_ACCOUNT_KEY, "") or "",
         "worker_url": settings.get(_AI_WORKER_URL_KEY, "") or "",
+        "endpoint_url": settings.get(_AI_ENDPOINT_URL_KEY, "") or "",
         "has_api_key": bool(raw_key),
         "api_key_encrypted": is_encrypted(raw_key),
         "providers": ai_provider_list(),
@@ -453,6 +465,7 @@ def put_ai_config(
     model = (payload.model or "").strip()
     account_id = (payload.cloudflare_account_id or "").strip()
     worker_url_raw = (payload.worker_url or "").strip()
+    endpoint_url_raw = (payload.endpoint_url or "").strip()
 
     # SSRF guard #1: CF account_id must be exactly 32 hex chars.
     if account_id and not CLOUDFLARE_ACCOUNT_ID_RE.match(account_id):
@@ -472,6 +485,17 @@ def put_ai_config(
     else:
         worker_url = ""
 
+    # SSRF + MITM guard #3 (custom provider): same validation as worker_url.
+    # A generic OpenAI-compatible endpoint is just as dangerous to point at
+    # an internal address, so it gets the identical treatment.
+    if endpoint_url_raw:
+        try:
+            endpoint_url = validate_worker_url(endpoint_url_raw)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+    else:
+        endpoint_url = ""
+
     new_api_key = payload.api_key
     # Distinguish "absent" from "empty string" — treat both as "don't change".
     should_update_key = isinstance(new_api_key, str) and new_api_key.strip() != ""
@@ -480,6 +504,7 @@ def put_ai_config(
     set_setting(db, _AI_MODEL_KEY, model)
     set_setting(db, _AI_CF_ACCOUNT_KEY, account_id)
     set_setting(db, _AI_WORKER_URL_KEY, worker_url)
+    set_setting(db, _AI_ENDPOINT_URL_KEY, endpoint_url)
     if should_update_key:
         encrypted = encrypt_value(new_api_key.strip())
         set_setting(db, _AI_API_KEY, encrypted)
@@ -526,6 +551,7 @@ def test_ai_config(request: Request, db: Session = Depends(get_db)):
             user='Reply with the word "ok" and nothing else.',
             account_id=cfg.get("cloudflare_account_id") or None,
             worker_url=cfg.get("worker_url") or None,
+            endpoint_url=cfg.get("endpoint_url") or None,
         )
     except AIProviderError as e:
         # AIProviderError messages already have the key redacted; use the
@@ -598,6 +624,7 @@ def ai_insights(
             company_name=company_name,
             account_id=cfg.get("cloudflare_account_id") or None,
             worker_url=cfg.get("worker_url") or None,
+            endpoint_url=cfg.get("endpoint_url") or None,
         )
     except AIProviderError as e:
         raise HTTPException(status_code=502, detail=_ai_error_detail(e))
@@ -678,6 +705,7 @@ def run_ai_action(
             api_key=api_key,
             account_id=cfg.get("cloudflare_account_id") or None,
             worker_url=cfg.get("worker_url") or None,
+            endpoint_url=cfg.get("endpoint_url") or None,
         )
     except AIProviderError as exc:
         raise HTTPException(status_code=502, detail=_ai_error_detail(exc))
@@ -737,6 +765,7 @@ def ai_query(
             tool_executor=tool_exec,
             account_id=cfg.get("cloudflare_account_id") or None,
             worker_url=cfg.get("worker_url") or None,
+            endpoint_url=cfg.get("endpoint_url") or None,
             max_calls=8,
         )
     except AIProviderError as e:

--- a/app/services/ai_actions.py
+++ b/app/services/ai_actions.py
@@ -330,6 +330,7 @@ def run_action(
     api_key: str,
     account_id: Optional[str] = None,
     worker_url: Optional[str] = None,
+    endpoint_url: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Execute one action: fetch data, prompt the LLM, return narrative."""
     spec = ACTIONS.get(action_key)
@@ -346,6 +347,7 @@ def run_action(
         user_prompt,
         account_id=account_id or None,
         worker_url=worker_url or None,
+        endpoint_url=endpoint_url or None,
     )
 
     return {

--- a/app/services/ai_service.py
+++ b/app/services/ai_service.py
@@ -721,7 +721,14 @@ def parse_response(provider_key: str, body: Dict[str, Any]) -> str:
     Returns an empty string on parse failure — the caller decides
     whether to treat that as an error.
     """
-    if provider_key in ("grok", "groq", "openai", "cloudflare", "cloudflare_worker", "custom"):
+    if provider_key in (
+        "grok",
+        "groq",
+        "openai",
+        "cloudflare",
+        "cloudflare_worker",
+        "custom",
+    ):
         try:
             return body["choices"][0]["message"]["content"] or ""
         except (KeyError, IndexError, TypeError):
@@ -795,7 +802,13 @@ def call_provider(
     `client` is injectable for tests that want to stub out the transport.
     """
     req = build_request(
-        provider_key, api_key, model, system, user, account_id, worker_url,
+        provider_key,
+        api_key,
+        model,
+        system,
+        user,
+        account_id,
+        worker_url,
         endpoint_url,
     )
     # Re-validate outbound URL against the per-provider allowlist before

--- a/app/services/ai_service.py
+++ b/app/services/ai_service.py
@@ -17,6 +17,8 @@
 #   * openai      — OpenAI /v1/chat/completions
 #   * gemini      — Google generativelanguage.googleapis.com generateContent
 #                   (Flash models free)
+#   * custom       — any OpenAI-compatible /v1/chat/completions endpoint
+#                   (user-supplied base URL, HTTPS-only, SSRF-guarded)
 #
 # Every network call goes through httpx with a 60-second timeout. API keys
 # are passed in from the caller — this module has no database access and
@@ -220,6 +222,7 @@ class ProviderSpec:
     model_choices: tuple = ()
     needs_account_id: bool = False  # Cloudflare direct REST
     needs_worker_url: bool = False  # Self-hosted CF Worker gateway
+    needs_endpoint_url: bool = False  # generic OpenAI-compatible endpoint (custom)
 
 
 PROVIDERS: Dict[str, ProviderSpec] = {
@@ -324,6 +327,21 @@ PROVIDERS: Dict[str, ProviderSpec] = {
             "gemini-2.0-flash-lite",
         ),
     ),
+    "custom": ProviderSpec(
+        key="custom",
+        label="Custom (OpenAI-compatible)",
+        default_model="",  # user supplies the model ID
+        wire_format="openai",
+        docs_url="",
+        free_tier_hint=(
+            "Point Slowbooks at any OpenAI-compatible chat endpoint. "
+            "Paste the base URL (e.g. https://api.example.com/v1) — "
+            "/chat/completions is appended automatically. HTTPS only, "
+            "private/LAN addresses blocked (SSRF guard)."
+        ),
+        needs_endpoint_url=True,
+        model_choices=(),
+    ),
 }
 
 
@@ -339,6 +357,7 @@ def provider_list() -> list:
             "free_tier_hint": p.free_tier_hint,
             "needs_account_id": p.needs_account_id,
             "needs_worker_url": p.needs_worker_url,
+            "needs_endpoint_url": p.needs_endpoint_url,
         }
         for p in PROVIDERS.values()
     ]
@@ -540,7 +559,7 @@ def _check_outbound_url(provider_key: str, url: str) -> str:
     if not isinstance(url, str) or not url:
         raise AIProviderError(f"{provider_key}: empty outbound URL")
 
-    if provider_key == "cloudflare_worker":
+    if provider_key in ("cloudflare_worker", "custom"):
         # Return the value validate_worker_url() produces (it returns the
         # normalized URL on success, raises on failure). Using the return
         # value rather than the input also gives static analyzers a clear
@@ -565,6 +584,7 @@ def build_request(
     user: str,
     account_id: Optional[str] = None,
     worker_url: Optional[str] = None,
+    endpoint_url: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build an httpx-ready request dict for the given provider.
 
@@ -629,6 +649,22 @@ def build_request(
         safe_url = validate_worker_url(worker_url)
         return _openai_style_request(safe_url, api_key, model, system, user)
 
+    if provider_key == "custom":
+        # Generic OpenAI-compatible endpoint. The base URL is user-supplied
+        # and validated aggressively (https only, no private/loopback IPs,
+        # no embedded credentials — see validate_worker_url). We append
+        # /chat/completions to the normalized base so the user can paste
+        # either the bare origin or a /v1-style base.
+        if not endpoint_url:
+            raise ValueError(
+                "Custom provider requires endpoint_url — paste the OpenAI-"
+                "compatible base URL in AI settings"
+            )
+        safe_url = validate_worker_url(endpoint_url)
+        if not safe_url.rstrip("/").endswith("/chat/completions"):
+            safe_url = safe_url.rstrip("/") + "/chat/completions"
+        return _openai_style_request(safe_url, api_key, model, system, user)
+
     if provider_key == "anthropic":
         return {
             "method": "POST",
@@ -685,7 +721,7 @@ def parse_response(provider_key: str, body: Dict[str, Any]) -> str:
     Returns an empty string on parse failure — the caller decides
     whether to treat that as an error.
     """
-    if provider_key in ("grok", "groq", "openai", "cloudflare"):
+    if provider_key in ("grok", "groq", "openai", "cloudflare", "cloudflare_worker", "custom"):
         try:
             return body["choices"][0]["message"]["content"] or ""
         except (KeyError, IndexError, TypeError):
@@ -750,6 +786,7 @@ def call_provider(
     user: str,
     account_id: Optional[str] = None,
     worker_url: Optional[str] = None,
+    endpoint_url: Optional[str] = None,
     timeout: float = DEFAULT_TIMEOUT,
     client: Optional[httpx.Client] = None,
 ) -> str:
@@ -758,7 +795,8 @@ def call_provider(
     `client` is injectable for tests that want to stub out the transport.
     """
     req = build_request(
-        provider_key, api_key, model, system, user, account_id, worker_url
+        provider_key, api_key, model, system, user, account_id, worker_url,
+        endpoint_url,
     )
     # Re-validate outbound URL against the per-provider allowlist before
     # any network IO. Defense-in-depth + CodeQL trust boundary at the sink.
@@ -806,6 +844,7 @@ def generate_insights(
     company_name: str = "",
     account_id: Optional[str] = None,
     worker_url: Optional[str] = None,
+    endpoint_url: Optional[str] = None,
     client: Optional[httpx.Client] = None,
 ) -> Dict[str, Any]:
     """End-to-end: build prompt, call provider, return structured result."""
@@ -818,6 +857,7 @@ def generate_insights(
         user=prompt,
         account_id=account_id,
         worker_url=worker_url,
+        endpoint_url=endpoint_url,
         client=client,
     )
     return {
@@ -844,6 +884,7 @@ def call_with_tools(
     tool_executor,
     account_id: Optional[str] = None,
     worker_url: Optional[str] = None,
+    endpoint_url: Optional[str] = None,
     max_calls: int = 8,
     client: Optional[httpx.Client] = None,
 ) -> Dict[str, Any]:
@@ -899,6 +940,7 @@ def call_with_tools(
                 user_question,
                 account_id,
                 worker_url,
+                endpoint_url,
             )
             req["json"]["messages"] = messages
             req["json"]["tools"] = [
@@ -923,6 +965,7 @@ def call_with_tools(
                 user_question,
                 account_id,
                 worker_url,
+                endpoint_url,
             )
             req["json"]["messages"] = messages
             req["json"]["tools"] = [
@@ -948,6 +991,7 @@ def call_with_tools(
                 user_question,
                 account_id,
                 worker_url,
+                endpoint_url,
             )
             req["json"]["tools"] = [
                 {

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -773,6 +773,7 @@ const SettingsPage = {
             providers.find(p => p.key === currentProvider) || providers[0] || {};
         const needsAccount = !!currentSpec.needs_account_id;
         const needsWorker = !!currentSpec.needs_worker_url;
+        const needsEndpoint = !!currentSpec.needs_endpoint_url;
         const hasKey = !!cfg.has_api_key;
         const currentModel = cfg.model || '';
 
@@ -830,6 +831,29 @@ const SettingsPage = {
                     and TLS certificates are always verified.
                 </p>
             </fieldset>
+            <fieldset id="ai-settings-endpoint-wrap" class="ai-worker-section"
+                      style="${needsEndpoint ? '' : 'display:none'}">
+                <legend>Custom OpenAI-Compatible Endpoint</legend>
+                <p class="ai-worker-help">
+                    Point Slowbooks at any OpenAI-compatible chat API (e.g.
+                    Command Code, a local gateway, or another provider's
+                    <code>/v1</code> base URL). <code>/chat/completions</code>
+                    is appended automatically if you don't include it.
+                </p>
+                <label class="form-field">
+                    <span>Base URL <em class="ai-worker-required">(https only)</em></span>
+                    <input type="url" id="ai-settings-endpoint-url"
+                           value="${escapeHtml(cfg.endpoint_url || '')}"
+                           placeholder="https://api.example.com/v1"
+                           autocomplete="off" spellcheck="false">
+                </label>
+                <p class="ai-worker-security">
+                    <strong>Security:</strong> only <code>https://</code> URLs
+                    are accepted; private/loopback IPs, embedded credentials,
+                    and non-HTTPS schemes are rejected. Redirects are disabled
+                    and TLS certificates are always verified.
+                </p>
+            </fieldset>
             <label class="form-field">
                 <span>API Key / Shared Secret ${hasKey ? '<em class="ai-key-saved">(saved &#10003;)</em>' : ''}</span>
                 <input type="password" id="ai-settings-key"
@@ -874,6 +898,7 @@ const SettingsPage = {
         const modelCustom = document.getElementById('ai-settings-model-custom');
         const cfWrap = document.getElementById('ai-settings-cf-wrap');
         const workerWrap = document.getElementById('ai-settings-worker-wrap');
+        const endpointWrap = document.getElementById('ai-settings-endpoint-wrap');
         const saveBtn = document.getElementById('ai-settings-save');
         const testBtn = document.getElementById('ai-settings-test');
         const testRes = document.getElementById('ai-settings-test-result');
@@ -903,6 +928,7 @@ const SettingsPage = {
             syncCustomVisibility();
             cfWrap.style.display = spec.needs_account_id ? '' : 'none';
             workerWrap.style.display = spec.needs_worker_url ? '' : 'none';
+            if (endpointWrap) endpointWrap.style.display = spec.needs_endpoint_url ? '' : 'none';
         });
 
         const resolveModel = () => {
@@ -915,6 +941,7 @@ const SettingsPage = {
             model: resolveModel(),
             cloudflare_account_id: document.getElementById('ai-settings-cf-account').value.trim(),
             worker_url: document.getElementById('ai-settings-worker-url').value.trim(),
+            endpoint_url: document.getElementById('ai-settings-endpoint-url') ? document.getElementById('ai-settings-endpoint-url').value.trim() : '',
             api_key: document.getElementById('ai-settings-key').value,
         });
 

--- a/tests/test_ai_integration.py
+++ b/tests/test_ai_integration.py
@@ -542,9 +542,7 @@ def test_build_request_custom_keeps_explicit_chat_completions():
 
 def test_build_request_custom_requires_endpoint():
     with pytest.raises(ValueError):
-        build_request(
-            "custom", "sk-fake", "model-x", "sys", "user", endpoint_url=None
-        )
+        build_request("custom", "sk-fake", "model-x", "sys", "user", endpoint_url=None)
 
 
 def test_parse_response_custom_openai_shape():

--- a/tests/test_ai_integration.py
+++ b/tests/test_ai_integration.py
@@ -13,7 +13,9 @@ import pytest
 from app.services.ai_service import (
     _extract_tool_calls,
     _parse_json_args,
+    build_request,
     call_with_tools,
+    parse_response,
     validate_worker_url,
     AIProviderError,
 )
@@ -503,3 +505,97 @@ def test_ai_config_never_returns_raw_api_key(client, db_session):
     # Scan the entire serialized response for our secret
     raw = json.dumps(body)
     assert "sk-very-secret-12345" not in raw
+
+
+# ---------------------------------------------------------------------------
+# custom (OpenAI-compatible) provider
+# ---------------------------------------------------------------------------
+
+
+def test_build_request_custom_appends_chat_completions():
+    """The custom provider normalizes a base URL to /chat/completions."""
+    req = build_request(
+        "custom",
+        "sk-fake",
+        "deepseek/deepseek-v4-flash",
+        "sys",
+        "user",
+        endpoint_url="https://api.commandcode.ai/provider/v1",
+    )
+    assert req["method"] == "POST"
+    assert req["url"] == "https://api.commandcode.ai/provider/v1/chat/completions"
+    assert req["headers"]["Authorization"] == "Bearer sk-fake"
+    assert req["json"]["model"] == "deepseek/deepseek-v4-flash"
+
+
+def test_build_request_custom_keeps_explicit_chat_completions():
+    req = build_request(
+        "custom",
+        "sk-fake",
+        "model-x",
+        "sys",
+        "user",
+        endpoint_url="https://api.example.com/v1/chat/completions",
+    )
+    assert req["url"] == "https://api.example.com/v1/chat/completions"
+
+
+def test_build_request_custom_requires_endpoint():
+    with pytest.raises(ValueError):
+        build_request(
+            "custom", "sk-fake", "model-x", "sys", "user", endpoint_url=None
+        )
+
+
+def test_parse_response_custom_openai_shape():
+    body = {"choices": [{"message": {"content": "Here is the analysis."}}]}
+    assert parse_response("custom", body) == "Here is the analysis."
+
+
+def test_call_with_tools_custom_roundtrip():
+    """The full tool loop works against a custom OpenAI-compatible endpoint."""
+    responses = [
+        _mock_response(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "tool_calls": [
+                                {
+                                    "id": "t1",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "list_customers",
+                                        "arguments": '{"limit": 2}',
+                                    },
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        ),
+        _mock_response(
+            {"choices": [{"message": {"content": "You have 2 customers."}}]},
+        ),
+    ]
+    client = _fake_client(responses)
+    tool_executor = MagicMock(return_value={"count": 2, "items": ["A", "B"]})
+
+    result = call_with_tools(
+        provider_key="custom",
+        api_key="sk-fake",
+        model="deepseek/deepseek-v4-flash",
+        user_question="How many customers do I have?",
+        tools=_FAKE_TOOLS,
+        tool_executor=tool_executor,
+        endpoint_url="https://api.commandcode.ai/provider/v1",
+        client=client,
+    )
+
+    assert result["success"] is True
+    assert result["call_count"] == 2
+    assert "2 customers" in result["final_response"]
+    # The client should have been hit with the /chat/completions URL.
+    req_url = client.request.call_args_list[0].args[1]
+    assert req_url == "https://api.commandcode.ai/provider/v1/chat/completions"

--- a/tests/test_ai_security.py
+++ b/tests/test_ai_security.py
@@ -75,3 +75,32 @@ def test_validate_worker_url_accepts_valid_workers_dev():
     )
     assert ok.startswith("https://")
     assert "workers.dev" in ok
+
+
+# -------- custom provider: same URL validation as cloudflare_worker --------
+# The `custom` provider reuses validate_worker_url() for its endpoint_url, so
+# every SSRF/scheme vector above applies equally. These tests pin that the
+# custom provider's endpoint (e.g. an OpenAI-compatible cloud API) is subject
+# to the identical allowlist — a public HTTPS endpoint passes, private/LAN
+# and non-HTTPS fail.
+
+
+def test_custom_endpoint_accepts_public_https():
+    ok = validate_worker_url("https://api.commandcode.ai/provider/v1")
+    assert ok == "https://api.commandcode.ai/provider/v1"
+    ok2 = validate_worker_url("https://api.example.com/v1")
+    assert ok2 == "https://api.example.com/v1"
+
+
+def test_custom_endpoint_rejects_lan_and_private():
+    for bad in (
+        "http://api.example.com/v1",           # plain http (MITM)
+        "https://192.168.1.50/v1",             # private
+        "https://10.0.0.8/v1",                 # private
+        "https://127.0.0.1:11434/v1",          # loopback (local ollama etc.)
+        "https://localhost/v1",                # localhost
+        "https://user:pass@api.example.com/v1",# embedded creds
+        "https://api.example.com/" + "x" * 4096, # oversize
+    ):
+        with pytest.raises(ValueError):
+            validate_worker_url(bad)

--- a/tests/test_ai_security.py
+++ b/tests/test_ai_security.py
@@ -94,13 +94,13 @@ def test_custom_endpoint_accepts_public_https():
 
 def test_custom_endpoint_rejects_lan_and_private():
     for bad in (
-        "http://api.example.com/v1",           # plain http (MITM)
-        "https://192.168.1.50/v1",             # private
-        "https://10.0.0.8/v1",                 # private
-        "https://127.0.0.1:11434/v1",          # loopback (local ollama etc.)
-        "https://localhost/v1",                # localhost
-        "https://user:pass@api.example.com/v1",# embedded creds
-        "https://api.example.com/" + "x" * 4096, # oversize
+        "http://api.example.com/v1",  # plain http (MITM)
+        "https://192.168.1.50/v1",  # private
+        "https://10.0.0.8/v1",  # private
+        "https://127.0.0.1:11434/v1",  # loopback (local ollama etc.)
+        "https://localhost/v1",  # localhost
+        "https://user:pass@api.example.com/v1",  # embedded creds
+        "https://api.example.com/" + "x" * 4096,  # oversize
     ):
         with pytest.raises(ValueError):
             validate_worker_url(bad)


### PR DESCRIPTION

## Summary

Adds an eighth "Custom (OpenAI-compatible)" provider to AI Insights, so users can point Slowbooks at any OpenAI-compatible /v1/chat/completions endpoint — e.g. Command Code, a self-hosted gateway, or any other vendor that speaks the OpenAI wire format. Today the provider list is hardcoded to 7 (Grok / Groq / Cloudflare / CF-Worker / Anthropic / OpenAI / Gemini) and none can be redirected at an arbitrary base URL.

## Changes

- New "Custom (OpenAI-compatible)" provider option in AI Insights settings
  - Selectable alongside the existing 7 providers in the AI Insights config UI
  - Shows a Base URL field when selected (mirrors the existing Cloudflare Worker Gateway URL field) plus the API key field
  - Base URL is normalized: /chat/completions is appended automatically if not already present, so users can paste https://api.example.com/v1 or the full URL
- New endpoint_url config value persisted in the existing settings table (key ai_endpoint_url), returned by GET /api/analytics/ai-config, accepted by PUT /api/analytics/ai-config, and enforced by _require_provider_extras so AI Insights / AI actions / AI query all validate the same way
- SSRF/MITM guard applied identically to the worker-gateway URL — HTTPS-only, private/loopback/link-local/multicast/reserved IPs blocked, no embedded credentials, DNS-rebinding re-check, redirects disabled, TLS verified. The API key is stored Fernet-encrypted at rest like every other provider key
- Latent bug fix in parse_response: cloudflare_worker was missing from the OpenAI-compatible response-parsing branch even though the CF worker returns OpenAI-shaped JSON — responses were always parsed to empty and surfaced as empty response (body shape unexpected). It is now parsed correctly (and the new custom provider shares the same branch)
- Developer-visible: ProviderSpec gains a needs_endpoint_url flag; build_request / call_provider / generate_insights / call_with_tools / run_action all accept and thread endpoint_url

## Test plan

- pytest tests/ -q — 1707 passed (7 new tests added)
- black --check app/ tests/ — clean
- ruff check app/ tests/ — clean
- Live smoke test against a real OpenAI-compatible endpoint:
  - call_provider("custom", endpoint_url="https://api.commandcode.ai/provider/v1", model="deepseek/deepseek-v4-flash") returned a valid completion
  - Full UI-backed flow verified on a running instance: saved the custom provider config via PUT /api/analytics/ai-config, then POST /api/analytics/ai-config/test returned provider_label: Custom (OpenAI-compatible) with a live LLM reply of "ok"
- New tests cover: endpoint URL validation (public HTTPS passes; LAN/private/plain-HTTP/embedded-creds/oversize rejected), request building (/chat/completions appended, explicit path preserved, missing endpoint rejected), OpenAI-shape response parsing, and a full tool-calling roundtrip against the custom provider
- Manually verified in the running app (new provider is visible in Settings → AI Insights)

## Screenshots / output

<img width="1110" height="526" alt="image" src="https://github.com/user-attachments/assets/2a4e4598-6376-4d65-bc2c-267211618588" />


## Security implications

The new provider accepts a user-supplied HTTPS URL, so it reuses the exact SSRF guard already applied to the Cloudflare Worker gateway URL (validate_worker_url). Threat model is unchanged: HTTPS-only, private/loopback/link-local/multicast/reserved IPs rejected, no embedded credentials, DNS-rebinding re-check at validation time, redirects disabled, TLS verified. The endpoint URL is stored in the same key/value settings table and the API key remains Fernet-encrypted at rest. No change to auth, encryption, portal flow, file uploads, subprocess calls, or startup checks.

## Database changes

None — no schema or migration. Reuses the existing key/value settings table with a new well-known key (ai_endpoint_url), consistent with ai_worker_url and ai_cloudflare_account_id.

## Documentation

None in this PR. The in-app hint text for the new provider explains the base-URL behavior and security posture. A follow-up could extend docs/features.md's AI-provider table if desired.

## Related issues

None.

---

