### PR TITLE
v2.9.3 — SimpleFIN request pinned to the guard-approved address (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
+### v2.9.3 — SimpleFIN request pinned to the address the guard approved
+
+**One security fix, right behind 2.9.2.** The SimpleFIN SSRF guard resolved
+the bridge hostname and refused private addresses, then the HTTP client
+resolved the name again to connect — a second DNS answer could steer the
+socket at a private service (DNS rebinding; CodeQL py/full-ssrf, #104,
+raised on the 2.9.2 pull request and wrongly dismissed as guarded). The
+request now connects to the address the guard checked, with the hostname
+kept for the Host header and TLS (the certificate is still verified against
+the hostname), and a response from a non-global peer is discarded.
+
 ### v2.9.2 — Security: HR and payroll are admin-only; payment row locks; Server Edition CSP; SimpleFIN on PostgreSQL
 
 **Security (Server Edition).** Four private reports arrived on the same
@@ -29,10 +40,6 @@ PostgreSQL cannot both pass the balance check and over-apply; an
 over-application that slips past the check is refused with 409 instead of a
 negative balance. Advisories GHSA-rh68-48w8-pj8r, GHSA-rh75-6834-f66j,
 GHSA-pwj7-6qq3-h4fj, GHSA-rm5h-555g-vpjj; fixed in 2.9.2.
-The SimpleFIN bridge request now connects to the address the SSRF guard
-approved (host header and SNI keep the hostname, the peer address is
-checked again after connect), closing the DNS-rebinding window between the
-guard's lookup and the connection's (CodeQL py/full-ssrf, #104).
 
 **Server Edition no longer serves the desktop's relaxed script policy to
 LAN browsers.** The launcher marks every server it starts as "desktop",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ PostgreSQL cannot both pass the balance check and over-apply; an
 over-application that slips past the check is refused with 409 instead of a
 negative balance. Advisories GHSA-rh68-48w8-pj8r, GHSA-rh75-6834-f66j,
 GHSA-pwj7-6qq3-h4fj, GHSA-rm5h-555g-vpjj; fixed in 2.9.2.
+The SimpleFIN bridge request now connects to the address the SSRF guard
+approved (host header and SNI keep the hostname, the peer address is
+checked again after connect), closing the DNS-rebinding window between the
+guard's lookup and the connection's (CodeQL py/full-ssrf, #104).
 
 **Server Edition no longer serves the desktop's relaxed script policy to
 LAN browsers.** The launcher marks every server it starts as "desktop",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -88,6 +88,7 @@ release that fixed them. Thank you to the reporters.
 | GHSA-rh75-6834-f66j | @hongshengy | 2.9.2 | bookkeeper could rewrite direct-deposit accounts and export NACHA |
 | GHSA-pwj7-6qq3-h4fj | @hongshengy | 2.9.2 | read-only could download pay stubs, W-2s and employee documents |
 | GHSA-rm5h-555g-vpjj | @furkan-arslan-sec | 2.9.2 | batch and bill payments took no row lock on the invoice or bill (PostgreSQL race) |
+| CodeQL alert 58 (py/full-ssrf), #104 | code scanning | 2.9.3 | SimpleFIN bridge request could be steered by DNS rebinding between the guard's lookup and the connection |
 
 ## Known considerations
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 # Single source of truth for the application version: app/main.py reports
 # it on the FastAPI app and /health, /api/system serves it to the frontend
 # footer, and the Windows release workflow parses it for the installer.
-__version__ = "2.9.2"
+__version__ = "2.9.3"

--- a/app/services/simplefin_service.py
+++ b/app/services/simplefin_service.py
@@ -101,6 +101,8 @@ def send(request: dict, timeout: float = DEFAULT_TIMEOUT) -> httpx.Response:
     address = _assert_public_https(request["url"])
     pinned_url, names = _pin(request["url"], address)
     try:
+        # follow_redirects=False is load-bearing: a redirect would resolve a
+        # new hostname and step straight around the pin. Keep it off.
         with httpx.Client(
             verify=True,
             follow_redirects=False,
@@ -116,16 +118,36 @@ def send(request: dict, timeout: float = DEFAULT_TIMEOUT) -> httpx.Response:
                 content=request.get("content"),
                 extensions={"sni_hostname": names["sni"]},
             )
+            # Peer check while the socket is still open (after the client
+            # closes, getpeername() is EBADF on Linux / WSAENOTSOCK on
+            # Windows — the 2.9.3 gate found exactly that). A stream that
+            # cannot report its peer is not evidence either way.
+            peer = _peer_address(response)
     except httpx.RequestError:
         logger.warning("SimpleFIN bridge request failed", exc_info=True)
         raise SimpleFINError("Could not reach the SimpleFIN bridge right now")
-    stream = response.extensions.get("network_stream")
-    peer = stream.get_extra_info("server_addr") if stream is not None else None
-    if peer and not ipaddress.ip_address(peer[0]).is_global:
+    if peer and not ipaddress.ip_address(peer).is_global:
         raise SimpleFINError(
             "Bridge host resolves to a private or local address — refusing"
         )
     return response
+
+
+def _peer_address(response: httpx.Response) -> str | None:
+    stream = response.extensions.get("network_stream")
+    if stream is None:
+        return None
+    try:
+        info = stream.get_extra_info("server_addr")
+    except (OSError, ValueError, AttributeError):
+        return None
+    if not info:
+        return None
+    try:
+        ipaddress.ip_address(info[0])
+    except (ValueError, IndexError, TypeError):
+        return None
+    return info[0]
 
 
 def decode_setup_token(setup_token: str) -> str:

--- a/app/services/simplefin_service.py
+++ b/app/services/simplefin_service.py
@@ -47,12 +47,15 @@ class SimpleFINError(Exception):
     """Raised with a user-safe message — never wraps raw exception text."""
 
 
-def _assert_public_https(url: str) -> None:
+def _assert_public_https(url: str) -> str:
     """SSRF guard: bridge URLs are user-supplied by design (self-hosted
     bridges are a feature), so before any request we require https and
     refuse hosts that resolve to non-public addresses — loopback, RFC1918,
     link-local/metadata, and friends. A hostile setup token must not be
-    able to point SlowBooks at localhost services or the LAN."""
+    able to point SlowBooks at localhost services or the LAN.
+
+    Returns the address that passed, so the caller connects to THAT address
+    and not to whatever a second lookup returns (DNS rebinding)."""
     parts = urlsplit(url)
     if parts.scheme != "https":
         raise SimpleFINError("Bridge URLs must use https")
@@ -63,38 +66,66 @@ def _assert_public_https(url: str) -> None:
         infos = socket.getaddrinfo(host, parts.port or 443, proto=socket.IPPROTO_TCP)
     except socket.gaierror:
         raise SimpleFINError("Could not resolve the bridge hostname")
+    if not infos:
+        raise SimpleFINError("Could not resolve the bridge hostname")
     for info in infos:
         ip = ipaddress.ip_address(info[4][0])
         if not ip.is_global:
             raise SimpleFINError(
                 "Bridge host resolves to a private or local address — refusing"
             )
+    return infos[0][4][0]
+
+
+def _pin(url: str, address: str) -> tuple[str, dict]:
+    """Rewrite `url` to connect to `address` while keeping the hostname for
+    the Host header and TLS (SNI + certificate check), so the socket cannot
+    be steered elsewhere by a second DNS answer."""
+    parts = urlsplit(url)
+    host = parts.hostname or ""
+    ip = ipaddress.ip_address(address)
+    netloc = f"[{address}]" if ip.version == 6 else address
+    if parts.port:
+        netloc += f":{parts.port}"
+    pinned = urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+    return pinned, {"host": host, "sni": host}
 
 
 def send(request: dict, timeout: float = DEFAULT_TIMEOUT) -> httpx.Response:
     """Execute a request dict from a build_* function (hardened defaults).
 
     Every outbound URL passes the SSRF guard first — this is the single
-    network chokepoint for the SimpleFIN feature."""
-    _assert_public_https(request["url"])
+    network chokepoint for the SimpleFIN feature — and the connection is
+    made to the address the guard approved (host header and SNI keep the
+    hostname), then the peer address is checked once more after connect."""
+    address = _assert_public_https(request["url"])
+    pinned_url, names = _pin(request["url"], address)
     try:
         with httpx.Client(
             verify=True,
             follow_redirects=False,
             timeout=timeout,
-            headers={"User-Agent": "slowbooks-bankfeed"},
+            headers={"User-Agent": "slowbooks-bankfeed", "Host": names["host"]},
             trust_env=False,
         ) as client:
-            return client.request(
+            response = client.request(
                 request["method"],
-                request["url"],
+                pinned_url,
                 params=request.get("params"),
                 auth=request.get("auth"),
                 content=request.get("content"),
+                extensions={"sni_hostname": names["sni"]},
             )
     except httpx.RequestError:
         logger.warning("SimpleFIN bridge request failed", exc_info=True)
         raise SimpleFINError("Could not reach the SimpleFIN bridge right now")
+    stream = response.extensions.get("network_stream")
+    peer = stream.get_extra_info("server_addr") if stream is not None else None
+    if peer and not ipaddress.ip_address(peer[0]).is_global:
+        raise SimpleFINError(
+            "Bridge host resolves to a private or local address — refusing"
+        )
+    return response
 
 
 def decode_setup_token(setup_token: str) -> str:

--- a/app/static/whats-new.json
+++ b/app/static/whats-new.json
@@ -1,4 +1,10 @@
 {
+  "2.9.3": {
+    "title": "SimpleFIN request pinned to the checked address",
+    "items": [
+      "The bank-feed bridge request connects to the address the SSRF guard approved, closing a DNS-rebinding window; certificate checks stay on the hostname"
+    ]
+  },
   "2.9.2": {
     "title": "Security: HR and payroll are admin-only; Server Edition policy, SimpleFIN on PostgreSQL, credit-card feeds",
     "items": [

--- a/tests/test_simplefin.py
+++ b/tests/test_simplefin.py
@@ -6,6 +6,8 @@ import json
 from datetime import date
 from decimal import Decimal
 
+import socket
+
 import httpx
 import pytest
 
@@ -324,3 +326,98 @@ def test_ssrf_guard_rejects_non_public(url):
 def test_ssrf_guard_allows_public_literal():
     # Literal public IP: getaddrinfo resolves numerically, no DNS involved
     sf._assert_public_https("https://1.1.1.1/simplefin")
+
+
+# ---------------------------------------------------------------------------
+# DNS rebinding: the request must go to the address the guard approved.
+# ---------------------------------------------------------------------------
+
+
+def _fake_getaddrinfo(ip):
+    def gai(host, port, *a, **kw):
+        fam = socket.AF_INET6 if ":" in ip else socket.AF_INET
+        return [(fam, socket.SOCK_STREAM, 6, "", (ip, port))]
+
+    return gai
+
+
+class _Stream:
+    def __init__(self, peer):
+        self.peer = peer
+
+    def get_extra_info(self, name):
+        return self.peer if name == "server_addr" else None
+
+
+def test_send_pins_the_connection_to_the_approved_address(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("93.184.216.34"))
+
+    def fake_request(self, method, url, **kw):
+        seen.update(
+            method=method,
+            url=str(url),
+            headers=dict(self.headers),
+            ext=kw.get("extensions"),
+        )
+        return httpx.Response(
+            200,
+            text="ok",
+            extensions={"network_stream": _Stream(("93.184.216.34", 443))},
+        )
+
+    monkeypatch.setattr(httpx.Client, "request", fake_request)
+    r = sf.send(
+        {"method": "GET", "url": "https://bridge.example.com/simplefin/accounts"}
+    )
+    assert r.status_code == 200
+    assert seen["url"] == "https://93.184.216.34/simplefin/accounts"
+    assert seen["headers"]["host"] == "bridge.example.com"
+    assert seen["ext"] == {"sni_hostname": "bridge.example.com"}
+
+
+def test_send_pins_ipv6_with_brackets_and_keeps_the_port(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        socket, "getaddrinfo", _fake_getaddrinfo("2606:2800:220:1:248:1893:25c8:1946")
+    )
+
+    def fake_request(self, method, url, **kw):
+        seen["url"] = str(url)
+        return httpx.Response(200, text="ok")
+
+    monkeypatch.setattr(httpx.Client, "request", fake_request)
+    sf.send(
+        {
+            "method": "GET",
+            "url": "https://bridge.example.com:8443/simplefin/accounts?x=1",
+        }
+    )
+    assert (
+        seen["url"]
+        == "https://[2606:2800:220:1:248:1893:25c8:1946]:8443/simplefin/accounts?x=1"
+    )
+
+
+def test_send_refuses_when_the_socket_landed_on_a_private_peer(monkeypatch):
+    """Belt and braces after connect: if the peer is not the public address
+    the guard approved, the response is discarded."""
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("93.184.216.34"))
+    monkeypatch.setattr(
+        httpx.Client,
+        "request",
+        lambda self, m, u, **kw: httpx.Response(
+            200,
+            text="secret",
+            extensions={"network_stream": _Stream(("10.0.0.5", 443))},
+        ),
+    )
+    with pytest.raises(sf.SimpleFINError):
+        sf.send(
+            {"method": "GET", "url": "https://bridge.example.com/simplefin/accounts"}
+        )
+
+
+def test_guard_returns_the_address_it_checked(monkeypatch):
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("93.184.216.34"))
+    assert sf._assert_public_https("https://bridge.example.com/x") == "93.184.216.34"

--- a/tests/test_simplefin.py
+++ b/tests/test_simplefin.py
@@ -421,3 +421,78 @@ def test_send_refuses_when_the_socket_landed_on_a_private_peer(monkeypatch):
 def test_guard_returns_the_address_it_checked(monkeypatch):
     monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("93.184.216.34"))
     assert sf._assert_public_https("https://bridge.example.com/x") == "93.184.216.34"
+
+
+class _ClosedStream:
+    """What the real stream looks like once the client has closed: the
+    2.9.3 gate found send() calling getpeername() on a dead socket."""
+
+    def get_extra_info(self, name):
+        raise OSError(9, "Bad file descriptor")
+
+
+def test_send_survives_a_stream_that_cannot_report_its_peer(monkeypatch):
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("93.184.216.34"))
+    monkeypatch.setattr(
+        httpx.Client,
+        "request",
+        lambda self, m, u, **kw: httpx.Response(
+            200, text="ok", extensions={"network_stream": _ClosedStream()}
+        ),
+    )
+    assert (
+        sf.send({"method": "GET", "url": "https://bridge.example.com/x"}).status_code
+        == 200
+    )
+
+
+def test_peer_is_read_before_the_client_closes(monkeypatch):
+    """The peer check must run inside the client's context: a stream that
+    only answers while the client is open must be enough."""
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("93.184.216.34"))
+    state = {"open": False}
+
+    class _LiveStream:
+        def get_extra_info(self, name):
+            if not state["open"]:
+                raise OSError(9, "Bad file descriptor")
+            return ("93.184.216.34", 443)
+
+    real_enter, real_exit = httpx.Client.__enter__, httpx.Client.__exit__
+
+    def enter(self):
+        state["open"] = True
+        return real_enter(self)
+
+    def exit_(self, *a):
+        state["open"] = False
+        return real_exit(self, *a)
+
+    monkeypatch.setattr(httpx.Client, "__enter__", enter)
+    monkeypatch.setattr(httpx.Client, "__exit__", exit_)
+    monkeypatch.setattr(
+        httpx.Client,
+        "request",
+        lambda self, m, u, **kw: httpx.Response(
+            200, text="ok", extensions={"network_stream": _LiveStream()}
+        ),
+    )
+    assert (
+        sf.send({"method": "GET", "url": "https://bridge.example.com/x"}).status_code
+        == 200
+    )
+
+    # and a private peer seen while open is still refused
+    class _PrivateStream:
+        def get_extra_info(self, name):
+            return ("10.0.0.5", 443) if state["open"] else None
+
+    monkeypatch.setattr(
+        httpx.Client,
+        "request",
+        lambda self, m, u, **kw: httpx.Response(
+            200, text="secret", extensions={"network_stream": _PrivateStream()}
+        ),
+    )
+    with pytest.raises(sf.SimpleFINError):
+        sf.send({"method": "GET", "url": "https://bridge.example.com/x"})


### PR DESCRIPTION
Closes #104 (CodeQL alert 58, py/full-ssrf). `_assert_public_https()` resolved the bridge hostname and refused non-global addresses, then httpx resolved the name again to connect — a second DNS answer could steer the socket at a private service. The guard now returns the address it checked; `send()` connects to that address with the hostname kept for the Host header and SNI (certificate still verified against the hostname) and refuses the response if the peer address is non-global anyway.

Tests: pinned URL for IPv4 and bracketed IPv6 with port, Host + `sni_hostname` carry the hostname, private peer refused, guard returns what it checked. Live check against the real SimpleFIN host: pinned request 200, wrong SNI refused at the handshake. Suite: 1907 passed.

Ships in the release the owner names (re-cut 2.9.2 or 2.9.3); gated in the testing repo either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DaDm82ccTQi7awPEQrrW3