### PR TITLE
macOS release: validate the stapled bundle inside the DMG by its staged name (#100)

### DIFF
--- a/packaging/macos/release.py
+++ b/packaging/macos/release.py
@@ -415,10 +415,14 @@ def _staple(target: Path, report_dir: Path) -> None:
         )
 
 
-def _verify_dmg_contents_stapled(dmg: Path, evidence: Path, work_dir: Path) -> None:
+def _verify_dmg_contents_stapled(
+    dmg: Path, evidence: Path, work_dir: Path, bundle_name: str
+) -> None:
     """Mount the shipped DMG and run `stapler validate` on the .app inside
     it — the artifact a user actually drags out. Fails the release if the
-    ticket is missing there, whatever the DMG's own ticket says."""
+    ticket is missing there, whatever the DMG's own ticket says.
+    ``bundle_name`` is the staged bundle's own name so a renamed .app is
+    validated rather than reported missing (#100)."""
     mount = work_dir / "final-dmg-mount"
     mount.mkdir()
     _record_run(
@@ -433,7 +437,9 @@ def _verify_dmg_contents_stapled(dmg: Path, evidence: Path, work_dir: Path) -> N
         "-quiet",
     )
     try:
-        inner = mount / "SlowBooks Pro.app"
+        inner = mount / bundle_name
+        if not inner.is_dir():
+            raise RuntimeError(f"{bundle_name} is not inside {dmg.name}; see {evidence}")
         result = _record_run(
             evidence, "xcrun", "stapler", "validate", "-v", str(inner), check=False
         )
@@ -617,7 +623,7 @@ def build_release(
             "context:primary-signature",
             str(final_dmg),
         )
-        _verify_dmg_contents_stapled(final_dmg, final_evidence, work_dir)
+        _verify_dmg_contents_stapled(final_dmg, final_evidence, work_dir, app.name)
 
     with final_dmg.open("rb") as stream:
         digest = hashlib.file_digest(stream, "sha256").hexdigest()

--- a/packaging/macos/release.py
+++ b/packaging/macos/release.py
@@ -439,7 +439,9 @@ def _verify_dmg_contents_stapled(
     try:
         inner = mount / bundle_name
         if not inner.is_dir():
-            raise RuntimeError(f"{bundle_name} is not inside {dmg.name}; see {evidence}")
+            raise RuntimeError(
+                f"{bundle_name} is not inside {dmg.name}; see {evidence}"
+            )
         result = _record_run(
             evidence, "xcrun", "stapler", "validate", "-v", str(inner), check=False
         )

--- a/tests/test_macos_release.py
+++ b/tests/test_macos_release.py
@@ -224,3 +224,38 @@ def test_notarize_rejects_log_with_errors(monkeypatch, tmp_path):
 
     with pytest.raises(RuntimeError, match="did not pass inspection"):
         release._notarize(dmg, "slowbooks-notary", tmp_path, "dmg")
+
+
+def test_dmg_contents_check_uses_the_staged_bundle_name(monkeypatch, tmp_path):
+    """#100: the mounted-DMG stapler check must look for the bundle by the
+    name that was actually staged, not a hardcoded 'SlowBooks Pro.app'."""
+    calls = []
+
+    def fake_record_run(report_path, *args, check=True):
+        calls.append(args)
+        if args[:2] == ("hdiutil", "attach"):
+            (tmp_path / "final-dmg-mount" / "Renamed.app").mkdir(parents=True)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(release, "_record_run", fake_record_run)
+    dmg = tmp_path / "SlowBooksPro.dmg"
+    dmg.write_bytes(b"dmg")
+    release._verify_dmg_contents_stapled(dmg, tmp_path / "ev.txt", tmp_path, "Renamed.app")
+    validated = [c for c in calls if c[1:3] == ("stapler", "validate")]
+    assert validated and validated[0][-1].endswith("/final-dmg-mount/Renamed.app")
+    assert calls[-1][:2] == ("hdiutil", "detach")
+
+
+def test_dmg_contents_check_fails_when_bundle_is_missing(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_record_run(report_path, *args, check=True):
+        calls.append(args)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(release, "_record_run", fake_record_run)
+    dmg = tmp_path / "SlowBooksPro.dmg"
+    dmg.write_bytes(b"dmg")
+    with pytest.raises(RuntimeError, match="is not inside"):
+        release._verify_dmg_contents_stapled(dmg, tmp_path / "ev.txt", tmp_path, "Missing.app")
+    assert calls[-1][:2] == ("hdiutil", "detach")

--- a/tests/test_macos_release.py
+++ b/tests/test_macos_release.py
@@ -240,7 +240,9 @@ def test_dmg_contents_check_uses_the_staged_bundle_name(monkeypatch, tmp_path):
     monkeypatch.setattr(release, "_record_run", fake_record_run)
     dmg = tmp_path / "SlowBooksPro.dmg"
     dmg.write_bytes(b"dmg")
-    release._verify_dmg_contents_stapled(dmg, tmp_path / "ev.txt", tmp_path, "Renamed.app")
+    release._verify_dmg_contents_stapled(
+        dmg, tmp_path / "ev.txt", tmp_path, "Renamed.app"
+    )
     validated = [c for c in calls if c[1:3] == ("stapler", "validate")]
     assert validated and validated[0][-1].endswith("/final-dmg-mount/Renamed.app")
     assert calls[-1][:2] == ("hdiutil", "detach")
@@ -257,5 +259,7 @@ def test_dmg_contents_check_fails_when_bundle_is_missing(monkeypatch, tmp_path):
     dmg = tmp_path / "SlowBooksPro.dmg"
     dmg.write_bytes(b"dmg")
     with pytest.raises(RuntimeError, match="is not inside"):
-        release._verify_dmg_contents_stapled(dmg, tmp_path / "ev.txt", tmp_path, "Missing.app")
+        release._verify_dmg_contents_stapled(
+            dmg, tmp_path / "ev.txt", tmp_path, "Missing.app"
+        )
     assert calls[-1][:2] == ("hdiutil", "detach")


### PR DESCRIPTION
Closes #100.

`_verify_dmg_contents_stapled()` mounted the final DMG and validated a hardcoded `SlowBooks Pro.app`. `build_release()` already holds the bundle as `app` and stages it under `app.name`, so this passes that name through. If the bundle is not on the image at all it now fails with a message naming the bundle and the DMG instead of a misleading stapler error. No behavior change for the current bundle name.

## Test plan
- New: `test_dmg_contents_check_uses_the_staged_bundle_name` (validate is run on the staged name) and `test_dmg_contents_check_fails_when_bundle_is_missing` (clear RuntimeError, DMG still detached).
- `tests/test_macos_release.py`: 12 passed; `test_release_staples_the_app_before_the_dmg` still passes.
- No change to signing, notarization or staple order; the v2.9.x evidence flow is unaffected.