### PR TITLE
v2.9.1: post-release tidy from the 2.9.0 gate

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -196,6 +196,19 @@ jobs:
           timestamp-rfc3161: http://timestamp.acs.microsoft.com/
           timestamp-digest: SHA256
 
+      - name: Publish checksums (SHA256SUMS.windows)
+        shell: pwsh
+        run: |
+          # macOS ships SHA256SUMS.macos; Windows shipped only Authenticode
+          # (the stronger control, but no published digest to compare a
+          # download against — 2.9.0 gate, skytech). Same format as the
+          # macOS file so one `sha256sum -c` idiom covers both.
+          $lines = foreach ($f in 'SlowBooksPro-Setup-x64.exe', 'SlowBooksPro-windows-x64.zip') {
+            "{0}  {1}" -f (Get-FileHash $f -Algorithm SHA256).Hash.ToLower(), $f
+          }
+          [IO.File]::WriteAllText("$PWD\SHA256SUMS.windows", ($lines -join "`n") + "`n")
+          Get-Content SHA256SUMS.windows
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -203,6 +216,7 @@ jobs:
           path: |
             SlowBooksPro-windows-x64.zip
             SlowBooksPro-Setup-x64.exe
+            SHA256SUMS.windows
 
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/v')
@@ -211,3 +225,4 @@ jobs:
           files: |
             SlowBooksPro-windows-x64.zip
             SlowBooksPro-Setup-x64.exe
+            SHA256SUMS.windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
+### v2.9.1 — Post-release tidy from the 2.9.0 gate
+
+**A stored AI provider key can be removed.** `PUT /api/analytics/ai-config`
+with `"api_key": ""` clears it (omit the field to keep it; a value replaces
+it), the spec says so, and the Settings page has a Remove button beside the
+saved-key mark — it no longer round-trips a blank field. **Windows releases
+publish `SHA256SUMS.windows`** beside the installer and zip, the same
+format as the macOS file, so a download can be checked without trusting
+the transport. **The migrations now create every table** (`api_tokens` was
+the last one only app startup made), so `alembic upgrade head` alone yields
+the complete schema. Two nonprofit vocabulary leaks closed: the
+Contributions by Donor card described "sales totals", and the analytics
+receivables aging header said "Customer". The macOS maintainer runbook
+describes the staple-before-DMG order that has shipped since 2.9.0, and the
+install guide's table and account counts are current.
+
 ### v2.9.0 — Nonprofit mode
 
 **A nonprofit sees its own words in the first minute.** Settings → Company

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -132,8 +132,8 @@ Open **http://localhost:3001** in your browser.
 ### What happens on first run
 
 1. PostgreSQL 17 starts and creates the `bookkeeper` database
-2. Alembic runs all migrations (creates 55 tables)
-3. Chart of Accounts is seeded (50 accounts — Contractor template, includes the payroll-liability accounts needed for pay-run processing)
+2. Alembic runs all migrations (the complete schema — no table depends on app startup)
+3. Chart of Accounts is seeded (57 accounts — Contractor template, includes the payroll-liability accounts and 6810 Depreciation Expense) and a default Equipment asset type
 4. Uvicorn starts serving the app on port 3001
 5. On first visit, you'll be prompted to set an operator password (min 8 characters)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -50,6 +50,26 @@ other desktop app. If something goes wrong before the app window can open, a
 small popup explains it, and full details are written to
 `%LOCALAPPDATA%\SlowBooksPro\data\launcher.log`.
 
+### Windows Defender "Controlled folder access"
+
+Off by default on Windows 11, but some people (and most managed PCs) turn it
+on. When it is on, Defender blocks any app it does not know from writing
+into Documents, Downloads and the other protected folders — including a
+OneDrive-redirected Documents — and a code signature earns no exception.
+SlowBooks writes there in two places: **Save PDF / Save CSV** on reports go
+to `Documents\SlowBooks Pro\Reports`, and **Save backup** copies the backup
+to `Downloads`. If the write is refused, the app does not fail silently: the
+PDF or CSV lands in `%LOCALAPPDATA%\SlowBooksPro\data\Reports` instead and
+the notice says so (with a *Show in folder* button), and the backup notice
+tells you it is still in the app's own `backups` folder. Defender's own toast
+may or may not appear.
+
+To let SlowBooks use your Documents and Downloads folders directly:
+**Windows Security → Virus & threat protection → Ransomware protection →
+Manage Controlled folder access → Allow an app through Controlled folder
+access → Add an allowed app → Recently blocked apps**, and pick
+`SlowBooksPro.exe` (or browse to `C:\Program Files\SlowBooks Pro 2026\`).
+
 ### Backups
 
 Backups created from the Settings UI are simply snapshots of the open

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Production checklist: **[docs/release-checklist.md](docs/release-checklist.md)**
 | [packaging/macos/README.md](packaging/macos/README.md) | macOS maintainer build, signing, notarization runbook |
 | [docs/features.md](docs/features.md) | Full feature catalog + API endpoint reference |
 | [docs/development.md](docs/development.md) | Tech stack, project structure, contributor flow |
-| [docs/data-model.md](docs/data-model.md) | Database schema — 55 tables |
+| [docs/data-model.md](docs/data-model.md) | Database schema |
 | [docs/operations.md](docs/operations.md) | Backups, restore, key rotation, monitoring |
 | [docs/payroll-hr-module.md](docs/payroll-hr-module.md) | Payroll / HR module reference |
 | [docs/release-checklist.md](docs/release-checklist.md) | Production deployment checklist |

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 # Single source of truth for the application version: app/main.py reports
 # it on the FastAPI app and /health, /api/system serves it to the frontend
 # footer, and the Windows release workflow parses it for the installer.
-__version__ = "2.9.0"
+__version__ = "2.9.1"

--- a/app/routes/analytics.py
+++ b/app/routes/analytics.py
@@ -20,6 +20,8 @@ from typing import Optional, Tuple
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import Response
+from pydantic import Field
+
 from app.schemas.common import StrictModel
 from sqlalchemy.orm import Session
 
@@ -55,7 +57,13 @@ router = APIRouter(prefix="/api/analytics", tags=["analytics"])
 class AIConfigUpdate(StrictModel):
     provider: Optional[str] = None
     model: Optional[str] = None
-    api_key: Optional[str] = None
+    api_key: Optional[str] = Field(
+        None,
+        description=(
+            "Omit to keep the stored key. A non-empty value replaces it "
+            "(stored encrypted, never returned). An empty string removes it."
+        ),
+    )
     cloudflare_account_id: Optional[str] = None
     worker_url: Optional[str] = None
     endpoint_url: Optional[str] = None
@@ -497,8 +505,13 @@ def put_ai_config(
         endpoint_url = ""
 
     new_api_key = payload.api_key
-    # Distinguish "absent" from "empty string" — treat both as "don't change".
+    # Absent (None) means "don't change". An explicit empty string means
+    # "remove the stored key": a credential that cannot be cleared through
+    # the API is a poor property for a credential (2.9.0 gate, skytech).
+    # The Settings page only sends api_key when the field was typed into,
+    # or when the user clicked Remove — never a blank round-trip.
     should_update_key = isinstance(new_api_key, str) and new_api_key.strip() != ""
+    should_clear_key = isinstance(new_api_key, str) and new_api_key.strip() == ""
 
     set_setting(db, _AI_PROVIDER_KEY, provider)
     set_setting(db, _AI_MODEL_KEY, model)
@@ -508,6 +521,8 @@ def put_ai_config(
     if should_update_key:
         encrypted = encrypt_value(new_api_key.strip())
         set_setting(db, _AI_API_KEY, encrypted)
+    elif should_clear_key:
+        set_setting(db, _AI_API_KEY, "")
 
     db.commit()
     _clear_ai_cache()

--- a/app/routes/invoices/documents.py
+++ b/app/routes/invoices/documents.py
@@ -85,7 +85,11 @@ def email_invoice(
     if not inv:
         raise HTTPException(status_code=404, detail="Invoice not found")
     company = get_settings(db)
-    subject = data.subject or f"Invoice #{inv.invoice_number}"
+    from app.services.email_service import invoice_email_label
+
+    subject = (
+        data.subject or f"{invoice_email_label(inv, company)} #{inv.invoice_number}"
+    )
     try:
         from app.services.email_service import send_email, render_invoice_email
         from app.models.email_log import EmailLog

--- a/app/routes/reports/financial.py
+++ b/app/routes/reports/financial.py
@@ -93,6 +93,7 @@ def profit_loss(
 def balance_sheet(
     as_of_date: date = Query(default=None), db: Session = Depends(get_db)
 ):
+    t = terms_from_db(db)
     if not as_of_date:
         as_of_date = date.today()
 
@@ -122,7 +123,7 @@ def balance_sheet(
         equity = list(equity) + [
             {
                 "account_id": None,
-                "account_name": "Net Income (current period)",
+                "account_name": f"{t('Net Income')} (current period)",
                 "account_number": None,
                 "amount": float(net_income),
             }

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -153,11 +153,34 @@ def render_template_from_db(db: Session, template_name: str, context: dict) -> t
     return None, None
 
 
+def invoice_email_label(invoice, company_settings: dict) -> str:
+    """What the attached document is called in the email: Invoice, Pledge,
+    Sales Receipt or Donation Receipt — the same literal face the PDF
+    prints (donor_documents.invoice_doc_kind), never the vocabulary swap."""
+    from app.services.donor_documents import invoice_doc_kind
+    from app.services.terminology import terms_for
+
+    kind = invoice_doc_kind(invoice, terms_for(company_settings))
+    return {
+        "SalesReceipt": "Sales Receipt",
+        "DonationReceipt": "Donation Receipt",
+    }.get(kind, kind)
+
+
 def render_invoice_email(invoice, company_settings: dict, pay_url: str = None) -> str:
     """Render the invoice email HTML body."""
+    from app.services.terminology import terms_for
+
+    doc_label = invoice_email_label(invoice, company_settings)
     try:
         template = _jinja_env.get_template("invoice_email.html")
-        return template.render(inv=invoice, company=company_settings, pay_url=pay_url)
+        return template.render(
+            inv=invoice,
+            company=company_settings,
+            pay_url=pay_url,
+            doc_label=doc_label,
+            terms=terms_for(company_settings),
+        )
     except Exception:
         # Fallback simple email. Customer name + company name are escaped
         # via html.escape() since they can contain user-controlled text
@@ -167,14 +190,16 @@ def render_invoice_email(invoice, company_settings: dict, pay_url: str = None) -
         import html as _html
 
         customer_name = _html.escape(
-            invoice.customer.name if invoice.customer else "Customer"
+            invoice.customer.name
+            if invoice.customer
+            else terms_for(company_settings)("Customer")
         )
         company_name = _html.escape(company_settings.get("company_name", "Our Company"))
         invoice_number = _html.escape(str(invoice.invoice_number))
         return f"""<html><body>
         <p>Dear {customer_name},</p>
-        <p>Please find attached Invoice #{invoice_number} for ${float(invoice.total):,.2f}.</p>
+        <p>Please find attached {doc_label} #{invoice_number} for ${float(invoice.total):,.2f}.</p>
         <p>Payment is due by {invoice.due_date}.</p>
-        <p>Thank you for your business.</p>
+        <p>{'Thank you for your support.' if terms_for(company_settings).is_nonprofit else 'Thank you for your business.'}</p>
         <p>{company_name}</p>
         </body></html>"""

--- a/app/services/pdf_service.py
+++ b/app/services/pdf_service.py
@@ -167,11 +167,14 @@ def generate_analytics_pdf(
     dashboard: dict, period: dict, company_settings: dict
 ) -> bytes:
     """Render the analytics dashboard snapshot as a printable PDF."""
+    from app.services.terminology import terms_for
+
     template = _jinja_env.get_template("analytics_pdf.html")
     html_str = template.render(
         dashboard=dashboard,
         period=period,
         company=company_settings,
+        terms=terms_for(company_settings),
         company_logo_data_uri=_company_logo_data_uri(company_settings),
     )
     return render_pdf(html_str)
@@ -249,11 +252,14 @@ def generate_collection_letter_pdf(
 ) -> bytes:
     from datetime import date as _date
 
+    from app.services.terminology import terms_for
+
     template = _jinja_env.get_template("collection_letter.html")
     html_str = template.render(
         customer=customer,
         invoices=invoices,
         company=company_settings,
+        terms=terms_for(company_settings),
         letter_type=letter_type,
         total_due=total_due,
         today=_date.today(),

--- a/app/services/terminology.py
+++ b/app/services/terminology.py
@@ -68,6 +68,8 @@ NONPROFIT: dict[str, str] = {
     "A/R Aging": "Pledge Aging",
     "Accounts Receivable Aging": "Pledges Receivable Aging",
     "Monthly Revenue": "Monthly Revenue & Support",
+    "Receivables": "Pledges Receivable",
+    "Revenue by Customer": "Revenue & Support by Donor",
 }
 
 # Words that must never be mapped, whole or as a phrase start.

--- a/app/static/js/analytics.js
+++ b/app/static/js/analytics.js
@@ -117,7 +117,7 @@ const AnalyticsPage = {
             <div class="analytics-kpi-grid">
                 <div class="analytics-kpi"><div class="analytics-kpi-label">Revenue</div><div class="analytics-kpi-value kpi-green">${formatCurrency(totalRevenue)}</div></div>
                 <div class="analytics-kpi"><div class="analytics-kpi-label">Expenses</div><div class="analytics-kpi-value kpi-red">${formatCurrency(totalExpenses)}</div></div>
-                <div class="analytics-kpi" title="Days Sales Outstanding — average number of days between invoicing a customer and collecting the payment. Lower is better. Computed as (open A/R balance ÷ last-30-day paid revenue) × 30."><div class="analytics-kpi-label">DSO (Days)</div><div class="analytics-kpi-value kpi-blue">${dso.toFixed(1)}</div></div>
+                <div class="analytics-kpi" title="${Terms.text('Days Sales Outstanding — average number of days between invoicing a customer and collecting the payment.')} Lower is better. Computed as (open A/R balance ÷ last-30-day paid revenue) × 30."><div class="analytics-kpi-label">DSO (Days)</div><div class="analytics-kpi-value kpi-blue">${dso.toFixed(1)}</div></div>
                 <div class="analytics-kpi"><div class="analytics-kpi-label">Margin %</div><div class="analytics-kpi-value kpi-purple">${margin.toFixed(1)}%</div></div>
             </div>
 
@@ -126,7 +126,7 @@ const AnalyticsPage = {
 
             <div class="analytics-two-col">
                 <div class="analytics-card">
-                    <div class="analytics-section-title">Revenue by Customer</div>
+                    <div class="analytics-section-title">${Terms.text('Revenue by Customer')}</div>
                     ${this._revenueTable(data.revenue_by_customer)}
                 </div>
                 <div class="analytics-card">
@@ -136,7 +136,7 @@ const AnalyticsPage = {
                 </div>
             </div>
 
-            <div class="analytics-section-title">Accounts Receivable Aging</div>
+            <div class="analytics-section-title">${T('Accounts Receivable Aging')}</div>
             <div class="analytics-card">
                 <div class="chart-wrap chart-wrap-sm"><canvas id="chart-ar-aging"></canvas></div>
                 ${this._agingTable(data.ar_aging, T("Customer"))}
@@ -356,7 +356,7 @@ const AnalyticsPage = {
       this._renderAgingChart(
         "chart-ar-aging",
         this.state.data.ar_aging,
-        "A/R",
+        T("A/R Aging").replace(/ Aging$/, ""),
         "#00c48f",
       );
       this._renderAgingChart(

--- a/app/static/js/analytics.js
+++ b/app/static/js/analytics.js
@@ -139,7 +139,7 @@ const AnalyticsPage = {
             <div class="analytics-section-title">Accounts Receivable Aging</div>
             <div class="analytics-card">
                 <div class="chart-wrap chart-wrap-sm"><canvas id="chart-ar-aging"></canvas></div>
-                ${this._agingTable(data.ar_aging, "Customer")}
+                ${this._agingTable(data.ar_aging, T("Customer"))}
             </div>
 
             <div class="analytics-section-title">Accounts Payable Aging</div>

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -240,10 +240,10 @@ const App = {
                 const results = await API.get(`/search?q=${encodeURIComponent(query)}`);
                 let html = '';
                 const sections = [
-                    { key: 'customers', label: 'Customers', onClick: (item) => `App.navigate('#/customers');closeSearchDropdown();` },
+                    { key: 'customers', label: T('Customers'), onClick: (item) => `App.navigate('#/customers');closeSearchDropdown();` },
                     { key: 'vendors', label: 'Vendors', onClick: (item) => `App.navigate('#/vendors');closeSearchDropdown();` },
                     { key: 'items', label: 'Items', onClick: (item) => `App.navigate('#/items');closeSearchDropdown();` },
-                    { key: 'invoices', label: 'Invoices', onClick: (item) => `InvoicesPage.view(${item.id});closeSearchDropdown();` },
+                    { key: 'invoices', label: T('Invoices'), onClick: (item) => `InvoicesPage.view(${item.id});closeSearchDropdown();` },
                     { key: 'estimates', label: 'Estimates', onClick: (item) => `App.navigate('#/estimates');closeSearchDropdown();` },
                     { key: 'payments', label: 'Payments', onClick: (item) => `App.navigate('#/payments');closeSearchDropdown();` },
                 ];
@@ -460,7 +460,7 @@ const App = {
                 `<div style="padding:4px 0; font-size:11px; border-bottom:1px solid var(--gray-200);">
                     <strong>#${escapeHtml(inv.invoice_number)}</strong> created — ${escapeHtml(inv.customer_name || '')} — ${formatCurrency(inv.total)}
                 </div>`);
-            toast(`Invoice #${inv.invoice_number} created`);
+            toast(`${T('Invoice')} #${inv.invoice_number} created`);
             // Reset form for next entry
             form.po_number.value = '';
             $('#qe-lines').innerHTML = `

--- a/app/static/js/customers.js
+++ b/app/static/js/customers.js
@@ -237,7 +237,7 @@ const CustomersPage = {
             terms: 'Net 30', credit_limit: '', tax_id: '', is_taxable: true, notes: '' };
         if (id) c = await API.get(`/customers/${id}`);
 
-        const title = id ? 'Edit Customer' : 'New Customer';
+        const title = id ? `Edit ${T('Customer')}` : T('New Customer');
         openModal(title, `
             <form id="customer-form" onsubmit="CustomersPage.save(event, ${id})">
                 <div class="form-grid">
@@ -311,7 +311,7 @@ const CustomersPage = {
                 </div>
                 <div class="form-actions">
                     <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
-                    <button type="submit" class="btn btn-primary">${id ? 'Update' : 'Create'} Customer</button>
+                    <button type="submit" class="btn btn-primary">${id ? 'Update' : 'Create'} ${T('Customer')}</button>
                 </div>
             </form>`);
     },
@@ -328,10 +328,10 @@ const CustomersPage = {
         try {
             if (id) {
                 await API.put(`/customers/${id}`, data);
-                toast('Customer updated');
+                toast(`${T('Customer')} updated`);
             } else {
                 await API.post('/customers', data, force ? { query: { force: true } } : undefined);
-                toast('Customer created');
+                toast(`${T('Customer')} created`);
             }
             closeModal();
             App.navigate(location.hash);

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -219,13 +219,13 @@ const DashboardPage = {
             const row = (m) => `<tr><td>${escapeHtml(m.label)}</td><td class="amount">${formatCurrency(m.income)}</td><td class="amount">${formatCurrency(m.expenses)}</td><td class="amount" style="font-weight:700;color:${m.net < 0 ? '#a4242b' : '#1f7a36'}">${formatCurrency(m.net)}</td></tr>`;
             return `<table class="data-table" style="font-size:12px"><thead><tr><th scope="col"></th><th scope="col" class="amount">${T('Income')}</th><th scope="col" class="amount">Expenses</th><th scope="col" class="amount">Net</th></tr></thead>
                 <tbody>${row(d.this_month)}${row(d.last_month)}</tbody></table>
-                <div style="font-size:11px;margin-top:4px;color:${d.net_change < 0 ? '#a4242b' : '#1f7a36'}">${d.net_change >= 0 ? '▲' : '▼'} ${formatCurrency(Math.abs(d.net_change))} vs last month · <a href="#/reports">Full P&L</a></div>`;
+                <div style="font-size:11px;margin-top:4px;color:${d.net_change < 0 ? '#a4242b' : '#1f7a36'}">${d.net_change >= 0 ? '▲' : '▼'} ${formatCurrency(Math.abs(d.net_change))} vs last month · <a href="#/reports">Full ${T('P&L')}</a></div>`;
         },
         cash_position(d) {
             return `<div class="card-value">${formatCurrency(d.cash)}</div>
                 <div style="font-size:11px;color:var(--gray-500)">in the bank today</div>
                 <table class="data-table" style="font-size:12px;margin-top:8px"><tbody>
-                    <tr><td>+ Receivables due within 30 days</td><td class="amount">${formatCurrency(d.ar_due_30)}</td></tr>
+                    <tr><td>+ ${T('Receivables')} due within 30 days</td><td class="amount">${formatCurrency(d.ar_due_30)}</td></tr>
                     <tr><td>− Payables due within 30 days</td><td class="amount">${formatCurrency(d.ap_due_30)}</td></tr>
                     <tr style="font-weight:700"><td>30-day forecast</td><td class="amount" style="color:${d.forecast_30 < 0 ? '#a4242b' : '#1f7a36'}">${formatCurrency(d.forecast_30)}</td></tr>
                 </tbody></table>
@@ -243,7 +243,7 @@ const DashboardPage = {
                 <div style="font-size:11px;margin-top:4px"><a href="#/expenses">Enter Expenses →</a></div>`;
         },
         job_budget_vs_actual(d) {
-            if (!d.count) return '<div style="color:var(--gray-500);font-size:12px">No jobs with a budget or activity yet. <a href="#/jobs">Jobs →</a></div>';
+            if (!d.count) return '<div style="color:var(--gray-500);font-size:12px">' + Terms.text('No jobs with a budget or activity yet.') + ' <a href="#/jobs">' + T('Jobs') + ' →</a></div>';
             const pct = v => v === null || v === undefined ? '—' : `${v.toFixed(0)}%`;
             return `<table class="data-table" style="font-size:12px"><thead><tr><th scope="col">${T('Job')}</th><th scope="col" class="amount">Budget</th><th scope="col" class="amount">Committed</th><th scope="col" class="amount">Actual</th><th scope="col" class="amount">Projected</th><th scope="col" class="amount">Variance</th><th scope="col" class="amount">% Used</th></tr></thead>
                 <tbody>${d.items.map(j => `<tr class="clickable" onclick="App.navigate('#/jobs/${j.job_id}')"><td>${escapeHtml(j.customer_name)}: ${escapeHtml(j.job_name)}</td><td class="amount">${formatCurrency(j.revised)}</td><td class="amount">${formatCurrency(j.committed)}</td><td class="amount">${formatCurrency(j.actual)}</td><td class="amount">${formatCurrency(j.projected)}</td><td class="amount" style="font-weight:700;color:${j.revised && j.variance < 0 ? '#a4242b' : '#1f7a36'}">${formatCurrency(j.variance)}</td><td class="amount">${pct(j.pct_used)}</td></tr>`).join('')}</tbody>

--- a/app/static/js/deposits.js
+++ b/app/static/js/deposits.js
@@ -30,7 +30,7 @@ const DepositsPage = {
                 <input type="date" id="deposit-date" value="${todayISO()}">
                 <label style="font-size:10px;font-weight:700;">Reference:</label>
                 <input type="text" id="deposit-ref" placeholder="Deposit slip #" style="width:120px;">
-                ${classOpts ? `<label style="font-size:10px;font-weight:700;">Class:</label>
+                ${classOpts ? `<label style="font-size:10px;font-weight:700;">${T('Class')}:</label>
                 <select id="deposit-class">${classOpts}</select>` : ''}
             </div>`;
 

--- a/app/static/js/estimates.js
+++ b/app/static/js/estimates.js
@@ -39,7 +39,7 @@ const EstimatesPage = {
 
         openModal(`Estimate #${est.estimate_number}`, `
             <div style="margin-bottom:12px;">
-                <strong>Customer:</strong> ${escapeHtml(est.customer_name || '')}<br>
+                <strong>${T('Customer')}:</strong> ${escapeHtml(est.customer_name || '')}<br>
                 <strong>Date:</strong> ${formatDate(est.date)}<br>
                 ${est.expiration_date ? `<strong>Expires:</strong> ${formatDate(est.expiration_date)}<br>` : ''}
                 <strong>Status:</strong> ${statusBadge(est.status)}
@@ -57,7 +57,7 @@ const EstimatesPage = {
             <div class="form-actions">
                 <button class="btn btn-secondary" onclick="window.open('/api/estimates/${est.id}/pdf','_blank')">Save PDF</button>
                 <button class="btn btn-secondary" onclick="window.open('/api/estimates/${est.id}/print-preview','_blank')">Print</button>
-                ${est.status !== 'converted' ? `<button class="btn btn-primary" onclick="EstimatesPage.convert(${est.id})">Convert to Invoice</button>` : ''}
+                ${est.status !== 'converted' ? `<button class="btn btn-primary" onclick="EstimatesPage.convert(${est.id})">Convert to ${T('Invoice')}</button>` : ''}
                 <button class="btn btn-secondary" onclick="closeModal()">Close</button>
             </div>`);
     },
@@ -66,7 +66,7 @@ const EstimatesPage = {
         if (!confirm('Convert this estimate to an invoice?')) return;
         try {
             const inv = await API.post(`/estimates/${id}/convert`);
-            toast(`Created Invoice #${inv.invoice_number}`);
+            toast(`Created ${T('Invoice')} #${inv.invoice_number}`);
             closeModal();
             App.navigate('#/invoices');
         } catch (err) { toast(err.message, 'error'); }
@@ -88,7 +88,7 @@ const EstimatesPage = {
 
     async saveNewCustomer() {
         const name = $('#est-new-cust-name').value.trim();
-        if (!name) { toast('Customer name is required', 'error'); return; }
+        if (!name) { toast(`${T('Customer')} name is required`, 'error'); return; }
         try {
             const cust = await API.post('/customers', {
                 name, email: $('#est-new-cust-email').value.trim() || null,
@@ -100,7 +100,7 @@ const EstimatesPage = {
             opt.value = cust.id; opt.textContent = cust.name; opt.selected = true;
             sel.appendChild(opt);
             $('#est-new-customer-form').style.display = 'none';
-            toast(`Customer "${cust.name}" created`);
+            toast(`${T('Customer')} "${cust.name}" created`);
         } catch (err) { toast(err.message, 'error'); }
     },
 

--- a/app/static/js/invoices.js
+++ b/app/static/js/invoices.js
@@ -4,6 +4,10 @@
  * auto-fill on item selection lives in itemSelected() below.
  */
 const InvoicesPage = {
+    // The document's literal face, as the PDF prints it: a flagged pledge is a
+    // PLEDGE, everything else an INVOICE regardless of company vocabulary.
+    docLabel(inv) { return inv.is_pledge ? 'Pledge' : 'Invoice'; }, // literal face
+
     async render() {
         // Sales receipts are invoices under the hood; they get their own
         // page, so keep them out of this list.
@@ -79,7 +83,7 @@ const InvoicesPage = {
 
         openModal(`${T('Invoice')} #${inv.invoice_number}`, `
             <div style="margin-bottom:12px;">
-                <strong>Customer:</strong> ${escapeHtml(inv.customer_name || '')}<br>
+                <strong>${T('Customer')}:</strong> ${escapeHtml(inv.customer_name || '')}<br>
                 <strong>Date:</strong> ${formatDate(inv.date)}<br>
                 <strong>Due:</strong> ${formatDate(inv.due_date)}<br>
                 <strong>Status:</strong> ${statusBadge(inv.status)}<br>
@@ -107,11 +111,11 @@ const InvoicesPage = {
                 <button class="btn btn-secondary" onclick="window.open('/api/invoices/${inv.id}/pdf','_blank')">Save PDF</button>
                 <button class="btn btn-secondary" onclick="window.open('/api/invoices/${inv.id}/print-preview','_blank')">Print</button>
                 <button class="btn btn-secondary" onclick="InvoicesPage.duplicate(${inv.id})">Duplicate</button>
-                <button class="btn btn-secondary" onclick="InvoicesPage.emailInvoice(${inv.id})">Email Invoice</button>
+                <button class="btn btn-secondary" onclick="InvoicesPage.emailInvoice(${inv.id})">Email ${T('Invoice')}</button>
                 <button class="btn btn-secondary" onclick="InvoicesPage.copyPaymentLink(${inv.id})">Copy Payment Link</button>
                 ${inv.checkout_provider && inv.status !== 'paid' && inv.status !== 'void' ? `<button class="btn btn-secondary" onclick="InvoicesPage.checkPaymentStatus(${inv.id}, '${inv.checkout_provider}')">Check Payment Status</button>` : ''}
                 ${inv.status === 'draft' ? `<button class="btn btn-primary" onclick="InvoicesPage.markSent(${inv.id})">Mark Sent</button>` : ''}
-                ${inv.status !== 'void' ? `<button class="btn btn-danger" onclick="InvoicesPage.void(${inv.id})">Void Invoice</button>` : ''}
+                ${inv.status !== 'void' ? `<button class="btn btn-danger" onclick="InvoicesPage.void(${inv.id})">Void ${T('Invoice')}</button>` : ''}
                 <button class="btn btn-secondary" onclick="closeModal()">Close</button>
             </div>`);
         InvoicesPage.loadAttachments('invoice', inv.id);
@@ -121,7 +125,7 @@ const InvoicesPage = {
         if (!confirm('Void this invoice? This cannot be undone.')) return;
         try {
             await API.post(`/invoices/${id}/void`);
-            toast('Invoice voided');
+            toast(`${T('Invoice')} voided`);
             closeModal();
             App.navigate(location.hash);
         } catch (err) { toast(err.message, 'error'); }
@@ -130,7 +134,7 @@ const InvoicesPage = {
     async markSent(id) {
         try {
             await API.post(`/invoices/${id}/send`);
-            toast('Invoice marked as sent');
+            toast(`${T('Invoice')} marked as sent`);
             closeModal();
             App.navigate(location.hash);
         } catch (err) { toast(err.message, 'error'); }
@@ -139,7 +143,7 @@ const InvoicesPage = {
     async duplicate(id) {
         try {
             const inv = await API.post(`/invoices/${id}/duplicate`);
-            toast(`Duplicated as Invoice #${inv.invoice_number}`);
+            toast(`Duplicated as ${T('Invoice')} #${inv.invoice_number}`);
             closeModal();
             App.navigate('#/invoices');
         } catch (err) { toast(err.message, 'error'); }
@@ -181,7 +185,7 @@ const InvoicesPage = {
                     <div class="form-group full-width"><label>Recipient Email *</label>
                         <input name="recipient" type="email" required value="${escapeHtml(email)}"></div>
                     <div class="form-group full-width"><label>Subject</label>
-                        <input name="subject" value="Invoice #${escapeHtml(inv.invoice_number)} from ${escapeHtml(inv.customer_name || 'us')}"></div>
+                        <input name="subject" value="${InvoicesPage.docLabel(inv)} #${escapeHtml(inv.invoice_number)} from ${escapeHtml(inv.customer_name || 'us')}"></div>
                     <div class="form-group full-width"><label>Message</label>
                         <textarea name="message">Please find attached Invoice #${escapeHtml(inv.invoice_number)}.</textarea></div>
                 </div>
@@ -201,7 +205,7 @@ const InvoicesPage = {
                 subject: form.subject.value,
                 message: form.message.value,
             });
-            toast('Invoice emailed');
+            toast(`${T('Invoice')} emailed`);
             closeModal();
         } catch (err) { toast(err.message, 'error'); }
     },
@@ -294,7 +298,7 @@ const InvoicesPage = {
                     <textarea name="notes">${escapeHtml(inv.notes || '')}</textarea></div>
                 <div class="form-actions">
                     <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
-                    <button type="submit" class="btn btn-primary">${id ? 'Update' : 'Create'} Invoice</button>
+                    <button type="submit" class="btn btn-primary">${id ? 'Update' : 'Create'} ${T('Invoice')}</button>
                 </div>
             </form>`);
         if (!id && inv.customer_id) InvoicesPage.customerSelected(inv.customer_id);
@@ -324,7 +328,7 @@ const InvoicesPage = {
 
     async saveNewCustomer() {
         const name = $('#inv-new-cust-name').value.trim();
-        if (!name) { toast('Customer name is required', 'error'); return; }
+        if (!name) { toast(`${T('Customer')} name is required`, 'error'); return; }
         try {
             const cust = await API.post('/customers', {
                 name, email: $('#inv-new-cust-email').value.trim() || null,
@@ -336,7 +340,7 @@ const InvoicesPage = {
             opt.value = cust.id; opt.textContent = cust.name; opt.selected = true;
             sel.appendChild(opt);
             $('#inv-new-customer-form').style.display = 'none';
-            toast(`Customer "${cust.name}" created`);
+            toast(`${T('Customer')} "${cust.name}" created`);
         } catch (err) { toast(err.message, 'error'); }
     },
 

--- a/app/static/js/items.js
+++ b/app/static/js/items.js
@@ -82,7 +82,7 @@ const ItemsPage = {
                         <input name="rate" type="number" step="0.01" value="${item.rate}"></div>
                     <div class="form-group"><label>Cost</label>
                         <input name="cost" type="number" step="0.01" value="${item.cost}"></div>
-                    <div class="form-group"><label>Income Account</label>
+                    <div class="form-group"><label>${T('Income')} Account</label>
                         <select name="income_account_id">
                             <option value="">-- None --</option>
                             ${incomeAccts.map(a => `<option value="${a.id}" ${item.income_account_id==a.id?'selected':''}>${a.account_number} - ${escapeHtml(a.name)}</option>`).join('')}

--- a/app/static/js/job_costs.js
+++ b/app/static/js/job_costs.js
@@ -85,7 +85,7 @@ const JobCostsPage = {
                 <div style="margin-top:8px;text-align:right;font-weight:700" id="jc-total">Total: $0.00</div>
                 <div class="form-actions">
                     <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
-                    <button type="submit" class="btn btn-primary">Post Job Cost</button>
+                    <button type="submit" class="btn btn-primary">Post ${T('Job')} Cost</button>
                 </div>
             </form>`);
         JobCostsPage._lineCount = 1;
@@ -189,7 +189,7 @@ const JobCostsPage = {
         const codeOpts = JobCostsPage._opt(JobCostsPage._codes, 'id', c => c.label, null);
         const typeOpts = JobCostsPage._opt(JobCostsPage._types, 'code', t => t.name, 'other', 'auto');
         const acctOpts = JobCostsPage._opt(JobCostsPage._accounts, 'id', a => `${a.account_number || ''} ${a.name}`.trim(), null, 'default');
-        openModal('Allocate a Cost Across Jobs', `
+        openModal(`Allocate a Cost Across ${T('Jobs')}`, `
             <form onsubmit="JobCostsPage.saveAllocate(event)">
                 <div class="form-grid">
                     <div class="form-group"><label>Date *</label><input name="date" type="date" required value="${todayISO()}"></div>
@@ -209,7 +209,7 @@ const JobCostsPage = {
                     <div class="form-group"><label>Cost account</label><select name="debit_account_id">${acctOpts}</select></div>
                     <div class="form-group"><label>Offset account</label><select name="credit_account_id">${acctOpts}</select></div>
                     <div class="form-group full-width"><label>Memo</label><input name="memo" placeholder="e.g. July small tools & consumables"></div>
-                    <div class="form-group full-width"><label>Jobs</label><div style="max-height:220px;overflow:auto;border:1px solid var(--gray-200);padding:6px">${jobOpts || '<em>No active jobs</em>'}</div></div>
+                    <div class="form-group full-width"><label>${T('Jobs')}</label><div style="max-height:220px;overflow:auto;border:1px solid var(--gray-200);padding:6px">${jobOpts || '<em>No active jobs</em>'}</div></div>
                 </div>
                 <div class="form-actions">
                     <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
@@ -272,7 +272,7 @@ const JobCostsPage = {
         if (!confirm('Void this job cost entry? A reversing entry is posted; the original stays in the ledger.')) return;
         try {
             await API.post(`/job-costs/${id}/void`, {});
-            toast('Job cost voided');
+            toast(`${T('Job')} cost voided`);
             closeModal();
             JobCostsPage._afterChange();
         } catch (err) { toast(err.message, 'error'); }

--- a/app/static/js/jobs.js
+++ b/app/static/js/jobs.js
@@ -69,7 +69,7 @@ const JobsPage = {
                     <option value="">${Terms.text('All customers')}</option>${custOpts}</select>
                 <select id="job-filter-status" onchange="JobsPage.setFilter('status', this.value)">
                     <option value="">Active jobs</option>${statusOpts}<option value="__inactive__">Inactive</option></select>
-                <span style="font-size:11px; color:var(--gray-500);">Job-to-date figures from posted lines. Click a job to drill down.</span>
+                <span style="font-size:11px; color:var(--gray-500);">${Terms.text('Job-to-date figures from posted lines. Click a job to drill down.')}</span>
             </div>
             <div id="jobs-table">${JobsPage._tableHtml()}</div>`;
     },
@@ -169,7 +169,7 @@ const JobsPage = {
         return `
             <div class="page-header">
                 <div>
-                    <div style="font-size:11px;"><a href="#/jobs">Jobs</a> › ${escapeHtml(job.customer_name)}</div>
+                    <div style="font-size:11px;"><a href="#/jobs">${T('Jobs')}</a> › ${escapeHtml(job.customer_name)}</div>
                     <h2 style="margin:2px 0 0 0;">${escapeHtml(job.name)}
                         <span class="badge" style="font-size:11px; vertical-align:middle;">${escapeHtml(JobsPage.STATUS_LABELS[job.status] || job.status)}</span>
                         ${job.is_active ? '' : '<span style="font-size:11px;color:#a4242b;">inactive</span>'}
@@ -177,7 +177,7 @@ const JobsPage = {
                 </div>
                 <div>
                     <button class="btn btn-secondary" onclick="InvoicesPage.showForm(null,${job.customer_id})">${T('New Invoice')}</button>
-                    <button class="btn btn-secondary" onclick="JobCostsPage.showForm(null, ${job.id})">Job Cost Entry</button>
+                    <button class="btn btn-secondary" onclick="JobCostsPage.showForm(null, ${job.id})">${T('Job')} Cost Entry</button>
                     <button class="btn btn-secondary" onclick="JobsPage.showForm(${job.id})">Edit</button>
                 </div>
             </div>
@@ -187,7 +187,7 @@ const JobsPage = {
                 <span style="margin-left:auto; font-size:11px; display:flex; gap:6px; align-items:center;">
                     Period <input type="date" id="job-period-start" value="${JobsPage._period.start}" onchange="JobsPage.setPeriod()">
                     – <input type="date" id="job-period-end" value="${JobsPage._period.end}" onchange="JobsPage.setPeriod()">
-                    <button class="btn btn-sm btn-secondary" onclick="JobsPage.clearPeriod()" title="Job to date">JTD</button>
+                    <button class="btn btn-sm btn-secondary" onclick="JobsPage.clearPeriod()" title="${T('Job')} to date">JTD</button>
                 </span>
             </div>
             <div id="job-tab-body">${await JobsPage.tabHtml()}</div>`;
@@ -279,7 +279,7 @@ const JobsPage = {
                     </table></div>
                 </div>
                 <div style="font-size:13px">
-                    <h4 style="font-size:11px;text-transform:uppercase;color:#888;margin:0 0 4px 0">Job</h4>
+                    <h4 style="font-size:11px;text-transform:uppercase;color:#888;margin:0 0 4px 0">${T('Job')}</h4>
                     <div>${job.job_number ? `#${escapeHtml(job.job_number)} · ` : ''}${escapeHtml(job.job_type || '')}</div>
                     <div>${job.start_date ? escapeHtml(job.start_date) : ''}${job.projected_end_date ? ` → ${escapeHtml(job.projected_end_date)}` : ''}${job.end_date ? ` (ended ${escapeHtml(job.end_date)})` : ''}</div>
                     ${job.site_address ? `<pre style="font-family:inherit;white-space:pre-wrap;margin:6px 0">${escapeHtml(job.site_address)}</pre>` : ''}
@@ -401,9 +401,9 @@ const JobsPage = {
     },
 
     sourceLabel(t) {
-        return { invoice: 'Invoice', bill: 'Bill', expense: 'Expense', cc_charge: 'Card charge', manual: 'Journal',
+        return { invoice: T('Invoice'), bill: 'Bill', expense: 'Expense', cc_charge: 'Card charge', manual: 'Journal',
             credit_memo: 'Credit memo', sales_receipt: 'Sales receipt', deposit: 'Deposit', check: 'Check',
-            job_cost: 'Job cost', job_cost_void: 'Void job cost', expense_void: 'Void expense', bill_void: 'Void bill' }[t] || (t || 'Entry');
+            job_cost: `${T('Job')} cost`, job_cost_void: `Void ${T('Job').toLowerCase()} cost`, expense_void: 'Void expense', bill_void: 'Void bill' }[t] || (t || 'Entry');
     },
 
     async toggle(key) { JobsPage._open.has(key) ? JobsPage._open.delete(key) : JobsPage._open.add(key); await JobsPage.setTab('costs'); },
@@ -526,7 +526,7 @@ const JobsPage = {
             <td class="amount">${l.kind === 'cost' ? formatCurrency(l.amount) : ''}</td>
         </tr>`).join('');
         return `<div class="table-container"><table class="data-table" style="font-size:12px">
-            <thead><tr><th scope="col">Date</th><th scope="col">Source</th><th scope="col">Account</th><th scope="col">Memo</th><th scope="col" class="amount">Income</th><th scope="col" class="amount">Cost</th></tr></thead>
+            <thead><tr><th scope="col">Date</th><th scope="col">Source</th><th scope="col">Account</th><th scope="col">Memo</th><th scope="col" class="amount">${T('Income')}</th><th scope="col" class="amount">Cost</th></tr></thead>
             <tbody>${rows}</tbody></table></div>`;
     },
 
@@ -547,7 +547,7 @@ const JobsPage = {
             ${unposted.length ? `<div style="margin-bottom:8px"><button class="btn btn-sm btn-primary" onclick="JobsPage.postTime([${unposted.map(e => e.id).join(',')}])">Post ${unposted.length} approved entr${unposted.length === 1 ? 'y' : 'ies'} to this job</button>
                 <span style="font-size:11px;color:#888">Labor posts at the employee's loaded cost rate with burden as its own line.</span></div>` : ''}
             <div class="table-container"><table class="data-table" style="font-size:12px">
-                <thead><tr><th scope="col">Date</th><th scope="col">Employee</th><th scope="col">Cost code</th><th scope="col" class="amount">Reg</th><th scope="col" class="amount">OT</th><th scope="col" class="amount">DT</th><th scope="col">Status</th><th scope="col">Job cost</th></tr></thead>
+                <thead><tr><th scope="col">Date</th><th scope="col">Employee</th><th scope="col">Cost code</th><th scope="col" class="amount">Reg</th><th scope="col" class="amount">OT</th><th scope="col" class="amount">DT</th><th scope="col">Status</th><th scope="col">${T('Job')} cost</th></tr></thead>
                 <tbody>${rows}</tbody></table></div>`;
     },
 
@@ -578,13 +578,13 @@ const JobsPage = {
                 <div class="form-grid">
                     <div class="form-group"><label>${T('Customer')} *</label>
                         <select name="customer_id" required><option value="">Select...</option>${custOpts}</select></div>
-                    <div class="form-group"><label>${T('Job name')} *</label>
+                    <div class="form-group"><label>${T('Job')} name *</label>
                         <input name="name" required maxlength="200" value="${escapeHtml(job.name)}" placeholder="Kitchen remodel"></div>
-                    <div class="form-group"><label>${T('Job #')}</label>
+                    <div class="form-group"><label>${T('Job')} #</label>
                         <input name="job_number" maxlength="50" value="${escapeHtml(job.job_number || '')}"></div>
                     <div class="form-group"><label>Status</label>
                         <select name="status">${statusOpts}</select></div>
-                    <div class="form-group"><label>${T('Job type')}</label>
+                    <div class="form-group"><label>${T('Job')} type</label>
                         <input name="job_type" maxlength="100" value="${escapeHtml(job.job_type || '')}" placeholder="Remodel, New build, Service…"></div>
                     <div class="form-group"><label>Contract amount</label>
                         <input name="contract_amount" type="number" step="0.01" min="0" value="${job.contract_amount ?? ''}"></div>
@@ -606,10 +606,10 @@ const JobsPage = {
                 <div class="form-actions">
                     ${id ? `<button type="button" class="btn btn-secondary" onclick="JobsPage.remove(${id})" style="margin-right:auto;">Delete</button>` : ''}
                     <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
-                    <button type="submit" class="btn btn-primary">${id ? 'Save Job' : 'Create Job'}</button>
+                    <button type="submit" class="btn btn-primary">${id ? `Save ${T('Job')}` : `Create ${T('Job')}`}</button>
                 </div>
             </form>`;
-        openModal(id ? 'Edit Job' : 'New Job', html);
+        openModal(id ? `Edit ${T('Job')}` : `New ${T('Job')}`, html);
     },
 
     async save(e, id) {
@@ -633,17 +633,17 @@ const JobsPage = {
         if (form.is_active) data.is_active = form.is_active.value === 'true';
         try {
             const saved = id ? await API.put(`/jobs/${id}`, data) : await API.post('/jobs', data);
-            toast(id ? 'Job saved' : 'Job created');
+            toast(id ? `${T('Job')} saved` : `${T('Job')} created`);
             closeModal();
             App.navigate(`#/jobs/${id || saved.id}`);
         } catch (err) { toast(err.message, 'error'); }
     },
 
     async remove(id) {
-        if (!confirm('Delete this job? Jobs with posted activity cannot be deleted — mark them inactive instead.')) return;
+        if (!confirm(Terms.text('Delete this job? Jobs with posted activity cannot be deleted — mark them inactive instead.'))) return;
         try {
             await API.del(`/jobs/${id}`);
-            toast('Job deleted');
+            toast(`${T('Job')} deleted`);
             closeModal();
             App.navigate('#/jobs');
         } catch (err) { toast(err.message, 'error'); }

--- a/app/static/js/payments.js
+++ b/app/static/js/payments.js
@@ -49,7 +49,7 @@ const PaymentsPage = {
         }
         let allocHtml = '';
         if (p.allocations.length) {
-            allocHtml = `<h4 style="margin:12px 0 8px;">Applied to Invoices</h4>
+            allocHtml = `<h4 style="margin:12px 0 8px;">Applied to ${T('Invoices')}</h4>
                 <div class="table-container"><table><thead><tr>
                 <th scope="col">${T('Invoice')}</th><th scope="col" class="amount">Amount</th></tr></thead><tbody>`;
             for (const a of p.allocations) {
@@ -60,7 +60,7 @@ const PaymentsPage = {
 
         openModal('Payment Details', `
             <div style="margin-bottom:12px;">
-                <strong>Customer:</strong> ${escapeHtml(p.customer_name || '')}<br>
+                <strong>${T('Customer')}:</strong> ${escapeHtml(p.customer_name || '')}<br>
                 <strong>Date:</strong> ${formatDate(p.date)}<br>
                 <strong>Amount:</strong> ${formatCurrency(p.amount)}<br>
                 <strong>Method:</strong> ${escapeHtml(p.method || 'N/A')}<br>
@@ -80,7 +80,7 @@ const PaymentsPage = {
     },
 
     async void(id) {
-        if (!confirm('Void this payment? Invoice balances will be restored.')) return;
+        if (!confirm(`Void this payment? ${T('Invoice')} balances will be restored.`)) return;
         try {
             await API.post(`/payments/${id}/void`);
             toast('Payment voided');
@@ -150,7 +150,7 @@ const PaymentsPage = {
             return;
         }
 
-        let html = `<h4 style="margin-bottom:8px;">Apply to Invoices</h4>
+        let html = `<h4 style="margin-bottom:8px;">Apply to ${T('Invoices')}</h4>
             <div class="table-container"><table><thead><tr>
             <th scope="col">${T('Invoice')}</th><th scope="col">Date</th><th scope="col" class="amount">Balance</th><th scope="col" class="amount">Apply</th>
             </tr></thead><tbody>`;

--- a/app/static/js/recurring.js
+++ b/app/static/js/recurring.js
@@ -69,7 +69,7 @@ const RecurringPage = {
         const custOpts = customers.map(c => `<option value="${c.id}" ${rec.customer_id==c.id?'selected':''}>${escapeHtml(c.name)}</option>`).join('');
         const itemOpts = items.map(i => `<option value="${i.id}">${escapeHtml(i.name)}</option>`).join('');
 
-        openModal(id ? 'Edit Recurring Invoice' : 'New Recurring Invoice', `
+        openModal(id ? `Edit ${T('Recurring Invoices').replace(/s$/, '')}` : `New ${T('Recurring Invoices').replace(/s$/, '')}`, `
             <form onsubmit="RecurringPage.save(event, ${id})">
                 <div class="form-grid">
                     <div class="form-group"><label>${T('Customer')} *</label>

--- a/app/static/js/reports.js
+++ b/app/static/js/reports.js
@@ -113,7 +113,7 @@ const ReportsPage = {
                 </div>
                 <div class="card" style="cursor:pointer" onclick="ReportsPage.incomeByCustomer()">
                     <div class="card-header">${T('Income by Customer')}</div>
-                    <p style="font-size:13px; color:var(--gray-500);">${Terms.text('Sales totals per customer')}</p>
+                    <p style="font-size:13px; color:var(--gray-500);">${Terms.isNonprofit() ? 'Contribution totals per donor' : 'Sales totals per customer'}</p>
                 </div>
                 <div class="card" style="cursor:pointer" onclick="ReportsPage.customerStatementPicker()">
                     <div class="card-header">${T('Customer Statement')}</div>

--- a/app/static/js/reports.js
+++ b/app/static/js/reports.js
@@ -899,8 +899,8 @@ ReportsPage.financialStatementsPdf = async function () {
     await ReportsPage.openPeriodModal("Financial Statements Pack", "this_year_to_date", async (_period, range) => {
         window.open(`/api/reports/financial-statements/pdf?start_date=${range.start}&end_date=${range.end}`, '_blank');
         return `<div style="font-size:12px;">The statements pack opened in a new tab —
-            P&L and Trial Balance for ${escapeHtml(range.start)} — ${escapeHtml(range.end)},
-            Balance Sheet as of ${escapeHtml(range.end)}. Paper size follows
+            ${T('P&L')} and Trial Balance for ${escapeHtml(range.start)} — ${escapeHtml(range.end)},
+            ${T('Balance Sheet')} as of ${escapeHtml(range.end)}. Paper size follows
             Settings → Report PDF Paper Size.</div>`;
     });
 };
@@ -920,7 +920,7 @@ ReportsPage.jobProfitability = async function () {
         </tr>`).join('');
         return `
             <div style="font-size:11px; color:var(--gray-500); margin-bottom:8px;">
-                ${escapeHtml(data.start_date)} — ${escapeHtml(data.end_date)} · "No job" holds untagged activity <em>and</em> the applied-cost credits behind Job Cost Entries (labor, equipment, overhead applied to jobs), so its costs can be negative and the totals still match the P&L
+                ${escapeHtml(data.start_date)} — ${escapeHtml(data.end_date)} · ${Terms.text('"No job" holds untagged activity')} <em>and</em> ${Terms.text('the applied-cost credits behind Job Cost Entries (labor, equipment, overhead applied to jobs), so its costs can be negative and the totals still match the P&L')}
             </div>
             <div class="table-container"><table>
                 <thead><tr><th scope="col">${T('Customer')}</th><th scope="col">${T('Job')}</th><th scope="col" class="amount">Contract</th><th scope="col" class="amount">${T('Income')}</th>

--- a/app/static/js/sales_receipts.js
+++ b/app/static/js/sales_receipts.js
@@ -44,7 +44,7 @@ const SalesReceiptsPage = {
 
         openModal(`${T('Sales Receipt')} #${sr.invoice_number}`, `
             <div style="margin-bottom:12px;">
-                <strong>Customer:</strong> ${escapeHtml(sr.customer_name || '')}<br>
+                <strong>${T('Customer')}:</strong> ${escapeHtml(sr.customer_name || '')}<br>
                 <strong>Date:</strong> ${formatDate(sr.date)}<br>
                 <strong>Status:</strong> ${statusBadge(sr.status)}<br>
                 ${payment && payment.method ? `<strong>Payment Method:</strong> ${escapeHtml(payment.method)}<br>` : ''}
@@ -193,7 +193,7 @@ const SalesReceiptsPage = {
                     <textarea name="notes"></textarea></div>
                 <div class="form-actions">
                     <button type="button" class="btn btn-secondary" onclick="ScanHelper.discard(); closeModal()">Cancel</button>
-                    <button type="submit" class="btn btn-primary">Record Sales Receipt</button>
+                    <button type="submit" class="btn btn-primary">Record ${T('Sales Receipt')}</button>
                 </div>
             </form>`);
         SalesReceiptsPage.recalc();
@@ -305,7 +305,7 @@ const SalesReceiptsPage = {
 
     async saveNewCustomer() {
         const name = $('#sr-new-cust-name').value.trim();
-        if (!name) { toast('Customer name is required', 'error'); return; }
+        if (!name) { toast(`${T('Customer')} name is required`, 'error'); return; }
         try {
             const cust = await API.post('/customers', {
                 name, email: $('#sr-new-cust-email').value.trim() || null,
@@ -317,7 +317,7 @@ const SalesReceiptsPage = {
             opt.value = cust.id; opt.textContent = cust.name; opt.selected = true;
             sel.appendChild(opt);
             $('#sr-new-customer-form').style.display = 'none';
-            toast(`Customer "${cust.name}" created`);
+            toast(`${T('Customer')} "${cust.name}" created`);
         } catch (err) { toast(err.message, 'error'); }
     },
 

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -79,17 +79,17 @@ const SettingsPage = {
                             </select></div>
                         <div class="form-group"><label>Default Tax Rate (%)</label>
                             <input name="default_tax_rate" type="number" step="0.01" value="${s.default_tax_rate || '0.0'}"></div>
-                        <div class="form-group"><label>${T('Invoice Prefix')}</label>
+                        <div class="form-group"><label>${`${T('Invoice')} Prefix`}</label>
                             <input name="invoice_prefix" value="${escapeHtml(s.invoice_prefix || '')}" placeholder="e.g. INV-"></div>
-                        <div class="form-group"><label>${T('Next Invoice #')}</label>
+                        <div class="form-group"><label>${`Next ${T('Invoice')} #`}</label>
                             <input name="invoice_next_number" value="${escapeHtml(s.invoice_next_number || '1001')}"></div>
                         <div class="form-group"><label>Estimate Prefix</label>
                             <input name="estimate_prefix" value="${escapeHtml(s.estimate_prefix || '')}" placeholder="e.g. E-"></div>
                         <div class="form-group"><label>Next Estimate #</label>
                             <input name="estimate_next_number" value="${escapeHtml(s.estimate_next_number || '1001')}"></div>
-                        <div class="form-group full-width"><label>${T('Default Invoice Notes')}</label>
+                        <div class="form-group full-width"><label>${`Default ${T('Invoice')} Notes`}</label>
                             <textarea name="invoice_notes">${escapeHtml(s.invoice_notes || '')}</textarea></div>
-                        <div class="form-group full-width"><label>${T('Invoice Footer')}</label>
+                        <div class="form-group full-width"><label>${`${T('Invoice')} Footer`}</label>
                             <input name="invoice_footer" value="${escapeHtml(s.invoice_footer || '')}"></div>
                         <div class="form-group"><label>Report PDF Paper Size</label>
                             <select name="pdf_paper_size">
@@ -247,7 +247,7 @@ const SettingsPage = {
                 <div class="settings-section" id="settings-ocr">
                     <h3>Receipt Scanning</h3>
                     <div style="font-size:10px; color:var(--text-muted); margin-bottom:8px;">
-                        Local OCR for the Scan Receipt button on the Enter Sales Receipt and Enter Bill forms.
+                        ${Terms.text('Local OCR for the Scan Receipt button on the Enter Sales Receipt and Enter Bill forms.')}
                         Everything runs on this computer — no cloud, no data leaves the machine.
                         The desktop app ships with a built-in engine (Windows OCR / Apple Vision), so scanning
                         works out of the box; Tesseract is an optional extra engine you can install yourself.
@@ -335,10 +335,10 @@ const SettingsPage = {
                 <div class="settings-section">
                     <h3>Cost Codes</h3>
                     <div style="font-size:10px; color:var(--text-muted); margin-bottom:8px;">
-                        The job-costing chart: which part of a job a cost belongs to
+                        ${Terms.text('The job-costing chart: which part of a job a cost belongs to')}
                         ("03 Concrete", "26 Electrical"), independent of the account it posts
                         to. Picked per line on bills, expenses, purchase orders and journal
-                        entries; the Job detail rolls costs up by code and cost type.
+                        entries; ${Terms.text('the Job detail rolls costs up by code and cost type.')}
                     </div>
                     <div style="display:flex; gap:8px; margin-bottom:12px; flex-wrap:wrap;">
                         <input type="text" id="new-cc-code" placeholder="Code" style="width:90px;">
@@ -359,7 +359,7 @@ const SettingsPage = {
                 <div class="settings-section">
                     <h3>Equipment</h3>
                     <div style="font-size:10px; color:var(--text-muted); margin-bottom:8px;">
-                        Owned machines charged to jobs by the hour from a Job Cost Entry. The recovery account is
+                        ${Terms.text('Owned machines charged to jobs by the hour from a Job Cost Entry.')} The recovery account is
                         the credit side (defaults to the equipment cost type's offset).
                     </div>
                     <div style="display:flex; gap:8px; margin-bottom:12px; flex-wrap:wrap;">

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -888,7 +888,7 @@ const SettingsPage = {
                 </p>
             </fieldset>
             <label class="form-field">
-                <span>API Key / Shared Secret ${hasKey ? '<em class="ai-key-saved">(saved &#10003;)</em>' : ''}</span>
+                <span>API Key / Shared Secret ${hasKey ? '<em class="ai-key-saved">(saved &#10003;)</em> <button type="button" class="btn btn-sm" id="ai-settings-key-remove" title="Remove the stored key">Remove</button>' : ''}</span>
                 <input type="password" id="ai-settings-key"
                        placeholder="${hasKey ? 'Leave blank to keep existing' : 'Paste key or openssl rand -hex 32'}"
                        autocomplete="new-password">
@@ -975,12 +975,33 @@ const SettingsPage = {
             cloudflare_account_id: document.getElementById('ai-settings-cf-account').value.trim(),
             worker_url: document.getElementById('ai-settings-worker-url').value.trim(),
             endpoint_url: document.getElementById('ai-settings-endpoint-url') ? document.getElementById('ai-settings-endpoint-url').value.trim() : '',
-            api_key: document.getElementById('ai-settings-key').value,
         });
+        // The key field is write-only: send it only when the user typed a new
+        // one. A blank field must never round-trip as "clear the key".
+        const keyPayload = () => {
+            const v = document.getElementById('ai-settings-key').value;
+            return v.trim() ? { api_key: v } : {};
+        };
+
+        const removeBtn = document.getElementById('ai-settings-key-remove');
+        if (removeBtn) {
+            removeBtn.addEventListener('click', async () => {
+                if (!confirm('Remove the stored API key? AI Insights will be off until a new key is saved.')) return;
+                try {
+                    // An explicit empty string is the API's "clear the key".
+                    const updated = await API.put('/analytics/ai-config', { ...collectPayload(), api_key: '' });
+                    SettingsPage.aiConfigState = updated;
+                    toast('AI provider key removed', 'success');
+                    SettingsPage.loadAiConfig();
+                } catch (err) {
+                    toast('Could not remove the key: ' + (err.message || err), 'error');
+                }
+            });
+        }
 
         saveBtn.addEventListener('click', async () => {
             try {
-                const updated = await API.put('/analytics/ai-config', collectPayload());
+                const updated = await API.put('/analytics/ai-config', { ...collectPayload(), ...keyPayload() });
                 SettingsPage.aiConfigState = updated;
                 toast('AI settings saved', 'success');
                 // Re-render to reflect "(saved ✓)" state and clear the key input
@@ -995,7 +1016,7 @@ const SettingsPage = {
             testRes.textContent = 'Saving…';
             testRes.className = 'ai-settings-test-result';
             try {
-                await API.put('/analytics/ai-config', collectPayload());
+                await API.put('/analytics/ai-config', { ...collectPayload(), ...keyPayload() });
             } catch (err) {
                 testRes.textContent = 'Save failed: ' + (err.message || err);
                 testRes.classList.add('ai-test-fail');

--- a/app/static/js/terms.js
+++ b/app/static/js/terms.js
@@ -54,7 +54,9 @@ const TERMS_NONPROFIT = {
     "Total Receivables": "Pledges Receivable",
     "A/R Aging": "Pledge Aging",
     "Accounts Receivable Aging": "Pledges Receivable Aging",
-    "Monthly Revenue": "Monthly Revenue & Support"
+    "Monthly Revenue": "Monthly Revenue & Support",
+    "Receivables": "Pledges Receivable",
+    "Revenue by Customer": "Revenue & Support by Donor"
 };
 
 const Terms = {

--- a/app/static/whats-new.json
+++ b/app/static/whats-new.json
@@ -1,4 +1,13 @@
 {
+  "2.9.1": {
+    "title": "Post-release tidy",
+    "items": [
+      "AI Insights: a stored provider key can be removed (Remove beside the saved mark; the API clears on an explicit empty string)",
+      "Windows releases ship SHA256SUMS.windows beside the installer and zip",
+      "Nonprofit mode: the Contributions by Donor card and the analytics aging header speak donor, not sales and customer",
+      "Migrations create every table on their own; the install guide's counts are current"
+    ]
+  },
   "2.9.0": {
     "title": "Nonprofit mode",
     "items": [

--- a/app/templates/analytics_pdf.html
+++ b/app/templates/analytics_pdf.html
@@ -245,9 +245,9 @@
 
     <div class="two-col">
         <div>
-            <h2 class="section">Revenue by Customer</h2>
+            <h2 class="section">{{ terms('Revenue by Customer') }}</h2>
             <table class="data">
-                <thead><tr><th>Customer</th><th class="num">Revenue</th></tr></thead>
+                <thead><tr><th>{{ terms('Customer') }}</th><th class="num">Revenue</th></tr></thead>
                 <tbody>
                 {% for customer, revenue in dashboard.revenue_by_customer.items()|sort(attribute=1, reverse=true) %}
                     <tr><td>{{ customer }}</td><td class="num green">{{ revenue | currency }}</td></tr>
@@ -339,8 +339,8 @@
         {% endif %}
     {% endmacro %}
 
-    <h2 class="section">Accounts Receivable Aging</h2>
-    {{ aging_table(dashboard.ar_aging, 'Customer') }}
+    <h2 class="section">{{ terms('Accounts Receivable Aging') }}</h2>
+    {{ aging_table(dashboard.ar_aging, terms('Customer')) }}
 
     <h2 class="section">Accounts Payable Aging</h2>
     {{ aging_table(dashboard.ap_aging, 'Vendor') }}

--- a/app/templates/collection_letter.html
+++ b/app/templates/collection_letter.html
@@ -52,7 +52,7 @@
     <div class="letter-type">Friendly Reminder</div>
     <div class="body-text urgency-30">
         <p>Dear {{ customer.name }},</p>
-        <p>Our records indicate that the following invoice(s) are past due. We understand that
+        <p>Our records indicate that {{ terms.text('the following invoice(s) are past due.') }} We understand that
         oversights happen, and we wanted to bring this to your attention.</p>
         <p>If you have already sent payment, please disregard this notice. Otherwise, we would
         appreciate your prompt attention to this matter.</p>
@@ -62,7 +62,7 @@
     <div class="letter-type">Second Notice — Account Past Due</div>
     <div class="body-text urgency-60">
         <p>Dear {{ customer.name }},</p>
-        <p>Despite our previous reminder, the following invoice(s) remain unpaid. Your account
+        <p>Despite our previous reminder, {{ terms.text('the following invoice(s) remain unpaid.') }} Your account
         is now significantly past due.</p>
         <p>Please arrange payment immediately to avoid any interruption to your account or
         additional collection activity.</p>
@@ -73,7 +73,7 @@
     <div class="body-text urgency-90">
         <p>Dear {{ customer.name }},</p>
         <p><strong>This is our final notice before we escalate collection efforts.</strong></p>
-        <p>The following invoice(s) are seriously past due. If payment is not received within
+        <p>{{ terms.text('The following invoice(s) are seriously past due.') }} If payment is not received within
         10 business days, we may be forced to pursue additional collection measures,
         which may affect your credit standing.</p>
         <p>Please contact us immediately to arrange payment or discuss a payment plan.</p>
@@ -83,7 +83,7 @@
     <table>
         <thead>
             <tr>
-                <th>Invoice #</th>
+                <th>{{ terms('Invoice') }} #</th>
                 <th>Date</th>
                 <th>Due Date</th>
                 <th>Days Past Due</th>

--- a/app/templates/invoice_email.html
+++ b/app/templates/invoice_email.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Invoice</title><style>
+    <title>{{ doc_label }}</title><style>
 body { font-family: Arial, sans-serif; font-size: 14px; color: #333; }
 .header { background: #003366; color: white; padding: 20px; text-align: center; }
 .content { padding: 20px; }
@@ -16,11 +16,11 @@ td { padding: 8px; border-bottom: 1px solid #eee; }
     <h1 style="margin:0;">{{ company.get('company_name', 'Our Company') }}</h1>
 </div>
 <div class="content">
-    <p>Dear {{ inv.customer.name if inv.customer else 'Customer' }},</p>
-    <p>Please find attached <strong>Invoice #{{ inv.invoice_number }}</strong>.</p>
+    <p>Dear {{ inv.customer.name if inv.customer else terms('Customer') }},</p>
+    <p>Please find attached <strong>{{ doc_label }} #{{ inv.invoice_number }}</strong>.</p>
 
     <table>
-        <tr><th>Invoice #</th><td>{{ inv.invoice_number }}</td></tr>
+        <tr><th>{{ doc_label }} #</th><td>{{ inv.invoice_number }}</td></tr>
         <tr><th>Date</th><td>{{ inv.date }}</td></tr>
         <tr><th>Due Date</th><td>{{ inv.due_date }}</td></tr>
         <tr><th>Terms</th><td>{{ inv.terms or 'Net 30' }}</td></tr>
@@ -38,7 +38,7 @@ td { padding: 8px; border-bottom: 1px solid #eee; }
     <p style="color:#666;">{{ inv.notes }}</p>
     {% endif %}
 
-    <p>Thank you for your business.</p>
+    <p>{% if terms.is_nonprofit %}Thank you for your support.{% else %}Thank you for your business.{% endif %}</p>
 </div>
 <div class="footer">
     <p>{{ company.get('company_name', '') }}<br>

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -119,7 +119,7 @@ and the **January verification pass** on `app/services/state_tax/tables.py`.
      duplicate-detection engine already at `/api/customers/check-duplicate`
      extends to invoice-number + PO-number lookup).
   3. **Classify + sentiment** — pass the body through the AI layer (the
-     existing 7-provider BYOK config in `app/services/ai_service.py`) to
+     existing 8-provider BYOK config in `app/services/ai_service.py`) to
      tag intent (payment confirmation / dispute / inquiry / quote /
      unrelated) plus sentiment (positive / neutral / negative). Tag goes
      into the staged record; AI never auto-acts.

--- a/migrations/versions/c4d5e6f7a8b9_api_tokens_table.py
+++ b/migrations/versions/c4d5e6f7a8b9_api_tokens_table.py
@@ -1,0 +1,53 @@
+"""api_tokens table (was create_all-only)
+
+The last table that only Base.metadata.create_all() created. After this,
+`alembic upgrade head` alone produces the full schema, so a Docker start no
+longer depends on the app's own create_all pass for anything (the advisory
+lock around that pass stays as a belt to this brace). Idempotent: every
+desktop file already has the table from create_all.
+
+Revision ID: c4d5e6f7a8b9
+Revises: b3c4d5e6f7a8
+Create Date: 2026-09-07
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "c4d5e6f7a8b9"
+down_revision: Union[str, None] = "b3c4d5e6f7a8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if "api_tokens" in sa.inspect(bind).get_table_names():
+        return
+    # Mirrors app/models/api_tokens.py; keep the two in step.
+    op.create_table(
+        "api_tokens",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("label", sa.String(length=100), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("token_hint", sa.String(length=12), nullable=False),
+        sa.Column("role", sa.String(length=20), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column("created_by", sa.String(length=100), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("last_used_at", sa.DateTime(), nullable=True),
+        sa.UniqueConstraint("label", name="uq_api_tokens_label"),
+    )
+    op.create_index("ix_api_tokens_id", "api_tokens", ["id"])
+    op.create_index(
+        "ix_api_tokens_token_hash", "api_tokens", ["token_hash"], unique=True
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_api_tokens_token_hash", table_name="api_tokens")
+    op.drop_index("ix_api_tokens_id", table_name="api_tokens")
+    op.drop_table("api_tokens")

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -35,9 +35,12 @@ Developer ID signing and notarization on the maintainer's Mac:
    and build metadata for seven days. It never creates or changes a GitHub
    Release.
 3. `release.py` verifies the artifact and source SHA, replaces every ad-hoc
-   signature from the inside out, signs the final DMG, submits that DMG to
-   Apple, retrieves the notarization log, staples the ticket, and runs final
-   command-line gates.
+   signature from the inside out, notarizes the bare `.app` and **staples it
+   first**, builds and signs the DMG from that stapled bundle, notarizes and
+   staples the DMG, then mounts the shipped DMG and runs `stapler validate`
+   on the bundle inside it. Both tickets are required: the one on the `.app`
+   is what a user who drags it to Applications launches offline with
+   (v2.9.0 gate). Evidence files are `notary-app-*` and `notary-dmg-*`.
 4. Installed-app acceptance and public-release verification remain separate
    human gates.
 

--- a/tests/test_gate_290_fixes.py
+++ b/tests/test_gate_290_fixes.py
@@ -759,3 +759,59 @@ def test_create_all_is_serialized_under_postgres(monkeypatch):
     assert "pg_advisory_xact_lock" in calls[1][1]
     assert calls[2] == ("create_all", "FakeConn")
     assert calls[-1] == ("commit",)
+
+
+# ---- 2.9.1: post-release tidy ------------------------------------------
+
+
+def test_migrations_create_every_model_table(tmp_path):
+    import sqlite3
+
+    from app.database import Base
+    import app.models  # noqa: F401
+
+    db = _migrate_fresh_sqlite(tmp_path)
+    migrated = {
+        r[0]
+        for r in sqlite3.connect(db).execute(
+            "select name from sqlite_master where type='table'"
+        )
+    }
+    missing = sorted(set(Base.metadata.tables) - migrated)
+    assert missing == [], f"tables only create_all() makes: {missing}"
+
+
+def test_ai_api_key_can_be_cleared_with_an_explicit_empty_string(client):
+    base = {"provider": "openai", "model": "gpt-5.4-mini"}
+    r = client.put(
+        "/api/analytics/ai-config", json={**base, "api_key": "sk-test-1234567890"}
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["has_api_key"] is True
+    # omitted -> kept
+    r = client.put("/api/analytics/ai-config", json=base)
+    assert r.json()["has_api_key"] is True
+    # explicit empty string -> cleared
+    r = client.put("/api/analytics/ai-config", json={**base, "api_key": ""})
+    assert r.status_code == 200, r.text
+    assert r.json()["has_api_key"] is False
+
+
+def test_settings_page_never_round_trips_a_blank_ai_key():
+    src = open("app/static/js/settings.js").read()
+    assert "keyPayload" in src and "ai-settings-key-remove" in src
+    assert "api_key: document.getElementById('ai-settings-key').value," not in src
+
+
+def test_nonprofit_vocabulary_on_analytics_aging_and_donor_card():
+    analytics = open("app/static/js/analytics.js").read()
+    assert '_agingTable(data.ar_aging, T("Customer"))' in analytics
+    reports = open("app/static/js/reports.js").read()
+    assert "Sales totals per donor" not in reports
+    assert "Contribution totals per donor" in reports
+
+
+def test_windows_workflow_publishes_checksums():
+    wf = open(".github/workflows/windows.yml").read()
+    assert "SHA256SUMS.windows" in wf
+    assert wf.count("SHA256SUMS.windows") >= 3  # written, uploaded, attached

--- a/tests/test_terminology.py
+++ b/tests/test_terminology.py
@@ -309,3 +309,124 @@ def test_invoice_and_receipt_pdfs_are_named_in_the_company_words(
     assert "DONATION RECEIPT" in preview and "SALES RECEIPT" not in preview
     stmt = client.get(f"/api/reports/customer-statement/{seed_customer.id}/pdf")
     assert stmt.status_code == 200 and stmt.content[:5] == b"%PDF-"
+
+
+# ---------------------------------------------------------------------------
+# Static sweep: no user-facing literal in the SPA may carry a business word
+# without going through T() / Terms.text(). Found the hard way — two leaks
+# shipped in 2.9.0 screenshots ("Sales totals per donor", an aging header
+# that said Customer) that the narrower regexes above never looked at.
+# ---------------------------------------------------------------------------
+
+_SWEEP_EXEMPT = {
+    # interop, tax, HR and shell files keep their own vocabulary by design
+    "iif.js",
+    "qbo.js",
+    "ocr.js",
+    "ocr_receipts.js",
+    "migration.js",
+    "tax.js",
+    "employees.js",
+    "companies.js",
+    "terms.js",
+    "desktop_shim.js",
+    "bootstrap.js",
+    "api.js",
+    "auth.js",
+    "payroll.js",
+    "benefits.js",
+    "pto.js",
+    "onboarding.js",
+    "garnishments.js",
+    "time_entries.js",
+    "tax_forms.js",
+    "portal.js",
+    "reseller_permits.js",
+    "ocr_canvas.js",
+}
+_SWEEP_WORDS = re.compile(
+    r"\b(Customers?|Invoices?|Sales Receipts?|Class(?:es)?|Jobs?|Net Income|"
+    r"Profit & Loss|P&L|Balance Sheet|Equity|Income|A/R|Receivables?)\b"
+)
+
+
+def _sweep_hits():
+    hits = []
+    for path in sorted((ROOT / "app/static/js").glob("*.js")):
+        if path.name in _SWEEP_EXEMPT:
+            continue
+        for lineno, line in enumerate(path.read_text().split("\n"), 1):
+            if re.search(r"\bT\(|Terms\.(text|isNonprofit)\(", line):
+                continue
+            if line.lstrip().startswith(("//", "*", "/*")):
+                continue
+            if (
+                "// literal face" in line
+            ):  # printed-document names are literal by design
+                continue
+            found = []
+            found += [m.group(1) for m in re.finditer(r">([^<>{}]*?)<", line)]
+            # text that trails a ${...} expression: `${id ? 'Update' : 'Create'} Customer</button>`
+            found += [m.group(1) for m in re.finditer(r"\}([^<>{}$]*?)<", line)]
+            # quoted UI strings on the line (modal titles, toasts inside ternaries)
+            found += [
+                m.group(2)
+                for m in re.finditer(r"(['\"])((?:(?!\1).){3,120})\1", line)
+                if not re.search(r"^[#/]|^[a-z_./-]+$|\.png|\.pdf|://", m.group(2))
+            ]
+            found += [
+                m.group(1)
+                for m in re.finditer(
+                    r'(?:placeholder|title|aria-label|label)="([^"]*)"', line
+                )
+            ]
+            found += [
+                m.group(2)
+                for m in re.finditer(
+                    r"(?:toast|confirm|alert)\(\s*(['\"`])(.*?)\1", line
+                )
+            ]
+            found += [
+                m.group(2)
+                for m in re.finditer(
+                    r"(?:title|label|heading)\s*:\s*(['\"])(.*?)\1", line
+                )
+            ]
+            for text in found:
+                if _SWEEP_WORDS.search(text):
+                    hits.append((path.name, lineno, text.strip()))
+    return hits
+
+
+def test_no_unwrapped_business_words_in_spa_text():
+    """Every hit must be an App.routes label (rewritten at boot by
+    applyTerminology — see test_route_labels_are_rewritten_at_boot); anything
+    else is a leak the nonprofit switch will show."""
+    keys = set(NONPROFIT)
+    leaks = [
+        h
+        for h in _sweep_hits()
+        if not (h[0] == "app.js" and h[1] < 60 and h[2] in keys)
+    ]
+    assert leaks == [], "unwrapped business words in SPA text:\n" + "\n".join(
+        f"  {f}:{n}: {t}" for f, n, t in leaks
+    )
+
+
+def test_every_T_call_resolves_to_a_dictionary_key():
+    """T('Job name') is not a key, so it rendered "Job name" for a nonprofit —
+    the wrapper looked right and did nothing (2.9.1 audit). Every argument
+    must be a key, or a singular/plural of one, case-insensitively."""
+    keys = {k.lower() for k in NONPROFIT}
+
+    def resolves(arg):
+        a = arg.lower()
+        return a in keys or (a.endswith("s") and a[:-1] in keys) or (a + "s") in keys
+
+    bad = []
+    for path in sorted((ROOT / "app/static/js").glob("*.js")):
+        for lineno, line in enumerate(path.read_text().split("\n"), 1):
+            for m in re.finditer(r"\bT\(\s*(['\"])(.*?)\1\s*\)", line):
+                if not resolves(m.group(2)):
+                    bad.append(f"{path.name}:{lineno}: T({m.group(2)!r})")
+    assert bad == [], "T() keys that do not resolve:\n" + "\n".join(bad)


### PR DESCRIPTION
## What

The two product findings skytech filed after installing the released 2.9.0 ([SlowBooks-Pro-Testing #9](https://github.com/VonHoltenCodes/SlowBooks-Pro-Testing/pull/9)), plus the Linux maintainer's follow-up notes from the release. No feature work.

- **A stored AI provider key can be removed.** `PUT /api/analytics/ai-config` with `"api_key": ""` clears it; omit the field to keep it; a value replaces it. Documented on the schema field. The Settings page now sends `api_key` only when something was typed and has a **Remove** button beside the "(saved ✓)" mark — it used to round-trip a blank field on every save, which is why an empty string had to be a no-op.
- **Windows releases publish `SHA256SUMS.windows`** (installer + zip, same format as the macOS file), uploaded as an artifact and attached on tags. Authenticode stays; this is the belt to that brace.
- **Migrations create every table.** `c4d5e6f7a8b9_api_tokens_table` covers the last table only `create_all()` made; a test pins that the model metadata is a subset of what `alembic upgrade head` produces. `docker compose up` no longer depends on the app's own table pass for anything (the advisory lock around it stays).
- **Nonprofit vocabulary leaks** seen in the release screenshots: the analytics receivables-aging header said "Customer" (now `T("Customer")` → Donor), and the Contributions by Donor card said "Sales totals per donor" (now "Contribution totals per donor").
- **Docs:** the macOS runbook's step 3 now describes the staple-before-DMG order that has shipped since 2.9.0 and names the evidence files; INSTALL.md's first-run counts are current (57 accounts, default asset type, complete schema from alembic); README data-model row and a todo note.
- Version 2.9.1, CHANGELOG entry, what's-new.

## Gate

Release from the gated SHA this time. Tests: 1886 passed; six new in `tests/test_gate_290_fixes.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DaDm82ccTQi7awPEQrrW3