### PR TITLE
Reports: rename 'Save Report…' to 'Add to Saved Reports…'

### DIFF
--- a/app/static/js/reports.js
+++ b/app/static/js/reports.js
@@ -171,7 +171,7 @@ const ReportsPage = {
     },
 
     async saveCurrent(reportType, params) {
-        const name = prompt('Save report as:');
+        const name = prompt('Name for this saved report:');
         if (!name || !name.trim()) return;
         try {
             await API.post('/saved-reports', {
@@ -363,7 +363,7 @@ const ReportsPage = {
     },
 
     async openPeriodModal(title, initialPeriod, loadContent, label = "Dates", useAsOfOnly = false, opts = {}) {
-        // opts.reportType (string) — when set, adds a "Save Report" button
+        // opts.reportType (string) — when set, adds an "Add to Saved Reports" button
         // that captures the current period/range as parameters.
         // opts.prefill ({period?, start_date?, end_date?, as_of_date?}) —
         // used when reopening a saved report; overrides initialPeriod and
@@ -377,7 +377,7 @@ const ReportsPage = {
         const startingPeriod = prefill.period || initialPeriod;
 
         const saveBtn = reportType
-            ? `<button class="btn btn-secondary" id="report-save-btn">Save Report…</button>`
+            ? `<button class="btn btn-secondary" id="report-save-btn">Add to Saved Reports…</button>`
             : '';
 
         openModal(title, `

--- a/docs/nonprofit-module.md
+++ b/docs/nonprofit-module.md
@@ -155,7 +155,7 @@ the PDF and in the CSV (`?compare=prior_year` on the API).
 *Documents → SlowBooks Pro → Reports*, opens it in a viewer window, and shows
 a "Saved to …" notice with a *Show in folder* button. Filenames carry the
 period, so two runs never overwrite each other. Saved report *definitions*
-(the "Save Report…" button) are a different thing: they are listed under
+(the "Add to Saved Reports…" button) are a different thing: they are listed under
 Saved Reports at the top of the Report Center, as a collapsible list.
 
 ## Driving nonprofit mode from the API


### PR DESCRIPTION
In the report period modal, **Save Report…** sits at the bottom next to Close while **Save PDF** is at the top right. Save Report… stores the report *definition* in the Saved Reports list (POST /api/saved-reports); it doesn't write a file. During the 2.9.0 macOS pass I clicked it expecting a PDF, twice. QuickBooks called this Memorize Report; **Add to Saved Reports…** says what it does in the app's own words.

Changes: button label and its comment in `app/static/js/reports.js`, the name prompt ("Name for this saved report:"), and the one docs reference in `docs/nonprofit-module.md`. No API or behavior change.

## Test plan
- Reports → Profit & Loss: bottom button reads *Add to Saved Reports…*; clicking prompts for a name and the report appears under Saved Reports.
- No test references the old label (grep clean).