### PR TITLE
fix(companies): migrate + seed new Postgres company DBs (alembic head + chart of accounts)

### DIFF
--- a/app/services/company_service.py
+++ b/app/services/company_service.py
@@ -486,12 +486,13 @@ def create_company(
             conn.exec_driver_sql(f"CREATE DATABASE {quoted_db_name}")
         system_engine.dispose()
 
-        # Create schema on the new database
-        new_engine = create_engine(base_url + database_name)
-        from app.database import Base
-
-        Base.metadata.create_all(new_engine)
-        new_engine.dispose()
+        # Bring the new database to the current schema and seed it
+        # (alembic upgrade head + Chart of Accounts), matching what the
+        # SQLite path (manifest_create_company) and the Docker entrypoint
+        # both do. A create_all-only database would boot with zero accounts
+        # and no alembic version stamp, so future upgrades would not apply
+        # cleanly.
+        _init_company_db(base_url + database_name)
 
         # Register in master DB
         company = Company(

--- a/tests/test_company_service_dbname.py
+++ b/tests/test_company_service_dbname.py
@@ -51,9 +51,33 @@ def test_create_company_quotes_db_name_via_dialect():
 
     with patch("app.services.company_service._is_sqlite", return_value=False), patch(
         "app.services.company_service.create_engine", return_value=engine
-    ), patch("app.services.company_service._base_url", return_value="postgresql://x/"):
+    ), patch("app.services.company_service._base_url", return_value="postgresql://x/"), patch(
+        "app.services.company_service._init_company_db"
+    ) as init_db:
         result = create_company(db, "Acme", "acme_books")
 
     assert result["success"] is True
     conn.dialect.identifier_preparer.quote.assert_called_once_with("acme_books")
     conn.exec_driver_sql.assert_called_once_with('CREATE DATABASE "acme_books"')
+    # The new database must be migrated + seeded (alembic head + CoA),
+    # not just create_all'd — a bare schema leaves zero accounts and no
+    # alembic stamp.
+    init_db.assert_called_once_with("postgresql://x/acme_books")
+
+
+def test_create_company_seeds_new_database():
+    """Postgres path runs the same migrate+seed init as the SQLite path."""
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+
+    with patch("app.services.company_service._is_sqlite", return_value=False), patch(
+        "app.services.company_service.create_engine"
+    ), patch(
+        "app.services.company_service._base_url", return_value="postgresql://x/"
+    ), patch(
+        "app.services.company_service._init_company_db"
+    ) as init_db:
+        result = create_company(db, "Acme", "acme_books")
+
+    assert result["success"] is True
+    init_db.assert_called_once_with("postgresql://x/acme_books")


### PR DESCRIPTION
# fix(companies): migrate + seed new Postgres company DBs

## Summary

The Postgres path of `create_company()` built the new company database with `Base.metadata.create_all()` only. That produces a database with:

- **No Chart of Accounts.** Zero accounts, so invoices, journal entries, and reports fail until accounts are added by hand.
- **No alembic version stamp.** Future `alembic upgrade head` runs do not behave like upgrades on that database.

The SQLite path (`manifest_create_company`) already runs the shared `_init_company_db()` helper — alembic `upgrade head`, the `CHART_OF_ACCOUNTS` seed, and default asset types — and the Docker entrypoint does the same for the primary database. This PR makes the Postgres path use the same helper.

## Reproduction (v2.9.4, Postgres deployment)

1. Create a new company via Companies (Postgres mode).
2. Open the company — the chart of accounts is empty (0 accounts).
3. `alembic current` on that database returns empty — it was never stamped.

## Fix

Replace the `create_all` block in `create_company()` with a call to the existing `_init_company_db(base_url + database_name)` helper.

## Tests

- Updated `test_create_company_quotes_db_name_via_dialect` to assert `_init_company_db` is called with the new database URL. Previously the patch target would have been silently bypassed — the existing test still passed with the bug present.
- Added `test_create_company_seeds_new_database`, locking the migrate-and-seed call.
- Target file: 5/5 pass. Neighboring suites (`test_desktop_mode.py`, `test_server_mode.py`): 46 passed.
- Full suite: 1,913 passed, 7 skipped, 1 pre-existing failure (`test_scan_pdf_without_poppler_400` — fails identically on clean `main` without this change; local poppler environment issue).
- Verified against a live Postgres deployment (Docker, v2.9.4): a company created before the fix had 0 accounts and no stamp; after re-initializing through the fixed path, the database carries the full seeded chart of accounts (57 accounts) and a current alembic stamp.
