### PR TITLE
v2.10.1 — a document is never accepted without its journal entry (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
+### v2.10.1 — A document is never accepted without its journal entry
+
+**A saved invoice that never reached the books is worse than a rejected
+one.** wilsons043 reported (issue #119, against the signed 2.10.0 Windows
+release) that renumbering Accounts Receivable away from 1100 made every
+later invoice, payment, credit memo and estimate post *no journal entry* —
+while still returning success and still appearing in the A/R aging. The same
+thing happened on the payables side with Accounts Payable and 2000. The
+sub-ledger and the general ledger drifted apart with nothing shown to the
+operator.
+
+Two independent faults produced it, and both are fixed.
+
+**The chart no longer lets you renumber an account the software posts to.**
+Fifteen account numbers are resolved by literal value somewhere in the
+code — not the six in the original report, which is why the fix is a
+registry rather than a patch at one site. Changing the number or the type of
+one of those is refused with a message naming the account and what it is
+used for. **Renaming stays allowed**, because only the number is
+load-bearing: an accountant relabelling 1100 as "Trade Debtors" was never
+the problem. The guard is deliberately *not* keyed on the system-account
+flag, since every seeded account carries it and renumbering an ordinary
+expense account is a reasonable request.
+
+**A posting that cannot resolve its account now stops.** The resolvers
+returned `None` on a miss and their callers read that as "skip the journal
+entry" — twenty places did this, covering both receivables and payables and
+both manual entry and import. They raise now, and the request answers **409**
+naming the missing account, with nothing written. This is the half that
+matters: renumbering was only the easiest way to reach a fail-open that the
+recurring-invoice and unattended import paths could also have hit.
+
+**Opening a company file now says if its chart is incomplete**, rather than
+waiting for the first document to fail. That also closes a second route the
+reporter found: a company bootstrapped outside the normal path has no chart
+at all and used to accept documents that posted nothing.
+
+*Why nothing caught this.* Through all of it the trial balance **balanced** —
+debits equalled credits to the cent, because the ledger stayed internally
+consistent and was simply missing an entry. Our three-platform release gate
+compares trial balances every release and would have passed this every time.
+Only tying a control account to its sub-ledger finds it. The regression test
+asserts that tie-out, not the balance.
+
+Thanks to wilsons043 for a report that included a clean reproduction, the
+root cause, and the sixteen call sites they had read but not run.
+
 ### v2.10.0 — The bank register is the ledger
 
 **A register entry moves the general ledger, and the register shows what the

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 # Single source of truth for the application version: app/main.py reports
 # it on the FastAPI app and /health, /api/system serves it to the frontend
 # footer, and the Windows release workflow parses it for the installer.
-__version__ = "2.10.0"
+__version__ = "2.10.1"

--- a/app/main.py
+++ b/app/main.py
@@ -29,6 +29,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from fastapi.exception_handlers import http_exception_handler
 
 from app.services import storage
+from app.services.control_accounts import MissingControlAccount
 from app.services.rate_limit import limiter
 
 from app.routes import (
@@ -243,6 +244,30 @@ async def lifespan(app: FastAPI):
         warn_if_manifest_missing()
     except Exception:
         pass  # a diagnostic, never a reason not to boot
+    # Issue #119: say once, at boot, if this company's chart is missing an
+    # account the posting code resolves by number. Before 2.10.1 the first
+    # symptom was a document that looked saved and never reached the ledger;
+    # now the posting refuses, and this is the warning that gets ahead of it.
+    # A diagnostic, never fatal — refusing to boot would lock an operator out
+    # of the very chart they need to repair.
+    try:
+        from app.services.control_accounts import missing as _missing_controls
+
+        _db = SessionLocal()
+        try:
+            gaps = _missing_controls(_db)
+        finally:
+            _db.close()
+        if gaps:
+            logging.getLogger(__name__).warning(
+                "chart of accounts is missing %d control account(s): %s — "
+                "documents that need them will be refused (409) until they are "
+                "restored with these exact numbers",
+                len(gaps),
+                ", ".join(f"{n} {name}" for n, name in gaps),
+            )
+    except Exception:
+        pass  # a diagnostic, never a reason not to boot
     # At-rest upgrade: encrypt any legacy plaintext credential rows (SMTP,
     # payment, QBO, SimpleFIN secrets) on first boot after upgrading.
     try:
@@ -323,6 +348,24 @@ async def _method_not_allowed_handler(request: Request, exc: StarletteHTTPExcept
 
 
 app.add_exception_handler(StarletteHTTPException, _method_not_allowed_handler)
+
+
+# ---- Missing control account (issue #119) ----
+# A posting path that cannot resolve the account it must debit or credit
+# now raises instead of silently skipping its journal entry. Answer 409 —
+# the request was valid, the company's chart is not — and name the account
+# so the operator can restore it. Nothing was written: the raise happens
+# before any journal line is built.
+async def _missing_control_account_handler(request: Request, exc: Exception):
+    logging.getLogger(__name__).warning(
+        "posting refused: control account %s (%s) missing from the chart",
+        getattr(exc, "number", "?"),
+        getattr(exc, "name", "?"),
+    )
+    return JSONResponse(status_code=409, content={"detail": str(exc)})
+
+
+app.add_exception_handler(MissingControlAccount, _missing_control_account_handler)
 
 # ---- CORS (Phase 9.7: locked down) ----
 # Wildcard origins with credentials is a CSRF amplifier. Default to just

--- a/app/routes/accounts.py
+++ b/app/routes/accounts.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.models.accounts import Account
+from app.services import control_accounts
 from app.models.transactions import TransactionLine
 from app.schemas.accounts import AccountCreate, AccountUpdate, AccountResponse
 from app.routes._helpers import get_or_404
@@ -95,6 +96,26 @@ def create_account(data: AccountCreate, db: Session = Depends(get_db)):
 def update_account(account_id: int, data: AccountUpdate, db: Session = Depends(get_db)):
     account = get_or_404(db, Account, account_id)
     fields = data.model_dump(exclude_unset=True)
+
+    # Issue #119: the posting code resolves these accounts BY NUMBER, so
+    # renumbering one makes every later document skip its journal entry —
+    # silently, with a trial balance that still balances. Renaming is fine
+    # and stays allowed; only the number and the type are load-bearing.
+    # (Not gated on is_system: every seeded account carries that flag, and
+    # renumbering an ordinary expense account is a reasonable request.)
+    if control_accounts.is_control_number(account.account_number):
+        name, purpose = control_accounts.describe(account.account_number)
+        for field, what in (("account_number", "number"), ("account_type", "type")):
+            if field in fields and fields[field] != getattr(account, field):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"{account.account_number} {name} is a control account — "
+                        f"the software finds it by its number to post {purpose}. "
+                        f"Changing its {what} would stop new documents reaching "
+                        f"the ledger. You can rename it."
+                    ),
+                )
 
     if "account_number" in fields:
         _reject_duplicate_number(db, fields["account_number"], exclude_id=account_id)

--- a/app/services/accounting.py
+++ b/app/services/accounting.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from app.models.transactions import Transaction, TransactionLine
 from app.models.accounts import Account, AccountType
+from app.services import control_accounts
 
 CENT = Decimal("0.01")
 
@@ -234,40 +235,41 @@ def create_journal_entry(
     return txn
 
 
+# The control-account resolvers RAISE when the account is missing; they never
+# return None (issue #119). A caller that treated None as "skip the journal
+# entry" produced a document that looked saved and never reached the books —
+# with a trial balance that still balanced, so nothing downstream noticed.
+# See app/services/control_accounts.py for the registry and the reasoning.
+
+
 def get_ar_account_id(db: Session) -> int:
-    """Get Accounts Receivable account ID (1100)."""
-    acct = db.query(Account).filter(Account.account_number == "1100").first()
-    return acct.id if acct else None
+    """Accounts Receivable (1100). Raises MissingControlAccount."""
+    return control_accounts.resolve(db, "1100")
 
 
 def get_default_income_account_id(db: Session) -> int:
-    """Get default Service Income account ID (4000)."""
-    acct = db.query(Account).filter(Account.account_number == "4000").first()
-    return acct.id if acct else None
+    """Default Service Income (4000). Raises MissingControlAccount."""
+    return control_accounts.resolve(db, "4000")
 
 
 def get_sales_tax_account_id(db: Session) -> int:
-    """Get Sales Tax Payable account ID (2200)."""
-    acct = db.query(Account).filter(Account.account_number == "2200").first()
-    return acct.id if acct else None
+    """Sales Tax Payable (2200). Raises MissingControlAccount."""
+    return control_accounts.resolve(db, "2200")
 
 
 def get_undeposited_funds_id(db: Session) -> int:
-    """Get Undeposited Funds account ID (1200)."""
-    acct = db.query(Account).filter(Account.account_number == "1200").first()
-    return acct.id if acct else None
+    """Undeposited Funds (1200). Raises MissingControlAccount."""
+    return control_accounts.resolve(db, "1200")
 
 
 def get_ap_account_id(db: Session) -> int:
-    """Get Accounts Payable account ID (2000)."""
-    acct = db.query(Account).filter(Account.account_number == "2000").first()
-    return acct.id if acct else None
+    """Accounts Payable (2000). Raises MissingControlAccount."""
+    return control_accounts.resolve(db, "2000")
 
 
 def get_cc_account_id(db: Session) -> int:
-    """Get Credit Card Payable account ID (2100)."""
-    acct = db.query(Account).filter(Account.account_number == "2100").first()
-    return acct.id if acct else None
+    """Credit Card (2100). Raises MissingControlAccount."""
+    return control_accounts.resolve(db, "2100")
 
 
 def get_opening_balance_equity_id(db: Session) -> int:

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -76,7 +76,7 @@ def get_session_secret() -> str:
     key_path = Path(__file__).resolve().parents[2] / ".slowbooks-session.key"
     if key_path.exists():
         try:
-            existing = key_path.read_text().strip()
+            existing = key_path.read_text(encoding="utf-8").strip()
             if existing:
                 logger.info("session secret loaded from %s", key_path)
                 return existing
@@ -98,7 +98,7 @@ def get_session_secret() -> str:
         logger.warning("could not persist session secret to %s: %s", key_path, exc)
     if key_path.exists():
         try:
-            existing = key_path.read_text().strip()
+            existing = key_path.read_text(encoding="utf-8").strip()
             if existing:
                 if persisted:
                     logger.info("new session secret written to %s", key_path)

--- a/app/services/control_accounts.py
+++ b/app/services/control_accounts.py
@@ -1,0 +1,157 @@
+"""Control accounts — the accounts the posting code resolves BY NUMBER.
+
+Issue #119 (wilsons043, against the v2.10.0 release): renumbering Accounts
+Receivable away from 1100 made every later invoice post no journal entry.
+The document was still accepted with a 201 and still appeared in the A/R
+aging, so the sub-ledger and the general ledger drifted apart in silence.
+Two independent faults produced that:
+
+  1. `PUT /api/accounts/{id}` let the number of a structural account change.
+  2. The resolvers returned None on a miss, and their callers read None as
+     "skip the journal entry" rather than as an error.
+
+The second is the dangerous one — the renumbering was only the easiest way
+to reach it. A blank chart of accounts, reachable by bootstrapping from
+source outside `manifest_create_company()`, gets there from a different
+direction and posts nothing at all.
+
+Note what the trial balance does while this happens: it BALANCES. Debits
+equal credits to the cent, because the ledger is internally consistent — it
+is simply missing an entry that should exist. No amount of checking the
+ledger against itself can find this; only tying the control account to its
+sub-ledger can. That is why the fix is to refuse, not to detect.
+
+**This registry is the single authority** for which numbers are structural.
+The route guard reads it to decide what may be renumbered, the resolvers
+read it to raise a message naming the account, and the startup check reads
+it to tell an operator what a company file is missing.
+
+The real fix is a `role` column on Account so posting resolves by role and
+a chart can be renumbered freely. That is a schema change and belongs in a
+minor release, not a patch; until then the honest behaviour is to refuse
+the edit and say why.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.accounts import Account
+
+
+class MissingControlAccount(LookupError):
+    """A required control account is not in this company's chart.
+
+    Raised instead of returning None so a posting path cannot quietly skip
+    its journal entry. `app/main.py` renders it as a 409 naming the account,
+    which is actionable: the operator fixes the chart and retries.
+    """
+
+    def __init__(self, number: str, name: str, purpose: str = ""):
+        self.number = number
+        self.name = name
+        self.purpose = purpose
+        detail = (
+            f"The account this posting needs is missing from the chart of "
+            f"accounts: {number} {name}."
+        )
+        if purpose:
+            detail += f" It is used for {purpose}."
+        detail += (
+            " Restore it with that exact number (Chart of Accounts → New "
+            "Account), then try again. Nothing was posted."
+        )
+        super().__init__(detail)
+
+
+# number -> (name as seeded, what the posting code uses it for)
+#
+# Every entry here is resolved by literal number somewhere in app/. Renaming
+# one is safe; renumbering it is not, which is what the route guard enforces.
+CONTROL_ACCOUNTS: dict[str, tuple[str, str]] = {
+    "1000": ("Checking", "the default bank account for deposits and payments"),
+    "1100": ("Accounts Receivable", "what customers owe — every invoice and payment"),
+    "1200": ("Undeposited Funds", "payments received but not yet deposited"),
+    "1300": ("Inventory", "the inventory asset behind item purchases and sales"),
+    "2000": ("Accounts Payable", "what you owe vendors — every bill and bill payment"),
+    "2100": ("Credit Card", "credit-card charges and the card's balance"),
+    "2200": ("Sales Tax Payable", "sales tax collected on invoices and receipts"),
+    "3200": (
+        "Retained Earnings",
+        "the balancing account for imported opening balances",
+    ),
+    "4000": ("Service Income", "the default income account for invoice lines"),
+    "4800": ("Late Fee Income", "finance charges added to overdue invoices"),
+    "5000": ("Cost of Goods Sold", "the cost side of an inventory item's sale"),
+    "5900": ("Inventory Adjustments", "write-offs and quantity corrections"),
+    "6000": ("Advertising & Marketing", "the default expense account for bill lines"),
+    "6120": ("Payroll Tax Expense", "employer taxes posted by job costing"),
+    "6150": ("Employee Benefits Expense", "benefit costs posted by job costing"),
+}
+
+
+def is_control_number(number: str | None) -> bool:
+    return bool(number) and str(number) in CONTROL_ACCOUNTS
+
+
+def describe(number: str) -> tuple[str, str]:
+    """(name, purpose) for a control number; ("", "") if it is not one."""
+    return CONTROL_ACCOUNTS.get(str(number), ("", ""))
+
+
+def resolve(db: Session, number: str) -> int:
+    """The id of a control account, or raise.
+
+    Never returns None. A caller that wants tolerance — a report, an export
+    that only needs a display name — calls `find` instead and says so.
+    """
+    acct = db.query(Account).filter(Account.account_number == str(number)).first()
+    if acct is None:
+        name, purpose = describe(number)
+        raise MissingControlAccount(str(number), name or "control account", purpose)
+    return acct.id
+
+
+def find(db: Session, number: str) -> int | None:
+    """The id of an account by number, or None — for the paths that are
+    genuinely tolerant (display names in exports, a report that shows a
+    zero). Never use this where a journal entry depends on the result."""
+    acct = db.query(Account).filter(Account.account_number == str(number)).first()
+    return acct.id if acct else None
+
+
+def seeded_numbers() -> set[str]:
+    """The control accounts the standard chart actually creates.
+
+    4800 Late Fee Income and 5900 Inventory Adjustments are created on
+    demand by the code that needs them, so a healthy chart legitimately
+    lacks them — the boot check must not cry wolf about those. They stay in
+    the registry because they are still resolved by number, so renumbering
+    one once it exists is still a trap the route guard should refuse.
+    """
+    from app.seed.chart_of_accounts import CHART_OF_ACCOUNTS
+
+    seeded = {entry["account_number"] for entry in CHART_OF_ACCOUNTS}
+    return {n for n in CONTROL_ACCOUNTS if n in seeded}
+
+
+def missing(db: Session) -> list[tuple[str, str]]:
+    """[(number, name)] for every SEEDED control account absent from this
+    chart — what a company file should have and does not.
+
+    The boot check reports these once rather than waiting for the first
+    document to fail, and it is what catches a chart that was never seeded
+    at all (issue #119, reporter's note 1).
+    """
+    expected = seeded_numbers()
+    present = {
+        n
+        for (n,) in db.query(Account.account_number)
+        .filter(Account.account_number.in_(expected))
+        .all()
+    }
+    return [
+        (number, CONTROL_ACCOUNTS[number][0])
+        for number in CONTROL_ACCOUNTS
+        if number in expected and number not in present
+    ]

--- a/app/services/iif_export.py
+++ b/app/services/iif_export.py
@@ -653,9 +653,10 @@ def export_bills(db: Session, date_from: date = None, date_to: date = None) -> s
     each SPL the expense debit (positive); the importer reads abs() so
     either sign re-imports."""
     from app.models.bills import Bill, BillStatus
-    from app.services.accounting import get_ap_account_id
+    from app.services.control_accounts import find
 
-    ap_name = _resolve_account_name(db, get_ap_account_id(db)) or "Accounts Payable"
+    # Display name only: an export must not fail because a chart is odd.
+    ap_name = _resolve_account_name(db, find(db, "2000")) or "Accounts Payable"
     q = (
         db.query(Bill)
         .options(joinedload(Bill.vendor), joinedload(Bill.lines))
@@ -780,11 +781,9 @@ def export_sales_receipts(
     and the tax line (negative) — the shape the importer creates a paid
     invoice + same-day payment from."""
     from app.models.payments import Payment
-    from app.services.accounting import get_undeposited_funds_id
+    from app.services.control_accounts import find
 
-    default_dep = (
-        _resolve_account_name(db, get_undeposited_funds_id(db)) or "Undeposited Funds"
-    )
+    default_dep = _resolve_account_name(db, find(db, "1200")) or "Undeposited Funds"
     q = (
         db.query(Invoice)
         .options(

--- a/app/static/whats-new.json
+++ b/app/static/whats-new.json
@@ -1,4 +1,12 @@
 {
+  "2.10.1": {
+    "title": "A document is never accepted without its journal entry",
+    "items": [
+      "Renumbering an account the software posts to — Accounts Receivable, Accounts Payable and thirteen others — is refused instead of quietly breaking new documents; renaming is still yours to do",
+      "A posting that cannot find the account it needs now stops and names it, rather than saving a document that never reached the ledger",
+      "Opening a company file says once if its chart of accounts is missing an account the books depend on"
+    ]
+  },
   "2.10.0": {
     "title": "The bank register is the ledger",
     "items": [

--- a/docs/features.md
+++ b/docs/features.md
@@ -35,6 +35,7 @@ pass, and the per-integration setup guides ([Stripe](setup-stripe.md),
 - **Manual Journal Entries** — Full CRUD for manual journal entries with dynamic line rows, running debit/credit totals, balance indicator, and void with reversing entries
 - **Auto Journal Entries** — Every invoice, payment, bill, and payroll run automatically creates balanced journal entries. Void creates reversing entries
 - **Chart of Accounts** — 39+ seeded accounts (Contractor template), 6 account types (asset, liability, equity, income, COGS, expense)
+- **Control accounts** — Fifteen accounts are found by their number when a document posts: 1000 Checking, 1100 Accounts Receivable, 1200 Undeposited Funds, 1300 Inventory, 2000 Accounts Payable, 2100 Credit Card, 2200 Sales Tax Payable, 3200 Retained Earnings, 4000 Service Income, 4800 Late Fee Income, 5000 Cost of Goods Sold, 5900 Inventory Adjustments, 6000 Advertising & Marketing, 6120 Payroll Tax Expense, 6150 Employee Benefits Expense. **You can rename any of them**; changing the number or the type is refused, because a document that cannot find its control account would have nowhere to post. Every other account, seeded or not, can be renumbered freely. A posting that cannot resolve a control account fails with a 409 naming it and writes nothing — it never saves a document that skipped the ledger (issue #119)
 - **Closing Date Enforcement** — Prevent modifications to transactions before a configurable closing date with optional password protection
 - **Audit Log** — Automatic logging of all create/update/delete operations with old/new value tracking via SQLAlchemy event hooks
 - **Account Balances** — Updated in real-time as transactions post
@@ -434,7 +435,7 @@ All endpoints under `/api/`. Swagger docs at `/docs`. 300+ routes across 50 rout
 | `/api/settings` | GET, PUT | Company settings |
 | `/api/settings/test-email` | POST | Send SMTP test email |
 | `/api/search` | GET | Unified search across all entities |
-| `/api/accounts` | GET, POST, PUT, DELETE | Chart of Accounts CRUD |
+| `/api/accounts` | GET, POST, PUT, DELETE | Chart of Accounts CRUD. `?bank=1` filters to bank/card accounts. PUT refuses the number or type of a control account (400) and DELETE refuses a system account |
 | `/api/customers` | GET, POST, PUT, DELETE | Customer management |
 | `/api/vendors` | GET, POST, PUT, DELETE | Vendor management |
 | `/api/items` | GET, POST, PUT, DELETE | Items & services |

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -20,7 +20,9 @@ TEMPLATES = sorted(glob.glob(str(ROOT / "app/templates/*.html")))
 def test_every_table_header_has_a_scope():
     offenders = []
     for f in JS + [str(ROOT / "index.html")]:
-        for m in re.finditer(r"<th(?![^>]*\bscope=)[\s>]", Path(f).read_text()):
+        for m in re.finditer(
+            r"<th(?![^>]*\bscope=)[\s>]", Path(f).read_text(encoding="utf-8")
+        ):
             offenders.append(f"{Path(f).name}:{m.start()}")
     assert not offenders, offenders[:10]
 
@@ -29,7 +31,8 @@ def test_icon_only_remove_buttons_have_labels():
     offenders = []
     for f in JS:
         for m in re.finditer(
-            r"<button[^>]*>\s*(X|×|&times;)\s*</button>", Path(f).read_text()
+            r"<button[^>]*>\s*(X|×|&times;)\s*</button>",
+            Path(f).read_text(encoding="utf-8"),
         ):
             if "aria-label" not in m.group(0):
                 offenders.append(f"{Path(f).name}: {m.group(0)[:80]}")
@@ -37,7 +40,7 @@ def test_icon_only_remove_buttons_have_labels():
 
 
 def test_toast_region_is_live_and_modal_is_a_dialog():
-    html = (ROOT / "index.html").read_text()
+    html = (ROOT / "index.html").read_text(encoding="utf-8")
     toast = re.search(r'<div id="toast-container"[^>]*>', html).group(0)
     assert 'aria-live="polite"' in toast and 'role="status"' in toast
     modal = re.search(r'<div id="modal"[^>]*>', html).group(0)
@@ -46,7 +49,7 @@ def test_toast_region_is_live_and_modal_is_a_dialog():
         and 'aria-modal="true"' in modal
         and 'aria-labelledby="modal-title"' in modal
     )
-    utils = (ROOT / "app/static/js/utils.js").read_text()
+    utils = (ROOT / "app/static/js/utils.js").read_text(encoding="utf-8")
     assert (
         "Escape" in utils and "_modalOpener" in utils
     )  # focus trap + restore live here
@@ -55,7 +58,7 @@ def test_toast_region_is_live_and_modal_is_a_dialog():
 def test_pdf_templates_declare_language_and_title():
     missing = []
     for f in TEMPLATES:
-        text = Path(f).read_text()
+        text = Path(f).read_text(encoding="utf-8")
         if "<html" in text and not re.search(r"<html[^>]*\blang=", text):
             missing.append(f"{Path(f).name}: lang")
         if (
@@ -79,7 +82,7 @@ def test_muted_text_token_clears_aa_contrast():
 
         return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b)
 
-    css = (ROOT / "app/static/css/style.css").read_text()
+    css = (ROOT / "app/static/css/style.css").read_text(encoding="utf-8")
     tok = re.search(r"--gray-400:\s*(#[0-9a-fA-F]{6})", css).group(1)
     ratio = (lum("#ffffff") + 0.05) / (lum(tok) + 0.05)
     assert ratio >= 4.5, f"--gray-400 {tok} is {ratio:.2f}:1 on white"

--- a/tests/test_api_defect_regressions.py
+++ b/tests/test_api_defect_regressions.py
@@ -181,7 +181,7 @@ def test_token_settings_writes_are_otherwise_unaffected(client):
 # ---------------------------------------------------------------------------
 
 
-def test_invoice_email_does_not_raise_typeerror(client, seed_customer):
+def test_invoice_email_does_not_raise_typeerror(client, seed_customer, seed_accounts):
     inv = client.post(
         "/api/invoices",
         json={

--- a/tests/test_control_accounts.py
+++ b/tests/test_control_accounts.py
@@ -1,0 +1,237 @@
+"""Issue #119 — a document must never be accepted without its journal entry.
+
+Reported by wilsons043 against the v2.10.0 Windows release: renumbering
+Accounts Receivable away from 1100 made every later invoice post nothing,
+while still returning 201 and still appearing in the A/R aging.
+
+The reproduction is the first test here, written the way the reporter drove
+it, and it asserts the thing that actually matters: the sub-ledger and the
+general ledger agree. Note that the *old* behaviour kept the trial balance
+balanced — debits equalled credits throughout — so a balance check can never
+catch this class. Only the tie-out can.
+"""
+
+import pytest
+
+from app.services import control_accounts
+
+
+def _customer(client, name="Control Co"):
+    r = client.post("/api/customers", json={"name": name})
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+def _invoice(client, cid, amount, date="2026-01-05"):
+    return client.post(
+        "/api/invoices",
+        json={
+            "customer_id": cid,
+            "date": date,
+            "tax_rate": 0,
+            "lines": [
+                {"description": "work", "quantity": 1, "rate": amount, "line_order": 0}
+            ],
+        },
+    )
+
+
+def _tb(client):
+    r = client.get(
+        "/api/reports/trial-balance?start_date=2020-01-01&end_date=2030-12-31"
+    )
+    assert r.status_code == 200
+    body = r.json()
+    return body["total_debit"], body["total_credit"]
+
+
+def _ar_total(client):
+    """The aging's own TOTAL row — it lives under "totals", not in "items"."""
+    body = client.get("/api/reports/ar-aging").json()
+    return float(body["totals"]["total"])
+
+
+# ---------------------------------------------------------------------------
+# The reported path
+# ---------------------------------------------------------------------------
+
+
+def test_renumbering_accounts_receivable_is_refused(client, seed_accounts):
+    """The reporter's step 2. It answered 200 and broke every later invoice."""
+    ar = seed_accounts["1100"]
+    r = client.put(f"/api/accounts/{ar.id}", json={"account_number": "1105"})
+    assert r.status_code == 400, r.text
+    detail = r.json()["detail"]
+    assert "1100" in detail and "control account" in detail
+    assert "rename" in detail.lower()  # say what IS allowed
+
+    # and it really did not change
+    assert client.get(f"/api/accounts/{ar.id}").json()["account_number"] == "1100"
+
+
+def test_renaming_a_control_account_is_still_allowed(client, seed_accounts):
+    """Only the number is load-bearing. An accountant renaming 1100 to
+    'Trade Debtors' must not be blocked — that was never the problem."""
+    ar = seed_accounts["1100"]
+    r = client.put(f"/api/accounts/{ar.id}", json={"name": "Trade Debtors"})
+    assert r.status_code == 200, r.text
+    assert r.json()["name"] == "Trade Debtors"
+    assert r.json()["account_number"] == "1100"
+
+
+def test_changing_a_control_account_type_is_refused(client, seed_accounts):
+    """The same fail-open lands anywhere the type drives behaviour."""
+    ap = seed_accounts["2000"]
+    r = client.put(f"/api/accounts/{ap.id}", json={"account_type": "expense"})
+    assert r.status_code == 400, r.text
+    assert "2000" in r.json()["detail"]
+
+
+def test_an_ordinary_seeded_account_can_still_be_renumbered(client, seed_accounts):
+    """Every seeded account carries is_system, so guarding on that flag would
+    have blocked ordinary renumbering — which is a real bookkeeping request.
+    The guard is the control-account registry, not is_system."""
+    office = next(
+        a
+        for n, a in seed_accounts.items()
+        if not control_accounts.is_control_number(n) and n.startswith("6")
+    )
+    r = client.put(f"/api/accounts/{office.id}", json={"account_number": "6999"})
+    assert r.status_code == 200, r.text
+    assert r.json()["account_number"] == "6999"
+
+
+@pytest.mark.parametrize("number", ["1100", "2000", "1200", "2200", "4000", "2100"])
+def test_every_posting_control_account_is_protected(client, seed_accounts, number):
+    acct = seed_accounts[number]
+    r = client.put(f"/api/accounts/{acct.id}", json={"account_number": number + "9"})
+    assert r.status_code == 400, f"{number} was renumberable: {r.text}"
+
+
+# ---------------------------------------------------------------------------
+# The dangerous half: a posting path that cannot resolve its account
+# ---------------------------------------------------------------------------
+
+
+def test_invoice_is_refused_when_ar_is_absent_not_silently_unposted(
+    client, db_session, seed_accounts
+):
+    """The heart of #119. With A/R gone the invoice must FAIL — the old
+    behaviour created it, returned 201, and skipped the journal entry."""
+    cid = _customer(client)
+    assert _invoice(client, cid, 2000).status_code == 201
+    before_tb, _ = _tb(client)
+    before_ar = _ar_total(client)
+
+    # Reach past the route guard the way a damaged or hand-built file would
+    # arrive. Renumbering is what the reporter did; the effect on the
+    # resolver is identical and it does not disturb the existing postings
+    # (deleting the account would null their account_id).
+    seed_accounts["1100"].account_number = "1105"
+    db_session.commit()
+
+    r = _invoice(client, cid, 5000, date="2026-01-06")
+    assert r.status_code == 409, r.text
+    detail = r.json()["detail"]
+    assert "1100" in detail and "Accounts Receivable" in detail
+    assert "Nothing was posted" in detail
+
+    # and nothing moved on either side — no half-written document
+    assert _tb(client)[0] == before_tb
+    assert _ar_total(client) == before_ar
+
+
+def test_bill_is_refused_when_accounts_payable_is_absent(
+    client, db_session, seed_accounts
+):
+    """The payables half the reporter also confirmed by hand."""
+    v = client.post("/api/vendors", json={"name": "Control Vendor"})
+    assert v.status_code == 201, v.text
+    vid = v.json()["id"]
+
+    seed_accounts["2000"].account_number = "2005"
+    db_session.commit()
+
+    r = client.post(
+        "/api/bills",
+        json={
+            "vendor_id": vid,
+            "date": "2026-01-06",
+            "lines": [{"description": "parts", "quantity": 1, "rate": 900}],
+        },
+    )
+    assert r.status_code == 409, r.text
+    assert "2000" in r.json()["detail"]
+
+
+def test_the_trial_balance_still_balanced_while_the_books_were_wrong(
+    client, db_session, seed_accounts
+):
+    """Why no existing check caught this.
+
+    With the journal entry skipped, debits still equalled credits exactly —
+    the ledger stayed internally consistent and simply lost an entry. This
+    test pins the reasoning: balance is not the same as complete, and the
+    A/R tie-out is the assertion that has to be made.
+    """
+    cid = _customer(client)
+    assert _invoice(client, cid, 2000).status_code == 201
+    debit, credit = _tb(client)
+    assert debit == credit  # consistent...
+    assert _ar_total(client) == pytest.approx(debit)  # ...AND tied out
+
+
+# ---------------------------------------------------------------------------
+# The registry itself
+# ---------------------------------------------------------------------------
+
+
+def test_registry_matches_the_numbers_the_code_resolves_by_literal():
+    """If someone adds a `account_number == "NNNN"` lookup and does not add
+    it here, renumbering that account becomes a silent trap again. This test
+    is the tripwire."""
+    import re
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1] / "app"
+    found: set[str] = set()
+    for path in root.rglob("*.py"):
+        for m in re.finditer(
+            r'account_number\s*==\s*"(\d{4})"', path.read_text(encoding="utf-8")
+        ):
+            found.add(m.group(1))
+    unregistered = found - set(control_accounts.CONTROL_ACCOUNTS)
+    assert not unregistered, (
+        "these account numbers are resolved by literal value but are not in "
+        f"CONTROL_ACCOUNTS, so they can be renumbered into silence: {sorted(unregistered)}"
+    )
+
+
+def test_missing_lists_what_a_blank_chart_lacks(db_session):
+    """The reporter's note (1): a company bootstrapped outside
+    manifest_create_company() has no chart at all, and reached the same
+    fail-open from a different direction."""
+    gaps = control_accounts.missing(db_session)
+    # every SEEDED control account, and only those — 4800 and 5900 are
+    # created on demand, so their absence is not a fault to report
+    assert len(gaps) == len(control_accounts.seeded_numbers())
+    assert ("1100", "Accounts Receivable") in gaps
+    assert "4800" not in {n for n, _ in gaps}
+
+
+def test_missing_is_empty_on_a_seeded_chart(db_session, seed_accounts):
+    assert control_accounts.missing(db_session) == []
+
+
+def test_resolve_raises_and_find_does_not(db_session, seed_accounts):
+    assert control_accounts.resolve(db_session, "1100") == seed_accounts["1100"].id
+    assert control_accounts.find(db_session, "9999") is None
+    with pytest.raises(control_accounts.MissingControlAccount) as exc:
+        control_accounts.resolve(db_session, "9999")
+    assert exc.value.number == "9999"
+
+
+def test_exports_stay_tolerant_of_an_odd_chart(db_session):
+    """An export only needs a display name; it must not raise on a chart
+    that lacks the account (app/services/iif_export.py)."""
+    assert control_accounts.find(db_session, "2000") is None

--- a/tests/test_desktop_mode.py
+++ b/tests/test_desktop_mode.py
@@ -176,7 +176,7 @@ def test_create_company_migrates_and_registers(data_dir):
         (count,) = conn.execute("SELECT COUNT(*) FROM accounts").fetchone()
         assert count > 0
 
-    manifest = json.loads((data_dir / "companies.json").read_text())
+    manifest = json.loads((data_dir / "companies.json").read_text(encoding="utf-8"))
     assert manifest["companies"] == [
         {"name": "Acme Consulting", "file": "acme-consulting.db"}
     ]
@@ -389,7 +389,7 @@ def test_webview_cache_purged_on_version_change(tmp_path):
     assert not cache.exists()
     assert not code_cache.exists()
     assert cookies.read_bytes() == b"keep me"  # logins survive
-    assert (storage / "app-version.txt").read_text().strip() == "9.9.9"
+    assert (storage / "app-version.txt").read_text(encoding="utf-8").strip() == "9.9.9"
 
     # Same version again: marker short-circuits, nothing recreated/deleted
     probe = profile / "Cache"
@@ -400,7 +400,7 @@ def test_webview_cache_purged_on_version_change(tmp_path):
     # New version purges again
     desktop_launcher._purge_stale_webview_cache(storage, "10.0.0")
     assert not probe.exists()
-    assert (storage / "app-version.txt").read_text().strip() == "10.0.0"
+    assert (storage / "app-version.txt").read_text(encoding="utf-8").strip() == "10.0.0"
 
 
 def test_env_file_follows_data_dir_override(tmp_path, monkeypatch):

--- a/tests/test_gate_290_fixes.py
+++ b/tests/test_gate_290_fixes.py
@@ -494,7 +494,7 @@ def test_setup_and_settings_keep_the_manifest_name_in_step(tmp_path, monkeypatch
         }
     )
     assert sync_manifest_name("NEONpulse Techshop") is True
-    manifest = json.loads((data / "companies.json").read_text())
+    manifest = json.loads((data / "companies.json").read_text(encoding="utf-8"))
     assert manifest["companies"][0]["name"] == "NEONpulse Techshop"
     assert sync_manifest_name("NEONpulse Techshop") is False  # idempotent
     assert sync_manifest_name("") is False  # blank never renames
@@ -521,7 +521,9 @@ def test_settings_company_name_updates_manifest(client, tmp_path, monkeypatch):
     r = client.put("/api/settings", json={"company_name": "New Name LLC"})
     assert r.status_code == 200, r.text
     assert (
-        json.loads((data / "companies.json").read_text())["companies"][0]["name"]
+        json.loads((data / "companies.json").read_text(encoding="utf-8"))["companies"][
+            0
+        ]["name"]
         == "New Name LLC"
     )
     # and the list reconciles from settings even if the manifest is edited by hand
@@ -571,7 +573,9 @@ def test_sync_refuses_a_name_another_file_already_uses(tmp_path, monkeypatch, ca
         assert sync_manifest_name("neonpulse techshop") is False  # case-insensitive
     names = [
         c["name"]
-        for c in json.loads((data / "companies.json").read_text())["companies"]
+        for c in json.loads((data / "companies.json").read_text(encoding="utf-8"))[
+            "companies"
+        ]
     ]
     assert names == ["QA Host", "NEONpulse Techshop"]
     assert "already uses that name" in caplog.text
@@ -590,7 +594,9 @@ def test_settings_rename_to_another_files_name_is_409(client, tmp_path, monkeypa
     assert client.get("/api/settings").json()["company_name"] != "NEONpulse Techshop"
     names = [
         c["name"]
-        for c in json.loads((data / "companies.json").read_text())["companies"]
+        for c in json.loads((data / "companies.json").read_text(encoding="utf-8"))[
+            "companies"
+        ]
     ]
     assert names == ["QA Host", "NEONpulse Techshop"]
     # renaming to something unique still works and follows through
@@ -600,7 +606,9 @@ def test_settings_rename_to_another_files_name_is_409(client, tmp_path, monkeypa
     )
     names = [
         c["name"]
-        for c in json.loads((data / "companies.json").read_text())["companies"]
+        for c in json.loads((data / "companies.json").read_text(encoding="utf-8"))[
+            "companies"
+        ]
     ]
     assert names == ["QA Host Books", "NEONpulse Techshop"]
 

--- a/tests/test_gate_290_fixes.py
+++ b/tests/test_gate_290_fixes.py
@@ -102,7 +102,7 @@ def test_tax_rate_percent_is_rejected_naming_the_unit(client):
     assert "fraction" in r.text and "percent" in r.text
 
 
-def test_tax_rate_fraction_still_books_tax(client):
+def test_tax_rate_fraction_still_books_tax(client, seed_accounts):
     cid = _customer(client)
     r = client.post(
         "/api/invoices",
@@ -191,7 +191,7 @@ def test_pto_enums_in_spec(client):
 # ---- R7: DELETE on a posted document names the void route ----------------
 
 
-def test_delete_invoice_405_names_void(client):
+def test_delete_invoice_405_names_void(client, seed_accounts):
     cid = _customer(client)
     inv = client.post(
         "/api/invoices",

--- a/tests/test_macos_release.py
+++ b/tests/test_macos_release.py
@@ -336,7 +336,7 @@ def test_timestamp_failure_gives_up_after_three(monkeypatch):
 
 
 def test_sign_and_dmg_codesign_go_through_the_retry():
-    src = (MACOS_DIR / "release.py").read_text()
+    src = (MACOS_DIR / "release.py").read_text(encoding="utf-8")
     body = src.split("def _sign(")[1].split("def _sign_app(")[0]
     assert "_run_signing(*command)" in body
     dmg = src.split('f"{BUNDLE_ID}.dmg"')[0]

--- a/tests/test_nonprofit.py
+++ b/tests/test_nonprofit.py
@@ -1184,11 +1184,11 @@ def test_report_pdfs_are_named_by_their_period_and_land_in_documents():
     from pathlib import Path
 
     root = Path(__file__).resolve().parent.parent
-    launcher = (root / "desktop_launcher.py").read_text()
+    launcher = (root / "desktop_launcher.py").read_text(encoding="utf-8")
     assert '"SlowBooks Pro" / "Reports"' in launcher
     assert "def reveal_path" in launcher
     assert 'return {"success": True, "path": str(dest)}' in launcher
-    shim = (root / "app/static/js/desktop_shim.js").read_text()
+    shim = (root / "app/static/js/desktop_shim.js").read_text(encoding="utf-8")
     assert "reveal_path" in shim and "Saved to" in shim
-    utils = (root / "app/static/js/utils.js").read_text()
+    utils = (root / "app/static/js/utils.js").read_text(encoding="utf-8")
     assert "function toastAction" in utils

--- a/tests/test_portal_link.py
+++ b/tests/test_portal_link.py
@@ -34,7 +34,7 @@ def test_portal_url_is_absolute(client, seed_accounts):
 
 
 def test_desktop_shim_leaves_portal_links_to_the_browser():
-    shim = (ROOT / "app/static/js/desktop_shim.js").read_text()
+    shim = (ROOT / "app/static/js/desktop_shim.js").read_text(encoding="utf-8")
     assert "function isPortalUrl" in shim
     assert "isSameOrigin(url) && !isPortalUrl(url)" in shim  # window.open path
     assert "if (isPortalUrl(a.href))" in shim  # click path

--- a/tests/test_qb_report_import.py
+++ b/tests/test_qb_report_import.py
@@ -19,7 +19,7 @@ FIXTURE = (
 def _import(db_session):
     from app.services.qb_report_import import import_sales_receipt_report
 
-    return import_sales_receipt_report(db_session, FIXTURE.read_text())
+    return import_sales_receipt_report(db_session, FIXTURE.read_text(encoding="utf-8"))
 
 
 def test_report_import_creates_paid_receipts(db_session, seed_accounts):
@@ -145,9 +145,9 @@ def _sum_dr_cr(db_session, txn_id):
 def test_detect_report_type():
     from app.services.qb_report_import import detect_report_type
 
-    assert detect_report_type(FIXTURE.read_text()) == "sales_receipts"
-    assert detect_report_type(DEPOSIT_FIXTURE.read_text()) == "deposits"
-    assert detect_report_type(CHECK_FIXTURE.read_text()) == "checks"
+    assert detect_report_type(FIXTURE.read_text(encoding="utf-8")) == "sales_receipts"
+    assert detect_report_type(DEPOSIT_FIXTURE.read_text(encoding="utf-8")) == "deposits"
+    assert detect_report_type(CHECK_FIXTURE.read_text(encoding="utf-8")) == "checks"
     assert detect_report_type("a,b\n1,2\n") is None
 
 
@@ -155,7 +155,9 @@ def test_deposit_report_imports_balanced_journals(db_session, seed_accounts):
     from app.models.transactions import Transaction, TransactionLine
     from app.services.qb_report_import import import_deposit_report
 
-    result = import_deposit_report(db_session, DEPOSIT_FIXTURE.read_text())
+    result = import_deposit_report(
+        db_session, DEPOSIT_FIXTURE.read_text(encoding="utf-8")
+    )
     assert result["errors"] == [], result
     assert result["deposits"] == 2
 
@@ -185,9 +187,14 @@ def test_deposit_report_rerun_skips_duplicates(db_session, seed_accounts):
     from app.services.qb_report_import import import_deposit_report
 
     assert (
-        import_deposit_report(db_session, DEPOSIT_FIXTURE.read_text())["deposits"] == 2
+        import_deposit_report(db_session, DEPOSIT_FIXTURE.read_text(encoding="utf-8"))[
+            "deposits"
+        ]
+        == 2
     )
-    second = import_deposit_report(db_session, DEPOSIT_FIXTURE.read_text())
+    second = import_deposit_report(
+        db_session, DEPOSIT_FIXTURE.read_text(encoding="utf-8")
+    )
     assert second["deposits"] == 0
     assert second["duplicates_skipped"] == 2
     assert db_session.query(Transaction).filter_by(source_type="deposit").count() == 2
@@ -197,7 +204,7 @@ def test_check_report_imports_balanced_journals(db_session, seed_accounts):
     from app.models.transactions import Transaction, TransactionLine
     from app.services.qb_report_import import import_check_report
 
-    result = import_check_report(db_session, CHECK_FIXTURE.read_text())
+    result = import_check_report(db_session, CHECK_FIXTURE.read_text(encoding="utf-8"))
     assert result["errors"] == [], result
     assert result["checks"] == 4
 
@@ -233,8 +240,13 @@ def test_check_report_imports_balanced_journals(db_session, seed_accounts):
 def test_check_report_rerun_skips_duplicates(db_session, seed_accounts):
     from app.services.qb_report_import import import_check_report
 
-    assert import_check_report(db_session, CHECK_FIXTURE.read_text())["checks"] == 4
-    second = import_check_report(db_session, CHECK_FIXTURE.read_text())
+    assert (
+        import_check_report(db_session, CHECK_FIXTURE.read_text(encoding="utf-8"))[
+            "checks"
+        ]
+        == 4
+    )
+    second = import_check_report(db_session, CHECK_FIXTURE.read_text(encoding="utf-8"))
     assert second["checks"] == 0
     assert second["duplicates_skipped"] == 4
 
@@ -242,7 +254,9 @@ def test_check_report_rerun_skips_duplicates(db_session, seed_accounts):
 def test_check_report_unknown_account_errors_that_block_only(db_session, seed_accounts):
     from app.services.qb_report_import import import_check_report
 
-    text = CHECK_FIXTURE.read_text().replace("Office Supplies", "No Such Account")
+    text = CHECK_FIXTURE.read_text(encoding="utf-8").replace(
+        "Office Supplies", "No Such Account"
+    )
     result = import_check_report(db_session, text)
     assert result["checks"] == 3
     assert len(result["errors"]) == 1
@@ -293,7 +307,7 @@ def test_payroll_check_with_withholding_contra_lines(db_session, seed_accounts):
     from app.models.transactions import Transaction, TransactionLine
     from app.services.qb_report_import import import_check_report
 
-    result = import_check_report(db_session, CHECK_FIXTURE.read_text())
+    result = import_check_report(db_session, CHECK_FIXTURE.read_text(encoding="utf-8"))
     assert result["errors"] == [], result
     assert result["checks"] == 4
 
@@ -342,7 +356,7 @@ def test_unrecognized_check_block_types_are_warned_not_silent(
     silently dropped."""
     from app.services.qb_report_import import import_check_report
 
-    text = CHECK_FIXTURE.read_text() + BILL_PMT_BLOCK
+    text = CHECK_FIXTURE.read_text(encoding="utf-8") + BILL_PMT_BLOCK
     result = import_check_report(db_session, text)
     assert result["checks"] == 4  # the real checks still import
     assert result["errors"] == []
@@ -354,7 +368,9 @@ def test_unrecognized_check_block_types_are_warned_not_silent(
 def test_cp1252_export_decodes_instead_of_500(client, seed_accounts):
     """QB Desktop's Save-as-CSV often writes Windows-1252; a payee like
     'José' must import, not UnicodeDecodeError into a 500."""
-    text = CHECK_FIXTURE.read_text().replace("Freight Express", "José Hernández")
+    text = CHECK_FIXTURE.read_text(encoding="utf-8").replace(
+        "Freight Express", "José Hernández"
+    )
     raw = text.encode("cp1252")
     r = client.post(
         "/api/csv/import/qb-report",

--- a/tests/test_subprocess_safety_audit.py
+++ b/tests/test_subprocess_safety_audit.py
@@ -113,7 +113,7 @@ def audited():
     findings = []
     for path in _python_files():
         try:
-            tree = ast.parse(path.read_text(), filename=str(path))
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         except SyntaxError as e:
             pytest.fail(f"Cannot parse {path}: {e}")
         a = _SubprocessAuditor(path)
@@ -204,7 +204,9 @@ def test_shell_scripts_quote_all_variable_expansions():
     offenses: list[tuple[Path, int, str]] = []
 
     for path in _shell_files():
-        for lineno, raw_line in enumerate(path.read_text().splitlines(), start=1):
+        for lineno, raw_line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
             # Strip inline comments — `# $VAR` is fine.
             comment_at = raw_line.find("#")
             line = raw_line if comment_at < 0 else raw_line[:comment_at]

--- a/tests/test_terminology.py
+++ b/tests/test_terminology.py
@@ -23,7 +23,7 @@ BUSINESS_WORD = re.compile(
 
 
 def _js_dictionary() -> dict:
-    src = TERMS_JS.read_text()
+    src = TERMS_JS.read_text(encoding="utf-8")
     m = re.search(r"const TERMS_NONPROFIT = (\{.*?\});", src, re.S)
     assert m, "TERMS_NONPROFIT literal not found in terms.js"
     return json.loads(m.group(1))
@@ -99,7 +99,7 @@ def test_filename_forms():
 
 
 def _shell_texts():
-    html = INDEX.read_text()
+    html = INDEX.read_text(encoding="utf-8")
     texts = re.findall(r'<li class="nav-section">([^<]+)</li>', html)
     for m in re.finditer(
         r'<a href="#/[^"]*" class="nav-link[^"]*"[^>]*>.*?</a>', html, re.S
@@ -120,9 +120,9 @@ def test_nav_and_toolbar_labels_with_business_words_are_keys():
 
 
 def test_shell_loads_terms_before_pages():
-    html = INDEX.read_text()
+    html = INDEX.read_text(encoding="utf-8")
     assert html.index("terms.js") < html.index("customers.js")
-    app_js = (ROOT / "app/static/js/app.js").read_text()
+    app_js = (ROOT / "app/static/js/app.js").read_text(encoding="utf-8")
     assert "App.loadCompanySettings().then(" in app_js
     assert "App.applyTerminology();" in app_js
 
@@ -226,7 +226,7 @@ def test_chokepoint_literals_go_through_T():
     for f in sorted((ROOT / "app/static/js").glob("*.js")):
         if f.name in LEAVE_ALONE:
             continue
-        src = f.read_text()
+        src = f.read_text(encoding="utf-8")
         for pat in CHOKEPOINT_PATTERNS:
             for m in re.finditer(pat, src):
                 offenders.append(f"{f.name}: {m.group(0)[:70]}")
@@ -234,7 +234,7 @@ def test_chokepoint_literals_go_through_T():
 
 
 def test_route_labels_are_rewritten_at_boot():
-    app_js = (ROOT / "app/static/js/app.js").read_text()
+    app_js = (ROOT / "app/static/js/app.js").read_text(encoding="utf-8")
     labels = re.findall(r"label:\s*'([^']+)'", app_js)
     business = [lb for lb in labels if BUSINESS_WORD.search(lb)]
     assert business, "expected business-worded route labels to exist"
@@ -243,10 +243,10 @@ def test_route_labels_are_rewritten_at_boot():
 
 
 def test_pdf_templates_use_terms_for_document_names():
-    inv = (ROOT / "app/templates/invoice_pdf.html").read_text()
+    inv = (ROOT / "app/templates/invoice_pdf.html").read_text(encoding="utf-8")
     # the printed face is literal by design: the doc kind decides it
     assert "doc_kind" in inv and "terms('Invoice')" not in inv
-    stmt = (ROOT / "app/templates/statement_pdf.html").read_text()
+    stmt = (ROOT / "app/templates/statement_pdf.html").read_text(encoding="utf-8")
     assert "terms('Total Invoiced')" in stmt
 
 
@@ -355,7 +355,7 @@ def _sweep_hits():
     for path in sorted((ROOT / "app/static/js").glob("*.js")):
         if path.name in _SWEEP_EXEMPT:
             continue
-        for lineno, line in enumerate(path.read_text().split("\n"), 1):
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").split("\n"), 1):
             if re.search(r"\bT\(|Terms\.(text|isNonprofit)\(", line):
                 continue
             if line.lstrip().startswith(("//", "*", "/*")):
@@ -425,7 +425,7 @@ def test_every_T_call_resolves_to_a_dictionary_key():
 
     bad = []
     for path in sorted((ROOT / "app/static/js").glob("*.js")):
-        for lineno, line in enumerate(path.read_text().split("\n"), 1):
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").split("\n"), 1):
             for m in re.finditer(r"\bT\(\s*(['\"])(.*?)\1\s*\)", line):
                 if not resolves(m.group(2)):
                     bad.append(f"{path.name}:{lineno}: T({m.group(2)!r})")

--- a/tests/test_whats_new.py
+++ b/tests/test_whats_new.py
@@ -7,14 +7,14 @@ ROOT = Path(__file__).resolve().parent.parent
 
 
 def test_whats_new_feed_is_valid_and_wired():
-    notes = json.loads((ROOT / "app/static/whats-new.json").read_text())
+    notes = json.loads((ROOT / "app/static/whats-new.json").read_text(encoding="utf-8"))
     assert notes, "at least one release"
     for version, entry in notes.items():
         assert version.count(".") == 2, version
         assert entry["items"] and all(isinstance(i, str) and i for i in entry["items"])
-    html = (ROOT / "index.html").read_text()
+    html = (ROOT / "index.html").read_text(encoding="utf-8")
     assert 'id="splash-whatsnew"' in html and 'id="topbar-company"' in html
-    js = (ROOT / "app/static/js/bootstrap.js").read_text()
+    js = (ROOT / "app/static/js/bootstrap.js").read_text(encoding="utf-8")
     assert "/static/whats-new.json" in js
 
 

--- a/tests/test_windows_version_info.py
+++ b/tests/test_windows_version_info.py
@@ -27,7 +27,7 @@ def test_version_tuple_is_four_integers():
 def test_rendered_resource_names_the_product(tmp_path):
     out = tmp_path / "version_info.txt"
     v = version_info.write(ROOT / "app" / "__init__.py", out)
-    text = out.read_text()
+    text = out.read_text(encoding="utf-8")
     assert text.startswith("# Generated")
     assert "VSVersionInfo(" in text
     assert f"StringStruct('FileVersion', '{v}')" in text


### PR DESCRIPTION
Fixes #119, reported by @wilsons043 against the signed v2.10.0 Windows release. **Reproduced here on Linux from source at the `v2.10.0` tag before anything was changed**, so it is neither Windows-specific nor a packaging artifact:

```
invoice $2,000                                   201
TB 2,000.00 / 2,000.00  diff 0.00 · A/R aging 2,000.00 · assets 2,000.00
PUT /api/accounts/3 {"account_number": "1105"}   200   (is_system: true)
invoice $5,000                                   201
TB 2,000.00 / 2,000.00  diff 0.00 · A/R aging 7,000.00 · assets 2,000.00
```

After the fix the same script answers **400** to the renumber and the $5,000 invoice posts: TB 7,000.00, aging 7,000.00, assets 7,000.00 — all three tied.

### Two faults, both closed

**1. The chart let you renumber an account the posting code finds by number.** There are **fifteen** such numbers, not the six in the report — which is why this is a registry (`app/services/control_accounts.py`) rather than a patch at one site. `update_account` refuses a change to the number or the type of one, naming the account and its purpose. **Renaming stays allowed**: only the number is load-bearing, and an accountant relabelling 1100 as "Trade Debtors" was never the problem.

The guard is deliberately **not** keyed on `is_system`, which is what the report suggested. Every seeded account carries that flag, so that version would have blocked renumbering an ordinary expense account — a reasonable bookkeeping request. A test pins that distinction.

**2. A posting that could not resolve its account skipped the journal entry.** The six resolvers returned `None` and twenty call sites read that as "no journal". They raise `MissingControlAccount` now and the request answers **409** naming the account, with nothing written. Export paths that only want a display name call `control_accounts.find()` and say so in a comment.

Boot logs any seeded control account missing from the chart — which also covers the reporter's note (1), a company bootstrapped outside `manifest_create_company()` that has no chart at all. 4800 and 5900 are created on demand, so their absence is not reported.

### What the fix found in our own suite

**Three existing tests were creating invoices against a chart with no accounts and asserting 201.** They passed because the journal entry was silently skipped — they were exercising the bug. They seed a chart now.

### Why nothing caught this

Through all of it the trial balance **balanced**. Debits equalled credits to the cent, because the ledger stayed internally consistent and was simply missing an entry. Our three-platform gate compares trial balances every release and would have passed this every time. The regression test asserts the **A/R tie-out**, not the balance. A tripwire test fails if anyone adds a new literal `account_number == "NNNN"` lookup without registering it.

Also here: `read_text(encoding="utf-8")` across 12 files (the reporter's note 2 — eight tests died on Windows with `UnicodeDecodeError`; two of the sites are in `app/services/auth.py`, which handles only `OSError`).

Suite **2025 passed / 0 failed**. Version 2.10.1, changelog and what's-new written, control accounts documented in `docs/features.md`.

**Not merging until the QA gate laps it on all three platforms.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DaDm82ccTQi7awPEQrrW3