### PR TITLE
README: a What's New section for v2.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,26 @@ Details, known gaps and how to report a barrier:
 
 ## What's New
 
+**v2.10 — The bank register is the ledger.** A payment typed into a
+checking account's register now moves that account in the general ledger,
+because the register *is* the ledger: bank and credit-card accounts are
+flagged on the chart, the register is that account's posted lines with a
+running balance, and every document you post — expense, deposit, bill
+payment, payroll — appears in it. Statement lines from a feed or an import
+no longer post silently; each one looks for the entry you already made and
+matches it, and the rest wait in **To review** until you add them with a
+category, match them by hand, or exclude them. Transfers are a document, so
+paying a credit card is a transfer and the amount owed falls. Reconciliation
+ticks ledger lines and locks what it closed. Upgrading a file keeps its old
+register balance and shows it once, to post as an opening balance or
+dismiss — the upgrade itself writes nothing to your ledger. Guide:
+[docs/banking.md](docs/banking.md).
+
+Also in 2.10: **PDF receipts scan on Windows and macOS with nothing to
+install** (the operating system renders the page; poppler-utils is the Linux
+path), and the cash flow statement now follows the journals that actually
+move cash.
+
 **v2.9 — Nonprofit mode.** One switch in Settings and a church, a club, a
 PTO or a community arts group sees its own words — donors, pledges,
 donations, funds, grants — and gets the documents every treasurer and
@@ -105,7 +125,7 @@ a native `.app` in a DMG, no Docker or Python required.
 [SimpleFIN](https://www.simplefin.org/) — you hold the bank credential,
 no middleman server, dedup + bank rules on arrival
 ([docs/setup-bank-feeds.md](docs/setup-bank-feeds.md)). Every install
-also serves a self-documenting local REST API (483 operations in v2.9); point
+also serves a self-documenting local REST API (499 operations in v2.10); point
 Claude Code or any agentic CLI at it —
 [slowbookspro.com/ai](https://www.slowbookspro.com/ai/) has the
 paste-prompt.


### PR DESCRIPTION
The README's What's New still opened on v2.9 after the release. Adds the v2.10 section — the register is the ledger, the review queue, transfers, reconciliation over ledger lines, and what an upgraded file does with its old register balance — pointing at `docs/banking.md`. Carries the two other user-visible items (PDF receipts scanning natively on Windows and macOS; the cash flow statement following the journals that move cash) as a short second paragraph rather than their own headings.

Also updates the API operation count in the v2.4 paragraph: 483 in v2.9 → **499** in v2.10, counted off the built app's OpenAPI document, matching the figure now on slowbookspro.com.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DaDm82ccTQi7awPEQrrW3