### PR TITLE
feat(import): support Bank of America detail CSV

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,6 @@
 # Ensure shell scripts always have LF line endings (fixes Docker on all platforms)
 *.sh text eol=lf
 docker-entrypoint.sh text eol=lf
+
+# Preserve the byte shape of the real Bank of America export fixture.
+tests/fixtures/bofa_detail_real_shape.csv -text whitespace=cr-at-eol

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
+**Bank of America detail CSV import.** Checking and savings detail exports
+with the bank's statement-summary preamble now import into the review queue.
+The statement's beginning-balance metadata is skipped because opening balances
+are posted separately through the linked ledger account.
+
 ### v2.10.2 — You can edit your chart of accounts again
 
 **2.10.1 told operators "You can rename it", and through the interface they

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Full catalog (300+ entries) in **[docs/features.md](docs/features.md)**. Highlig
 - **Double-entry core** — auto + manual journals, closing-date
   enforcement, automatic audit log, 50-account contractor chart
 - **Banking** — the register is the ledger (entries post, feeds are a review queue, reconciliation over ledger lines), transfers, deposits, check printing,
-  OFX/QFX + Chase/PayPal CSV import with dedup, SimpleFIN bank feeds,
+  OFX/QFX + Bank of America/Chase/PayPal CSV import with dedup, SimpleFIN bank feeds,
   shared auto-categorization rules
 - **Reports & tax** — P&L (plain & by Class), Balance Sheet, Trial
   Balance, agings, GL, Cash Flow, Sales Tax with pay-to-government flow,

--- a/app/routes/bank_import.py
+++ b/app/routes/bank_import.py
@@ -108,7 +108,7 @@ async def import_csv(
 ):
     """Import CSV bank transactions into a bank account.
 
-    Auto-detects format (Chase checking, Chase credit, PayPal).
+    Auto-detects format (Bank of America detail, Chase checking/credit, PayPal).
     Deduplicates by content-derived import_id (re-imports and overlapping
     exports skip; legitimate same-day duplicates still import).
     Auto-applies bank rules after import.

--- a/app/services/bank_csv_import.py
+++ b/app/services/bank_csv_import.py
@@ -1,5 +1,5 @@
 # ============================================================================
-# CSV Bank Transaction Import — Chase checking, Chase credit card, PayPal
+# CSV Bank Transaction Import — Bank of America, Chase, and PayPal
 # Extends Feature 18 (bank feed import) to support CSV bank statement exports.
 #
 # Column mapping & pitfalls documented in the skill. Key rules:
@@ -53,6 +53,7 @@ PAYPAL_NEW_SIG = {
     "From Email Address",
     "Name",
 }
+BOFA_DETAIL_SIG = {"Date", "Description", "Amount", "Running Bal."}
 
 
 def detect_format(headers: set[str]) -> str:
@@ -65,6 +66,8 @@ def detect_format(headers: set[str]) -> str:
         return "paypal"
     if PAYPAL_NEW_SIG.issubset(headers):
         return "paypal_new"
+    if BOFA_DETAIL_SIG.issubset(headers):
+        return "bofa_detail"
     return "unknown"
 
 
@@ -277,6 +280,50 @@ def parse_paypal_new(reader: csv.DictReader) -> list[dict]:
     return transactions
 
 
+def _parse_bofa_amount(val: str) -> Decimal:
+    """Parse Bank of America amounts such as ``1,234.56`` or ``($25.00)``."""
+    normalized = val.strip().replace(",", "").replace("$", "")
+    if normalized.startswith("(") and normalized.endswith(")"):
+        normalized = f"-{normalized[1:-1]}"
+    return Decimal(normalized)
+
+
+def parse_bofa_detail(reader: csv.DictReader) -> list[dict]:
+    """Parse Bank of America's detailed checking/savings CSV export.
+
+    The export starts with a statement-summary block before the real header.
+    ``parse_csv`` positions the reader at that header. A beginning-balance row
+    is statement metadata, not a transaction, so it stays out of the review
+    queue; opening balances are posted separately through the linked account.
+    """
+    transactions = []
+    for row in reader:
+        date_str = (row.get("Date") or "").strip()
+        description = (row.get("Description") or "").strip()
+        amount_str = (row.get("Amount") or "").strip()
+
+        if not date_str or not amount_str:
+            continue
+
+        try:
+            txn_date = parse_date(date_str)
+            amount = _parse_bofa_amount(amount_str)
+        except (ValueError, InvalidOperation) as e:
+            logger.warning("Skipping Bank of America row: %s", e)
+            continue
+
+        transactions.append(
+            {
+                "date": txn_date,
+                "amount": amount,
+                "payee": description,
+                "description": description,
+                "check_number": None,
+            }
+        )
+    return transactions
+
+
 # ── Dispatch ─────────────────────────────────────────────────────────────
 
 
@@ -293,23 +340,40 @@ def parse_csv(csv_text: str) -> dict:
     if csv_text.startswith("\ufeff"):
         csv_text = csv_text[1:]
 
-    reader = csv.DictReader(io.StringIO(csv_text))
-    if not reader.fieldnames:
+    lines = csv_text.splitlines()
+    if not lines:
         return {
             "format": "unknown",
             "transactions": [],
             "error": "Empty CSV or no headers",
         }
 
-    # Normalize headers: strip whitespace, quotes, and BOM residue
-    headers = {h.strip().strip('"').strip("'") for h in reader.fieldnames if h}
-    fmt = detect_format(headers)
+    # Some exports (notably Bank of America detail CSVs) put a statement
+    # summary before the transaction table. Locate the first recognized
+    # header instead of assuming it is physical row 1.
+    reader = None
+    fmt = "unknown"
+    headers: set[str] = set()
+    for index, line in enumerate(lines):
+        candidate = next(csv.reader([line]), [])
+        candidate_headers = {h.strip().strip('"').strip("'") for h in candidate if h}
+        candidate_format = detect_format(candidate_headers)
+        if candidate_format != "unknown":
+            headers = candidate_headers
+            fmt = candidate_format
+            reader = csv.DictReader(io.StringIO("\n".join(lines[index:])))
+            break
+
+    if reader is None:
+        first_row = next(csv.reader([lines[0]]), [])
+        headers = {h.strip().strip('"').strip("'") for h in first_row if h}
 
     parsers = {
         "chase_checking": parse_chase_checking,
         "chase_credit": parse_chase_credit,
         "paypal": parse_paypal,
         "paypal_new": parse_paypal_new,
+        "bofa_detail": parse_bofa_detail,
     }
 
     parser = parsers.get(fmt)
@@ -332,6 +396,7 @@ _IMPORT_ID_PREFIX = {
     "chase_credit": "cc",
     "paypal": "pp",
     "paypal_new": "pp",
+    "bofa_detail": "bofa",
 }
 
 

--- a/tests/fixtures/bofa_detail_real_shape.csv
+++ b/tests/fixtures/bofa_detail_real_shape.csv
@@ -1,0 +1,10 @@
+Description,,Summary Amt.
+Beginning balance as of 01/01/2026,,"1,000.00"
+Total credits,,"1,250.00"
+Total debits,,"-250.00"
+Ending balance as of 01/31/2026,,"2,000.00"
+
+Date,Description,Amount,Running Bal.
+01/01/2026,Beginning balance as of 01/01/2026,,"1,000.00"
+01/20/2026,"SYNTHETIC PAYOR, LLC CREDIT","1,250.00","2,250.00"
+01/22/2026,SYNTHETIC DEBIT,-250.00,"2,000.00"

--- a/tests/test_bank_csv_import.py
+++ b/tests/test_bank_csv_import.py
@@ -2,6 +2,7 @@
 content-derived import_id dedup, and bank-rule parity with OFX import."""
 
 from decimal import Decimal
+from pathlib import Path
 
 from app.models.accounts import Account, AccountType
 from app.models.bank_rules import BankRule
@@ -43,19 +44,9 @@ PAYPAL_NEW_CSV = (
     "grace@example.com,Grace Hopper,,,0.00,0.00,INV-9,\n"
 )
 
-BOFA_DETAIL_CSV = (
-    "Description,,Summary Amt.\n"
-    'Beginning balance as of 01/01/2026,,"1,000.00"\n'
-    'Total credits,,"1,239.90"\n'
-    'Total debits,,"(250.00)"\n'
-    'Ending balance as of 01/31/2026,,"1,989.90"\n'
-    "\n"
-    "Date,Description,Amount,Running Bal.\n"
-    '01/01/2026,Beginning balance as of 01/01/2026,,"1,000.00"\n'
-    '01/20/2026,Interest Earned,4.90,"1,004.90"\n'
-    '01/22/2026,Online Banking transfer to CHK 1234,(250.00),"754.90"\n'
-    '01/25/2026,BKOFAMERICA MOBILE DEPOSIT,"1,235.00","1,989.90"\n'
-)
+BOFA_DETAIL_FIXTURE = Path(__file__).parent / "fixtures/bofa_detail_real_shape.csv"
+BOFA_DETAIL_CSV_BYTES = BOFA_DETAIL_FIXTURE.read_bytes()
+BOFA_DETAIL_CSV = BOFA_DETAIL_CSV_BYTES.decode("ascii")
 
 
 def _mk_bank_account(db_session):
@@ -127,14 +118,18 @@ def test_parse_paypal_new_format():
 
 
 def test_parse_bofa_detail_after_summary_preamble():
+    # The fixture preserves the line endings emitted by both real exports.
+    assert b"\r\n" in BOFA_DETAIL_CSV_BYTES
+    assert b"\n" not in BOFA_DETAIL_CSV_BYTES.replace(b"\r\n", b"")
+
     result = parse_csv(BOFA_DETAIL_CSV)
     assert result["format"] == "bofa_detail"
     assert result["error"] is None
     txns = result["transactions"]
-    assert len(txns) == 3
-    assert txns[0]["amount"] == Decimal("4.90")
+    assert len(txns) == 2
+    assert txns[0]["payee"] == "SYNTHETIC PAYOR, LLC CREDIT"
+    assert txns[0]["amount"] == Decimal("1250.00")
     assert txns[1]["amount"] == Decimal("-250.00")
-    assert txns[-1]["amount"] == Decimal("1235.00")
 
 
 # ── Import + dedup ───────────────────────────────────────────────────────
@@ -168,7 +163,7 @@ def test_bofa_reimport_skips_everything(db_session):
     ba = _mk_bank_account(db_session)
     first = import_csv_transactions(db_session, ba.id, BOFA_DETAIL_CSV)
     assert first["format"] == "bofa_detail"
-    assert first["imported"] == 3
+    assert first["imported"] == 2
     assert first["matched"] == 0
 
     rows = (
@@ -176,12 +171,12 @@ def test_bofa_reimport_skips_everything(db_session):
         .filter(BankTransaction.bank_account_id == ba.id)
         .all()
     )
-    assert len(rows) == 3
+    assert len(rows) == 2
     assert all(row.import_source == "csv_bofa_detail" for row in rows)
 
     second = import_csv_transactions(db_session, ba.id, BOFA_DETAIL_CSV)
     assert second["imported"] == 0
-    assert second["skipped"] == 3
+    assert second["skipped"] == 2
 
 
 def test_overlapping_export_skips_only_known_rows(db_session):

--- a/tests/test_bank_csv_import.py
+++ b/tests/test_bank_csv_import.py
@@ -43,6 +43,20 @@ PAYPAL_NEW_CSV = (
     "grace@example.com,Grace Hopper,,,0.00,0.00,INV-9,\n"
 )
 
+BOFA_DETAIL_CSV = (
+    "Description,,Summary Amt.\n"
+    'Beginning balance as of 01/01/2026,,"1,000.00"\n'
+    'Total credits,,"1,239.90"\n'
+    'Total debits,,"(250.00)"\n'
+    'Ending balance as of 01/31/2026,,"1,989.90"\n'
+    "\n"
+    "Date,Description,Amount,Running Bal.\n"
+    '01/01/2026,Beginning balance as of 01/01/2026,,"1,000.00"\n'
+    '01/20/2026,Interest Earned,4.90,"1,004.90"\n'
+    '01/22/2026,Online Banking transfer to CHK 1234,(250.00),"754.90"\n'
+    '01/25/2026,BKOFAMERICA MOBILE DEPOSIT,"1,235.00","1,989.90"\n'
+)
+
 
 def _mk_bank_account(db_session):
     ba = BankAccount(name="Test Checking", bank_name="Chase")
@@ -75,6 +89,10 @@ def test_detect_formats():
         == "chase_credit"
     )
     assert detect_format({"Date", "Time", "Name", "Type", "Status"}) == "paypal"
+    assert (
+        detect_format({"Date", "Description", "Amount", "Running Bal."})
+        == "bofa_detail"
+    )
     assert detect_format({"Nothing", "Useful"}) == "unknown"
 
 
@@ -108,6 +126,17 @@ def test_parse_paypal_new_format():
     assert txns[0]["payee"] == "Grace Hopper"
 
 
+def test_parse_bofa_detail_after_summary_preamble():
+    result = parse_csv(BOFA_DETAIL_CSV)
+    assert result["format"] == "bofa_detail"
+    assert result["error"] is None
+    txns = result["transactions"]
+    assert len(txns) == 3
+    assert txns[0]["amount"] == Decimal("4.90")
+    assert txns[1]["amount"] == Decimal("-250.00")
+    assert txns[-1]["amount"] == Decimal("1235.00")
+
+
 # ── Import + dedup ───────────────────────────────────────────────────────
 
 
@@ -133,6 +162,26 @@ def test_reimport_same_file_skips_everything(db_session):
     second = import_csv_transactions(db_session, ba.id, CHASE_CHECKING_CSV)
     assert second["imported"] == 0
     assert second["skipped"] == 4
+
+
+def test_bofa_reimport_skips_everything(db_session):
+    ba = _mk_bank_account(db_session)
+    first = import_csv_transactions(db_session, ba.id, BOFA_DETAIL_CSV)
+    assert first["format"] == "bofa_detail"
+    assert first["imported"] == 3
+    assert first["matched"] == 0
+
+    rows = (
+        db_session.query(BankTransaction)
+        .filter(BankTransaction.bank_account_id == ba.id)
+        .all()
+    )
+    assert len(rows) == 3
+    assert all(row.import_source == "csv_bofa_detail" for row in rows)
+
+    second = import_csv_transactions(db_session, ba.id, BOFA_DETAIL_CSV)
+    assert second["imported"] == 0
+    assert second["skipped"] == 3
 
 
 def test_overlapping_export_skips_only_known_rows(db_session):


### PR DESCRIPTION
## Summary

Adds support for Bank of America checking and savings detail CSV exports, including the statement-summary rows that precede the transaction table.

## Changes

- Detect the Bank of America detail header after its summary preamble.
- Parse signed currency values, including comma, dollar-sign, and parenthesized formats.
- Skip beginning-balance metadata because v2.10 posts opening balances separately through the linked ledger account.
- Use content-derived IDs so reimports and overlapping exports remain idempotent.
- Document Bank of America CSV support in the README and changelog.

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_bank_csv_import.py -q` — 13 passed
- [ ] `.venv/bin/python -m pytest tests/ -q` — 2,017 passed, 9 skipped, with one pre-existing macOS OCR renderer-selection mismatch in `test_scan_pdf_without_any_renderer_400`
- [x] `.venv/bin/black --check app/ tests/`
- [x] `.venv/bin/ruff check app/ tests/`
- [x] `.venv/bin/pip-audit -r requirements.txt --progress-spinner off` — no known vulnerabilities

## Screenshots / output

Not applicable; the existing CSV import UI auto-detects this additional format.

## Security implications

No authentication, authorization, upload-limit, or storage behavior changes. Tests use synthetic statement data only.

## Database changes

- [x] No schema changes

## Documentation

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] `README.md` updated
- [ ] `docs/` updated — no separate behavior document needed
- [ ] `docs/todo.md` updated — not applicable

## Related issues

No linked issue.
