### PR TITLE
Vendor credits (#129) — v2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
+### v2.11.0 — Record a credit from a supplier
+
+**A supplier credit had nowhere correct to go.** Reported by
+@CimarronSiteServices (issue #129) while evaluating SlowBooks against
+QuickBooks Online. A vendor issues a credit for returned or short-shipped
+materials; a bill with a negative line is refused, an expense with a
+negative amount is refused, and both refusals point at credit memos — which
+only accept a customer. The reporter went looking through bills, expenses,
+credit memos, card charges and journal entries, and was right that none of
+them was the answer.
+
+**Vendor Credits are the missing document.** A bill posts DR Expense / CR
+Accounts Payable; a vendor credit is its mirror. It reduces what you owe
+that vendor the moment it is entered, and you apply it to a bill afterwards
+— or leave it on the vendor's account until there is a bill to settle.
+Applying posts nothing at all, because A/P already moved when the credit was
+issued; applying only decides which bill it pays down.
+
+The reporter also named why a manual journal entry against A/P was not good
+enough, and he was right: a journal entry moves the general ledger without
+moving the vendor sub-ledger, so A/P aging and the vendor's balance stop
+agreeing with account 2000. That is the same split as #119, and it is why
+this is a document rather than a shortcut.
+
+**Returning stock takes it off the shelf.** A bill receives inventory into
+the Inventory asset rather than an expense; a credit for returned goods
+takes it back out of Inventory, records a `return_out` movement, and drops
+the quantity on hand. Anything else would leave an asset on the balance
+sheet for goods that are no longer in the building. A credit for an
+inventory item with no asset account is refused rather than posted to an
+expense — the same refusal `create_bill` already makes, for the same reason.
+
+**Both aging reports were hiding credits, and now show them.** Found while
+building this, and confirmed before it was fixed: an unapplied credit memo
+credits A/R at the moment it is issued, but A/R aging summed only invoice
+balances. A customer with a 1,000 invoice and a 300 credit showed a ledger
+balance of 700 and an aging total of 1,000. The report overstated what
+customers owed by every credit not yet applied, and the sub-ledger did not
+tie to account 1100. The payable side would have inherited exactly the same
+hole, so both are fixed together, and both reports now carry an
+`unapplied_credits` column — because "you owe 700" and "you owe 1,000 and
+hold a 300 credit" are different facts to someone about to pay a vendor.
+
+`CONTROL` on the badge vocabulary: `.badge-issued` and `.badge-applied` had
+no CSS rule and never have. Credit memos have rendered an unstyled badge
+since the day they shipped. Vendor credits use the same two words, so both
+documents are styled now.
+
 ### v2.10.3 — You can see when there is a new version
 
 **The update notice was in the last place anyone would look.** It sat at the

--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ Full catalog (300+ entries) in **[docs/features.md](docs/features.md)**. Highlig
 - **Accounts receivable** — invoices, estimates, payments with
   multi-invoice allocation, credit memos, recurring schedules, batch
   payments, Quick Entry for paper backlogs
-- **Accounts payable** — purchase orders, bills, bill payments, AP aging
+- **Accounts payable** — purchase orders, bills, bill payments, vendor
+  credits, AP aging
 - **Double-entry core** — auto + manual journals, closing-date
   enforcement, automatic audit log, 50-account contractor chart
 - **Banking** — the register is the ledger (entries post, feeds are a review queue, reconciliation over ledger lines), transfers, deposits, check printing,

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 # Single source of truth for the application version: app/main.py reports
 # it on the FastAPI app and /health, /api/system serves it to the frontend
 # footer, and the Windows release workflow parses it for the installer.
-__version__ = "2.10.3"
+__version__ = "2.11.0"

--- a/app/main.py
+++ b/app/main.py
@@ -53,6 +53,7 @@ from app.routes import audit, search
 
 # Phase 2: Accounts Payable
 from app.routes import purchase_orders, bills, bill_payments, credit_memos
+from app.routes import vendor_credits
 
 # Phase 3: Productivity
 from app.routes import recurring, batch_payments
@@ -776,6 +777,7 @@ app.include_router(purchase_orders.router)
 app.include_router(bills.router)
 app.include_router(bill_payments.router)
 app.include_router(credit_memos.router)
+app.include_router(vendor_credits.router)
 # Phase 3: Productivity
 app.include_router(recurring.router)
 app.include_router(batch_payments.router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -39,6 +39,11 @@ from app.models.api_tokens import ApiToken  # noqa: F401 — registers the table
 from app.models.purchase_orders import PurchaseOrder, PurchaseOrderLine
 from app.models.bills import Bill, BillLine, BillPayment, BillPaymentAllocation
 from app.models.credit_memos import CreditMemo, CreditMemoLine, CreditApplication
+from app.models.vendor_credits import (
+    VendorCredit,
+    VendorCreditLine,
+    VendorCreditApplication,
+)
 
 # Phase 3: Productivity
 from app.models.recurring import RecurringInvoice, RecurringInvoiceLine
@@ -120,6 +125,9 @@ __all__ = [
     "CreditMemo",
     "CreditMemoLine",
     "CreditApplication",
+    "VendorCredit",
+    "VendorCreditLine",
+    "VendorCreditApplication",
     # Phase 3
     "RecurringInvoice",
     "RecurringInvoiceLine",

--- a/app/models/vendor_credits.py
+++ b/app/models/vendor_credits.py
@@ -1,0 +1,141 @@
+# ============================================================================
+# Vendor Credits — the AP-side counterpart of a customer credit memo
+#
+# Issue #129 (CimarronSiteServices): a supplier issuing a credit for returned
+# or short-shipped materials had nowhere correct to go. Bills and expenses
+# both reject a negative amount and both point the operator at credit memos,
+# which only accept a customer. The remaining option was a manual journal
+# entry against Accounts Payable, which moves the general ledger but not the
+# vendor sub-ledger — so A/P aging and the vendor's balance would disagree
+# with account 2000. That is the same split #119 was about, and it is why
+# this is a document rather than a shortcut.
+#
+# A bill posts DR Expense / CR A/P. A vendor credit is its mirror:
+# DR A/P / CR Expense. Applying one to a bill moves no money and posts
+# nothing — the credit already reduced A/P when it was issued; applying it
+# only decides WHICH bill it settles, exactly as a credit memo does on the
+# receivable side.
+# ============================================================================
+
+import enum
+
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Date,
+    Numeric,
+    DateTime,
+    Text,
+    Enum,
+    ForeignKey,
+    func,
+)
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class VendorCreditStatus(str, enum.Enum):
+    DRAFT = "draft"
+    ISSUED = "issued"
+    APPLIED = "applied"
+    VOID = "void"
+
+
+class VendorCredit(Base):
+    __tablename__ = "vendor_credits"
+
+    id = Column(Integer, primary_key=True, index=True)
+    credit_number = Column(String(50), unique=True, nullable=False)
+    vendor_id = Column(Integer, ForeignKey("vendors.id"), nullable=False, index=True)
+    status = Column(Enum(VendorCreditStatus), default=VendorCreditStatus.DRAFT)
+    # The bill this credit came from, when the vendor named one. Advisory:
+    # a credit can be applied to any of the vendor's open bills.
+    original_bill_id = Column(Integer, ForeignKey("bills.id"), nullable=True)
+    # The vendor's own credit-note number, when they issued one.
+    ref_number = Column(String(100), nullable=True)
+
+    date = Column(Date, nullable=False)
+    subtotal = Column(Numeric(12, 2), default=0)
+    tax_rate = Column(Numeric(5, 4), default=0)
+    tax_amount = Column(Numeric(12, 2), default=0)
+    total = Column(Numeric(12, 2), default=0)
+    amount_applied = Column(Numeric(12, 2), default=0)
+    balance_remaining = Column(Numeric(12, 2), default=0)
+
+    notes = Column(Text, nullable=True)
+    transaction_id = Column(Integer, ForeignKey("transactions.id"), nullable=True)
+
+    # Class tracking dimension (QB-style); NULL groups with Uncategorized
+    class_id = Column(Integer, ForeignKey("classes.id"), nullable=True)
+    # Job-costing dimension (QB "Customer:Job"); NULL = no job
+    job_id = Column(Integer, ForeignKey("jobs.id"), nullable=True)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    vendor = relationship("Vendor", backref="vendor_credits")
+    original_bill = relationship("Bill", foreign_keys=[original_bill_id])
+    lines = relationship(
+        "VendorCreditLine",
+        back_populates="vendor_credit",
+        cascade="all, delete-orphan",
+        order_by="VendorCreditLine.line_order",
+    )
+    transaction = relationship("Transaction", foreign_keys=[transaction_id])
+    applications = relationship(
+        "VendorCreditApplication",
+        back_populates="vendor_credit",
+        cascade="all, delete-orphan",
+    )
+
+
+class VendorCreditLine(Base):
+    __tablename__ = "vendor_credit_lines"
+
+    id = Column(Integer, primary_key=True, index=True)
+    vendor_credit_id = Column(
+        Integer,
+        ForeignKey("vendor_credits.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    item_id = Column(Integer, ForeignKey("items.id"), nullable=True)
+    # The expense account being credited back. Mirrors BillLine.account_id —
+    # a credit memo line takes its account from the item's INCOME account
+    # because an invoice does; this takes it from the expense side because
+    # a bill does.
+    account_id = Column(Integer, ForeignKey("accounts.id"), nullable=True)
+    description = Column(Text, nullable=True)
+    quantity = Column(Numeric(10, 2), default=1)
+    rate = Column(Numeric(12, 2), default=0)
+    amount = Column(Numeric(12, 2), default=0)
+    # Per-line job / class; NULL falls back to the header
+    job_id = Column(Integer, ForeignKey("jobs.id"), nullable=True)
+    class_id = Column(Integer, ForeignKey("classes.id"), nullable=True)
+    cost_code_id = Column(Integer, ForeignKey("cost_codes.id"), nullable=True)
+    line_order = Column(Integer, default=0)
+
+    vendor_credit = relationship("VendorCredit", back_populates="lines")
+    item = relationship("Item")
+    account = relationship("Account")
+
+
+class VendorCreditApplication(Base):
+    __tablename__ = "vendor_credit_applications"
+
+    id = Column(Integer, primary_key=True, index=True)
+    vendor_credit_id = Column(
+        Integer,
+        ForeignKey("vendor_credits.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    bill_id = Column(Integer, ForeignKey("bills.id"), nullable=False, index=True)
+    amount = Column(Numeric(12, 2), nullable=False)
+
+    vendor_credit = relationship("VendorCredit", back_populates="applications")
+    bill = relationship("Bill", backref="vendor_credit_applications")

--- a/app/routes/attachments.py
+++ b/app/routes/attachments.py
@@ -32,6 +32,9 @@ _ENTITY_TYPE_DIRS = {
     "expense": "expense",
     "estimate": "estimate",
     "purchase_order": "purchase_order",
+    # The supplier's own credit note is the evidence behind a vendor credit,
+    # the same way their invoice is the evidence behind a bill.
+    "vendor_credit": "vendor_credit",
     "vendor": "vendor",
     "customer": "customer",
 }

--- a/app/routes/reports/payables_tax.py
+++ b/app/routes/reports/payables_tax.py
@@ -143,6 +143,7 @@ def ap_aging(as_of_date: date = Query(default=None), db: Session = Depends(get_d
     try:
         from app.models.bills import Bill, BillStatus
         from app.models.contacts import Vendor
+        from app.models.vendor_credits import VendorCredit, VendorCreditStatus
 
         bills = (
             db.query(Bill)
@@ -165,6 +166,7 @@ def ap_aging(as_of_date: date = Query(default=None), db: Session = Depends(get_d
                     "over_60": Decimal(0),
                     "over_90": Decimal(0),
                     "total": Decimal(0),
+                    "unapplied_credits": Decimal(0),
                 }
 
             days = (as_of_date - bill.due_date).days if bill.due_date else 0
@@ -179,20 +181,59 @@ def ap_aging(as_of_date: date = Query(default=None), db: Session = Depends(get_d
                 aging[vid]["over_90"] += bal
             aging[vid]["total"] += bal
 
+        # Unapplied vendor credits (issue #129). A credit debits A/P the
+        # moment it is issued, so a report that only sums bill balances
+        # reads HIGHER than account 2000 by every credit not yet applied —
+        # the sub-ledger and the control account stop agreeing, which is
+        # the objection that made this a document instead of a journal
+        # entry. Shown on its own line as well as netted, because "you owe
+        # 700" and "you owe 1,000 and hold a 300 credit" are different
+        # facts to a person about to pay a vendor.
+        credits = (
+            db.query(VendorCredit)
+            .filter(VendorCredit.status != VendorCreditStatus.VOID)
+            .filter(VendorCredit.date <= as_of_date)
+            .filter(VendorCredit.balance_remaining > 0)
+            .all()
+        )
+        for vc in credits:
+            vid = vc.vendor_id
+            if vid not in aging:
+                aging[vid] = {
+                    "vendor_name": vendor_names.get(vid, "Unknown"),
+                    "vendor_id": vid,
+                    "current": Decimal(0),
+                    "over_30": Decimal(0),
+                    "over_60": Decimal(0),
+                    "over_90": Decimal(0),
+                    "total": Decimal(0),
+                    "unapplied_credits": Decimal(0),
+                }
+            amt = Decimal(str(vc.balance_remaining))
+            aging[vid]["unapplied_credits"] += amt
+            # A credit has no due date, so it reduces the newest bucket —
+            # it is money available now, not money aged.
+            aging[vid]["current"] -= amt
+            aging[vid]["total"] -= amt
+
+        _COLS = (
+            "current",
+            "over_30",
+            "over_60",
+            "over_90",
+            "total",
+            "unapplied_credits",
+        )
         items = list(aging.values())
-        totals = {
-            "vendor_name": "TOTAL",
-            "vendor_id": 0,
-            "current": sum(i["current"] for i in items),
-            "over_30": sum(i["over_30"] for i in items),
-            "over_60": sum(i["over_60"] for i in items),
-            "over_90": sum(i["over_90"] for i in items),
-            "total": sum(i["total"] for i in items),
-        }
         for item in items:
-            for k in ("current", "over_30", "over_60", "over_90", "total"):
+            item.setdefault("unapplied_credits", Decimal(0))
+        totals = {"vendor_name": "TOTAL", "vendor_id": 0}
+        for k in _COLS:
+            totals[k] = sum(i[k] for i in items)
+        for item in items:
+            for k in _COLS:
                 item[k] = float(item[k])
-        for k in ("current", "over_30", "over_60", "over_90", "total"):
+        for k in _COLS:
             totals[k] = float(totals[k])
 
         return {"as_of_date": as_of_date.isoformat(), "items": items, "totals": totals}

--- a/app/routes/reports/receivables.py
+++ b/app/routes/reports/receivables.py
@@ -59,6 +59,7 @@ def ar_aging(as_of_date: date = Query(default=None), db: Session = Depends(get_d
                 "over_60": Decimal(0),
                 "over_90": Decimal(0),
                 "total": Decimal(0),
+                "unapplied_credits": Decimal(0),
             }
 
         days = (as_of_date - inv.due_date).days if inv.due_date else 0
@@ -73,21 +74,52 @@ def ar_aging(as_of_date: date = Query(default=None), db: Session = Depends(get_d
             aging[cid]["over_90"] += bal
         aging[cid]["total"] += bal
 
+    # Unapplied credit memos. A credit memo credits A/R the moment it is
+    # issued, so summing only invoice balances reads HIGHER than account
+    # 1100 by every credit not yet applied — the aging and the control
+    # account disagree, and the report overstates what customers owe. Found
+    # while building the payable-side twin (issue #129); fixed on both sides
+    # together so they cannot drift apart again.
+    from app.models.credit_memos import CreditMemo, CreditMemoStatus
+
+    credits = (
+        db.query(CreditMemo)
+        .filter(CreditMemo.status != CreditMemoStatus.VOID)
+        .filter(CreditMemo.date <= as_of_date)
+        .filter(CreditMemo.balance_remaining > 0)
+        .all()
+    )
+    for cm in credits:
+        cid = cm.customer_id
+        if cid not in aging:
+            aging[cid] = {
+                "customer_name": customer_names.get(cid, "Unknown"),
+                "customer_id": cid,
+                "current": Decimal(0),
+                "over_30": Decimal(0),
+                "over_60": Decimal(0),
+                "over_90": Decimal(0),
+                "total": Decimal(0),
+                "unapplied_credits": Decimal(0),
+            }
+        amt = Decimal(str(cm.balance_remaining))
+        aging[cid]["unapplied_credits"] += amt
+        # A credit has no due date: it offsets the newest bucket.
+        aging[cid]["current"] -= amt
+        aging[cid]["total"] -= amt
+
+    _COLS = ("current", "over_30", "over_60", "over_90", "total", "unapplied_credits")
     items = list(aging.values())
-    totals = {
-        "customer_name": "TOTAL",
-        "customer_id": 0,
-        "current": sum(i["current"] for i in items),
-        "over_30": sum(i["over_30"] for i in items),
-        "over_60": sum(i["over_60"] for i in items),
-        "over_90": sum(i["over_90"] for i in items),
-        "total": sum(i["total"] for i in items),
-    }
+    for item in items:
+        item.setdefault("unapplied_credits", Decimal(0))
+    totals = {"customer_name": "TOTAL", "customer_id": 0}
+    for k in _COLS:
+        totals[k] = sum(i[k] for i in items)
     # Convert Decimals to float for JSON
     for item in items:
-        for k in ("current", "over_30", "over_60", "over_90", "total"):
+        for k in _COLS:
             item[k] = float(item[k])
-    for k in ("current", "over_30", "over_60", "over_90", "total"):
+    for k in _COLS:
         totals[k] = float(totals[k])
 
     return {"as_of_date": as_of_date.isoformat(), "items": items, "totals": totals}

--- a/app/routes/vendor_credits.py
+++ b/app/routes/vendor_credits.py
@@ -1,0 +1,447 @@
+# ============================================================================
+# Vendor Credits — the AP-side counterpart of a customer credit memo
+#
+# Issue #129 (CimarronSiteServices). A bill posts DR Expense / CR A/P; a
+# vendor credit is its mirror, DR A/P / CR Expense. Applying one to a bill
+# posts NOTHING — A/P already moved when the credit was issued, and the
+# application only decides which bill it settles. That is exactly how a
+# credit memo behaves against an invoice.
+#
+# The reason this is a document and not a journal entry: a manual JE against
+# 2000 moves the general ledger without moving the vendor sub-ledger, so A/P
+# aging and the vendor's balance stop agreeing with the control account. The
+# reporter named that himself, and it is the same split as #119.
+# ============================================================================
+
+from decimal import Decimal
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session, joinedload, selectinload
+from sqlalchemy.exc import IntegrityError
+
+from app.database import get_db
+from app.models.accounts import Account
+from app.models.bills import Bill, BillStatus
+from app.models.contacts import Vendor
+from app.models.items import Item
+from app.models.transactions import Transaction
+from app.models.vendor_credits import (
+    VendorCredit,
+    VendorCreditApplication,
+    VendorCreditLine,
+    VendorCreditStatus,
+)
+from app.routes._helpers import clamp_pagination
+from app.schemas.vendor_credits import (
+    VendorCreditApplicationCreate,
+    VendorCreditCreate,
+    VendorCreditResponse,
+)
+from app.services.accounting import (
+    _q,
+    compute_line_totals,
+    create_journal_entry,
+    get_ap_account_id,
+    reversing_lines,
+)
+from app.services.inventory_service import get_inventory_asset_account_id
+from app.services.closing_date import check_closing_date
+from app.services.numbering import next_vendor_credit_number
+
+router = APIRouter(prefix="/api/vendor-credits", tags=["vendor_credits"])
+
+
+def _with_vendor_name(vc: VendorCredit) -> VendorCreditResponse:
+    resp = VendorCreditResponse.model_validate(vc)
+    resp.vendor_name = vc.vendor.name if vc.vendor else None
+    return resp
+
+
+@router.get("", response_model=list[VendorCreditResponse])
+def list_vendor_credits(
+    vendor_id: int = None,
+    status: str = None,
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(get_db),
+):
+    skip, limit = clamp_pagination(skip, limit)
+    q = db.query(VendorCredit).options(
+        joinedload(VendorCredit.vendor),
+        selectinload(VendorCredit.lines),
+    )
+    if vendor_id:
+        q = q.filter(VendorCredit.vendor_id == vendor_id)
+    if status:
+        q = q.filter(VendorCredit.status == status)
+    rows = q.order_by(VendorCredit.date.desc(), VendorCredit.id.desc())
+    rows = rows.offset(skip).limit(limit).all()
+    return [_with_vendor_name(vc) for vc in rows]
+
+
+@router.get("/{vc_id}", response_model=VendorCreditResponse)
+def get_vendor_credit(vc_id: int, db: Session = Depends(get_db)):
+    vc = (
+        db.query(VendorCredit)
+        .options(joinedload(VendorCredit.vendor), selectinload(VendorCredit.lines))
+        .filter(VendorCredit.id == vc_id)
+        .first()
+    )
+    if not vc:
+        raise HTTPException(status_code=404, detail="Vendor credit not found")
+    return _with_vendor_name(vc)
+
+
+@router.post("", response_model=VendorCreditResponse, status_code=201)
+def create_vendor_credit(data: VendorCreditCreate, db: Session = Depends(get_db)):
+    check_closing_date(db, data.date)
+
+    vendor = db.query(Vendor).filter(Vendor.id == data.vendor_id).first()
+    if not vendor:
+        raise HTTPException(status_code=404, detail="Vendor not found")
+
+    if data.original_bill_id is not None:
+        bill = db.query(Bill).filter(Bill.id == data.original_bill_id).first()
+        if not bill:
+            raise HTTPException(status_code=404, detail="Bill not found")
+        if bill.vendor_id != data.vendor_id:
+            raise HTTPException(
+                status_code=400,
+                detail="That bill belongs to a different vendor.",
+            )
+
+    subtotal, tax_amount, total = compute_line_totals(data.lines, data.tax_rate)
+    if total <= 0:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "A vendor credit must be for more than zero. Enter the credit "
+                "as a positive amount — the document is what makes it a credit."
+            ),
+        )
+
+    vc = None
+    # Same retry as invoices and credit memos: next_vendor_credit_number is
+    # MAX+1 with no row lock, so two concurrent creates can compute the same
+    # number and one loses at the UNIQUE constraint on flush.
+    for _ in range(10):
+        vc = VendorCredit(
+            credit_number=next_vendor_credit_number(db),
+            vendor_id=data.vendor_id,
+            date=data.date,
+            original_bill_id=data.original_bill_id,
+            ref_number=data.ref_number,
+            subtotal=subtotal,
+            tax_rate=data.tax_rate,
+            tax_amount=tax_amount,
+            total=total,
+            balance_remaining=total,
+            notes=data.notes,
+            class_id=data.class_id,
+            job_id=data.job_id,
+            status=VendorCreditStatus.ISSUED,
+        )
+        db.add(vc)
+        try:
+            db.flush()
+            break
+        except IntegrityError as e:
+            if "credit_number" not in str(e.orig).lower():
+                raise
+            db.rollback()
+            vc = None
+    if vc is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Could not assign a vendor credit number — please retry.",
+        )
+
+    default_expense = db.query(Account).filter(Account.account_number == "6000").first()
+    default_expense_id = default_expense.id if default_expense else None
+
+    journal_lines = []
+    returns = []  # [(item, quantity, unit_cost), ...] for inventory lines
+
+    for i, line_data in enumerate(data.lines):
+        # Round per line so the stored line amount matches compute_line_totals
+        # and the credits land on the same cents as the rounded A/P debit.
+        amt = _q(Decimal(str(line_data.quantity)) * Decimal(str(line_data.rate)))
+        item = None
+        if line_data.item_id:
+            item = db.query(Item).filter(Item.id == line_data.item_id).first()
+
+        if item is not None and item.track_inventory:
+            # Returning stock to the vendor takes it off the shelf, so the
+            # credit goes against the Inventory asset, not an expense — the
+            # exact mirror of how a bill receives it. Refuse rather than
+            # silently posting to an expense account, which is what
+            # create_bill does for the same reason.
+            posting_acct = get_inventory_asset_account_id(db, item)
+            if not posting_acct:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Item '{item.name}' is inventory-tracked but has no "
+                        "asset_account_id and no account #1300 (Inventory) is "
+                        "seeded. Either set the item's inventory asset account "
+                        "or add the Inventory account to the chart of accounts."
+                    ),
+                )
+            if line_data.quantity > 0:
+                returns.append(
+                    (
+                        item,
+                        Decimal(str(line_data.quantity)),
+                        Decimal(str(line_data.rate)),
+                    )
+                )
+        else:
+            posting_acct = line_data.account_id
+            if not posting_acct and item and item.expense_account_id:
+                posting_acct = item.expense_account_id
+            if not posting_acct and vendor.default_expense_account_id:
+                posting_acct = vendor.default_expense_account_id
+            if not posting_acct:
+                posting_acct = default_expense_id
+
+        db.add(
+            VendorCreditLine(
+                vendor_credit_id=vc.id,
+                item_id=line_data.item_id,
+                account_id=posting_acct,
+                description=line_data.description,
+                quantity=line_data.quantity,
+                rate=line_data.rate,
+                amount=amt,
+                job_id=line_data.job_id,
+                class_id=line_data.class_id,
+                cost_code_id=line_data.cost_code_id,
+                line_order=line_data.line_order or i,
+            )
+        )
+
+        if amt > 0 and posting_acct:
+            journal_lines.append(
+                {
+                    "account_id": posting_acct,
+                    "debit": Decimal("0"),
+                    "credit": amt,
+                    "description": line_data.description or "",
+                    "job_id": line_data.job_id,
+                    "class_id": line_data.class_id,
+                    "cost_code_id": line_data.cost_code_id,
+                }
+            )
+
+    # Give back the sales tax that was charged on the original bill.
+    if tax_amount > 0:
+        tax_acct = db.query(Account).filter(Account.account_number == "2200").first()
+        if tax_acct:
+            journal_lines.append(
+                {
+                    "account_id": tax_acct.id,
+                    "debit": Decimal("0"),
+                    "credit": tax_amount,
+                    "description": "Sales tax on vendor credit",
+                }
+            )
+
+    if not journal_lines:
+        # Every line resolved to no account. Refuse rather than record a
+        # document that never reached the books — #119's rule.
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "No account could be found for any line on this credit, so "
+                "nothing would be posted. Set an account on each line, or "
+                "add account 6000 to the chart of accounts. Nothing was saved."
+            ),
+        )
+
+    ap_id = get_ap_account_id(db)
+    journal_lines.append(
+        {
+            "account_id": ap_id,
+            "debit": total,
+            "credit": Decimal("0"),
+            "description": f"Vendor Credit {vc.credit_number}",
+        }
+    )
+    txn = create_journal_entry(
+        db,
+        data.date,
+        f"Vendor Credit {vc.credit_number} - {vendor.name}",
+        journal_lines,
+        source_type="vendor_credit",
+        source_id=vc.id,
+        reference=vc.ref_number,
+        class_id=vc.class_id,
+        job_id=vc.job_id,
+    )
+    vc.transaction_id = txn.id
+
+    if returns:
+        from app.models.items import MovementType
+        from app.services.inventory_service import _append_movement
+
+        for item, qty, unit_cost in returns:
+            # Negative quantity: the goods went back to the vendor. Costed at
+            # the credit's own rate, not avg_cost, so a bill and the credit
+            # that reverses it net to zero on both quantity and value.
+            _append_movement(
+                db,
+                item,
+                MovementType.RETURN_OUT,
+                quantity=-qty,
+                unit_cost=unit_cost,
+                source_type="vendor_credit",
+                source_id=vc.id,
+                transaction_id=txn.id,
+                memo=f"Return to vendor: {vc.credit_number}",
+            )
+
+    db.commit()
+    db.refresh(vc)
+    return _with_vendor_name(vc)
+
+
+@router.post("/{vc_id}/apply")
+def apply_vendor_credit(
+    vc_id: int, data: VendorCreditApplicationCreate, db: Session = Depends(get_db)
+):
+    """Settle part of a bill with a credit the vendor already gave you.
+
+    Posts nothing. A/P moved when the credit was issued; this decides which
+    bill it pays down, and both sub-ledger rows move together so the aging
+    stays tied to account 2000.
+    """
+    # Lock both rows for the read-check-write. Two concurrent applies would
+    # otherwise both read the same balance_remaining and both pass the check,
+    # spending the credit twice. No-op on SQLite; a real lock on Postgres.
+    vc = (
+        db.query(VendorCredit)
+        .filter(VendorCredit.id == vc_id)
+        .with_for_update()
+        .first()
+    )
+    if not vc:
+        raise HTTPException(status_code=404, detail="Vendor credit not found")
+    if vc.status == VendorCreditStatus.VOID:
+        raise HTTPException(status_code=400, detail="Vendor credit is voided")
+
+    bill = db.query(Bill).filter(Bill.id == data.bill_id).with_for_update().first()
+    if not bill:
+        raise HTTPException(status_code=404, detail="Bill not found")
+    if bill.status == BillStatus.VOID:
+        raise HTTPException(status_code=400, detail="That bill is voided")
+    if bill.vendor_id != vc.vendor_id:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "That bill belongs to a different vendor. A credit can only "
+                "be applied to bills from the vendor who issued it."
+            ),
+        )
+
+    amount = Decimal(str(data.amount))
+    if amount <= 0:
+        raise HTTPException(status_code=400, detail="Amount must be more than zero")
+    if amount > Decimal(str(vc.balance_remaining or 0)):
+        raise HTTPException(status_code=400, detail="Amount exceeds credit balance")
+    if amount > Decimal(str(bill.balance_due or 0)):
+        raise HTTPException(status_code=400, detail="Amount exceeds bill balance")
+
+    db.add(
+        VendorCreditApplication(
+            vendor_credit_id=vc.id,
+            bill_id=data.bill_id,
+            amount=amount,
+        )
+    )
+
+    vc.amount_applied = Decimal(str(vc.amount_applied or 0)) + amount
+    vc.balance_remaining = Decimal(str(vc.balance_remaining or 0)) - amount
+    if vc.balance_remaining == 0:
+        vc.status = VendorCreditStatus.APPLIED
+
+    bill.amount_paid = Decimal(str(bill.amount_paid or 0)) + amount
+    bill.balance_due = Decimal(str(bill.balance_due or 0)) - amount
+    bill.status = BillStatus.PAID if bill.balance_due == 0 else BillStatus.PARTIAL
+
+    db.commit()
+    return {
+        "message": f"Applied {amount} to bill {bill.bill_number}",
+        "credit_balance_remaining": str(vc.balance_remaining),
+        "bill_balance_due": str(bill.balance_due),
+    }
+
+
+@router.post("/{vc_id}/void", response_model=VendorCreditResponse)
+def void_vendor_credit(vc_id: int, db: Session = Depends(get_db)):
+    """Reverse a vendor credit: put every application back on its bill, post
+    the mirror-image entry, put returned stock back on the shelf, and mark it
+    void."""
+    from app.models.items import MovementType
+    from app.services.inventory_service import _append_movement
+
+    vc = (
+        db.query(VendorCredit)
+        .filter(VendorCredit.id == vc_id)
+        .with_for_update()
+        .first()
+    )
+    if not vc:
+        raise HTTPException(status_code=404, detail="Vendor credit not found")
+    if vc.status == VendorCreditStatus.VOID:
+        raise HTTPException(status_code=400, detail="Vendor credit is already void")
+    check_closing_date(db, vc.date)
+
+    for app_row in list(vc.applications):
+        bill = (
+            db.query(Bill).filter(Bill.id == app_row.bill_id).with_for_update().first()
+        )
+        if bill:
+            amt = Decimal(str(app_row.amount))
+            bill.amount_paid = Decimal(str(bill.amount_paid or 0)) - amt
+            bill.balance_due = Decimal(str(bill.balance_due or 0)) + amt
+            bill.status = (
+                BillStatus.PARTIAL if bill.amount_paid > 0 else BillStatus.UNPAID
+            )
+        db.delete(app_row)
+
+    if vc.transaction_id:
+        txn = db.query(Transaction).filter(Transaction.id == vc.transaction_id).first()
+        if txn is not None:
+            create_journal_entry(
+                db,
+                vc.date,
+                f"VOID Vendor Credit {vc.credit_number}",
+                reversing_lines(txn.lines),
+                source_type="vendor_credit_void",
+                source_id=vc.id,
+                class_id=vc.class_id,
+                job_id=vc.job_id,
+            )
+
+    for line in vc.lines:
+        if not line.item_id:
+            continue
+        item = db.query(Item).filter(Item.id == line.item_id).first()
+        if item and item.track_inventory and line.quantity > 0:
+            _append_movement(
+                db,
+                item,
+                MovementType.VOID,
+                quantity=Decimal(str(line.quantity)),
+                unit_cost=Decimal(str(line.rate or 0)),
+                source_type="vendor_credit_void",
+                source_id=vc.id,
+                memo=f"VOID Vendor Credit {vc.credit_number}",
+            )
+
+    vc.amount_applied = Decimal("0")
+    vc.balance_remaining = Decimal("0")
+    vc.status = VendorCreditStatus.VOID
+    db.commit()
+    db.refresh(vc)
+    return _with_vendor_name(vc)

--- a/app/schemas/vendor_credits.py
+++ b/app/schemas/vendor_credits.py
@@ -1,0 +1,87 @@
+from datetime import date as dt_date, datetime
+from decimal import Decimal
+from typing import Optional
+from pydantic import BaseModel, field_validator, model_validator
+
+from app.schemas.common import StrictModel, TaxRateFloat, validate_non_negative_line
+
+
+class VendorCreditLineCreate(StrictModel):
+    item_id: Optional[int] = None
+    account_id: Optional[int] = None
+    description: Optional[str] = None
+    quantity: float = 1
+    rate: float = 0
+    job_id: Optional[int] = None
+    class_id: Optional[int] = None
+    cost_code_id: Optional[int] = None
+    line_order: int = 0
+
+    @model_validator(mode="after")
+    def _check_non_negative(self):
+        # A credit is entered as a positive amount, the same way a bill is.
+        # The direction is the document's job, not the operator's.
+        validate_non_negative_line(self.quantity, self.rate)
+        return self
+
+
+class VendorCreditLineResponse(BaseModel):
+    id: int
+    item_id: Optional[int] = None
+    account_id: Optional[int] = None
+    description: Optional[str] = None
+    quantity: Decimal = Decimal("0")
+    rate: Decimal = Decimal("0")
+    amount: Decimal = Decimal("0")
+    job_id: Optional[int] = None
+    class_id: Optional[int] = None
+    cost_code_id: Optional[int] = None
+    line_order: int = 0
+    model_config = {"from_attributes": True}
+
+
+class VendorCreditApplicationCreate(StrictModel):
+    bill_id: int
+    amount: float
+
+
+class VendorCreditCreate(StrictModel):
+    vendor_id: int
+    date: dt_date
+    original_bill_id: Optional[int] = None
+    ref_number: Optional[str] = None
+    tax_rate: TaxRateFloat = 0
+    notes: Optional[str] = None
+    class_id: Optional[int] = None
+    job_id: Optional[int] = None
+    lines: list[VendorCreditLineCreate] = []
+
+    @field_validator("lines")
+    @classmethod
+    def _require_lines(cls, v):
+        if not v:
+            raise ValueError("vendor credit must have at least one line")
+        return v
+
+
+class VendorCreditResponse(BaseModel):
+    id: int
+    credit_number: str
+    vendor_id: int
+    vendor_name: Optional[str] = None
+    status: str
+    original_bill_id: Optional[int] = None
+    ref_number: Optional[str] = None
+    date: dt_date
+    subtotal: Decimal = Decimal("0")
+    tax_rate: Decimal = Decimal("0")
+    tax_amount: Decimal = Decimal("0")
+    total: Decimal = Decimal("0")
+    amount_applied: Decimal = Decimal("0")
+    balance_remaining: Decimal = Decimal("0")
+    notes: Optional[str] = None
+    class_id: Optional[int] = None
+    job_id: Optional[int] = None
+    lines: list[VendorCreditLineResponse] = []
+    created_at: Optional[datetime] = None
+    model_config = {"from_attributes": True}

--- a/app/services/bank_register.py
+++ b/app/services/bank_register.py
@@ -79,6 +79,7 @@ _LINKS = {
     "bill": "/#/bills/{id}",
     "payment": "/#/payments/{id}",
     "bill_payment": "/#/bill-payments/{id}",
+    "vendor_credit": "/#/vendor-credits/{id}",
     "journal": "/#/journal/{id}",
     "manual_journal": "/#/journal/{id}",
     "manual": "/#/journal/{txn}",

--- a/app/services/numbering.py
+++ b/app/services/numbering.py
@@ -17,6 +17,7 @@ from sqlalchemy import func as sqlfunc
 from sqlalchemy.orm import Session
 
 from app.models.credit_memos import CreditMemo
+from app.models.vendor_credits import VendorCredit
 from app.models.estimates import Estimate
 from app.models.invoices import Invoice
 from app.models.purchase_orders import PurchaseOrder
@@ -69,6 +70,16 @@ def next_invoice_number(db: Session) -> str:
 def next_credit_memo_number(db: Session) -> str:
     return next_document_number(
         db, CreditMemo.memo_number, prefix="CM-", first=1, pad=4
+    )
+
+
+def next_vendor_credit_number(db: Session) -> str:
+    """VC-0001. Its own series, not shared with credit memos — a vendor
+    credit and a customer credit memo are different documents and an
+    operator reading "CM-0007" on a supplier's paperwork would be right to
+    doubt it."""
+    return next_document_number(
+        db, VendorCredit.credit_number, prefix="VC-", first=1, pad=4
     )
 
 

--- a/app/static/css/dark.css
+++ b/app/static/css/dark.css
@@ -338,6 +338,8 @@
 [data-theme="dark"] .badge-recorded { background: #1a3a2a; color: #4caf7a; border-color: #2a6a4a; }
 [data-theme="dark"] .badge-partial { background: #3a3010; color: #e0a840; border-color: #5a5020; }
 [data-theme="dark"] .badge-void { background: #3a1a1a; color: #e05555; border-color: #5a2a2a; }
+[data-theme="dark"] .badge-issued { background: #1a3a5a; color: #6bb3e8; border-color: #2a5a8a; }
+[data-theme="dark"] .badge-applied { background: #1a3a2a; color: #4caf7a; border-color: #2a6a4a; }
 [data-theme="dark"] .badge-overdue { background: #3a1a1a; color: #e05555; border-color: #5a2a2a; }
 
 /* Amount columns */

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -738,6 +738,12 @@ td.amount, th.amount {
 .badge-paid    { background: #d1fae5; color: #065f46; border: 1px solid #6ee7b7; }
 .badge-recorded { background: #d1fae5; color: #065f46; border: 1px solid #6ee7b7; }
 .badge-void    { background: #fee2e2; color: #991b1b; border: 1px solid #fca5a5; }
+/* issued / applied: the credit-document vocabulary. These existed in the
+   status enum from the day credit memos shipped and had no rule, so every
+   credit memo has been rendering an unstyled badge. Vendor credits use the
+   same words, so both are styled here. */
+.badge-issued  { background: #dbeafe; color: #1e40af; border: 1px solid #93c5fd; }
+.badge-applied { background: #d1fae5; color: #065f46; border: 1px solid #6ee7b7; }
 .badge-pending { background: #fef3c7; color: #92400e; border: 1px solid #fbbf24; }
 .badge-accepted{ background: #d1fae5; color: #065f46; border: 1px solid #6ee7b7; }
 .badge-rejected{ background: #fee2e2; color: #991b1b; border: 1px solid #fca5a5; }

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -31,6 +31,8 @@ const App = {
         '/purchase-orders': { page: 'purchase-orders', label: 'Purchase Orders',  render: () => PurchaseOrdersPage.render() },
         '/bills':         { page: 'bills',           label: 'Bills',              render: () => BillsPage.render() },
         '/credit-memos':  { page: 'credit-memos',    label: 'Credit Memos',       render: () => CreditMemosPage.render() },
+        '/vendor-credits':{ page: 'vendor-credits',  label: 'Vendor Credits',     render: () => VendorCreditsPage.render() },
+        '/vendor-credits/:id': { page: 'vendor-credits', label: 'Vendor Credit',  render: (id) => VendorCreditsPage.view(id) },
         // Phase 3: Productivity
         '/recurring':     { page: 'recurring',       label: 'Recurring Invoices', render: () => RecurringPage.render() },
         '/batch-payments': { page: 'batch-payments', label: 'Batch Payments',     render: () => BatchPaymentsPage.render() },

--- a/app/static/js/jobs.js
+++ b/app/static/js/jobs.js
@@ -402,7 +402,8 @@ const JobsPage = {
 
     sourceLabel(t) {
         return { invoice: T('Invoice'), bill: 'Bill', expense: 'Expense', cc_charge: 'Card charge', manual: 'Journal',
-            credit_memo: 'Credit memo', sales_receipt: 'Sales receipt', deposit: 'Deposit', check: 'Check',
+            credit_memo: 'Credit memo', vendor_credit: 'Vendor credit', vendor_credit_void: 'Void vendor credit',
+            sales_receipt: 'Sales receipt', deposit: 'Deposit', check: 'Check',
             job_cost: `${T('Job')} cost`, job_cost_void: `Void ${T('Job').toLowerCase()} cost`, expense_void: 'Void expense', bill_void: 'Void bill' }[t] || (t || 'Entry');
     },
 

--- a/app/static/js/vendor_credits.js
+++ b/app/static/js/vendor_credits.js
@@ -1,0 +1,201 @@
+/**
+ * Vendor Credits — the AP-side counterpart of a credit memo (issue #129).
+ *
+ * A supplier credits you for returned or short-shipped materials. The
+ * document debits Accounts Payable and credits the expense (or Inventory,
+ * for stock going back). Applying it to a bill posts nothing — it decides
+ * which bill the credit settles.
+ */
+const VendorCreditsPage = {
+    async render() {
+        const credits = await API.get('/vendor-credits');
+        return renderListPage({
+            title: 'Vendor Credits',
+            headerHtml: `<button class="btn btn-primary" onclick="VendorCreditsPage.showForm()">+ New Vendor Credit</button>`,
+            empty: '<p>No vendor credits yet. Enter one when a supplier credits you for a return, a short shipment or an overcharge.</p>',
+            columns: ['#', 'Vendor', 'Date', 'Ref', 'Status',
+                { label: 'Total', cls: 'amount' }, { label: 'Remaining', cls: 'amount' }, 'Actions'],
+            items: credits,
+            row: c => `<tr>
+                    <td><strong>${escapeHtml(c.credit_number)}</strong></td>
+                    <td>${escapeHtml(c.vendor_name || '')}</td>
+                    <td>${formatDate(c.date)}</td>
+                    <td>${escapeHtml(c.ref_number || '')}</td>
+                    <td>${statusBadge(c.status)}</td>
+                    <td class="amount">${formatCurrency(c.total)}</td>
+                    <td class="amount">${formatCurrency(c.balance_remaining)}</td>
+                    <td class="actions">
+                        ${c.status === 'issued' ? `<button class="btn btn-sm btn-primary" onclick="VendorCreditsPage.showApply(${c.id})">Apply</button>` : ''}
+                        ${c.status !== 'void' ? `<button class="btn btn-sm btn-secondary" onclick="VendorCreditsPage.void(${c.id})">Void</button>` : ''}
+                    </td>
+                </tr>`,
+        });
+    },
+
+    async view(id) {
+        const c = await API.get(`/vendor-credits/${id}`);
+        const lines = (c.lines || []).map(l => `<tr>
+                <td>${escapeHtml(l.description || '')}</td>
+                <td class="amount">${l.quantity}</td>
+                <td class="amount">${formatCurrency(l.rate)}</td>
+                <td class="amount">${formatCurrency(l.amount)}</td>
+            </tr>`).join('');
+        openModal(`Vendor Credit ${escapeHtml(c.credit_number)}`, `
+            <p>${escapeHtml(c.vendor_name || '')} &middot; ${formatDate(c.date)} &middot; ${statusBadge(c.status)}</p>
+            <div class="table-container"><table>
+                <thead><tr><th scope="col">Description</th><th scope="col" class="amount">Qty</th><th scope="col" class="amount">Rate</th><th scope="col" class="amount">Amount</th></tr></thead>
+                <tbody>${lines}</tbody>
+            </table></div>
+            <p style="margin-top:8px;">Total ${formatCurrency(c.total)} &middot; applied ${formatCurrency(c.amount_applied)} &middot; remaining <strong>${formatCurrency(c.balance_remaining)}</strong></p>
+            <div class="form-actions"><button class="btn btn-secondary" onclick="closeModal()">Close</button></div>`);
+        return '';
+    },
+
+    async void(id) {
+        if (!confirm('Void this vendor credit? Any applied credit goes back onto the bill, a reversing entry is posted, and returned stock goes back on the shelf.')) return;
+        try {
+            await API.post(`/vendor-credits/${id}/void`, {});
+            toast('Vendor credit voided');
+            App.navigate('#/vendor-credits');
+        } catch (err) { toast(err.message, 'error'); }
+    },
+
+    _items: [],
+    _accounts: [],
+    lineCount: 0,
+
+    async showForm() {
+        const [vendors, items, accounts] = await Promise.all([
+            API.get('/vendors?active_only=true'),
+            API.get('/items?active_only=true'),
+            API.get('/accounts?active_only=true'),
+        ]);
+        VendorCreditsPage._items = items;
+        VendorCreditsPage._accounts = accounts.filter(a => a.account_type === 'expense' || a.account_type === 'cogs');
+        VendorCreditsPage.lineCount = 1;
+        const classGroup = await classFormGroupHtml();
+
+        const vendOpts = vendors.map(v => `<option value="${v.id}">${escapeHtml(v.name)}</option>`).join('');
+
+        openModal('New Vendor Credit', `
+            <form onsubmit="VendorCreditsPage.save(event)">
+                <p class="form-hint">Enter the credit as a positive amount. It reduces what you owe this vendor, and you choose which bill it settles afterwards.</p>
+                <div class="form-grid">
+                    <div class="form-group"><label>Vendor *</label>
+                        <select name="vendor_id" required><option value="">Select...</option>${vendOpts}</select></div>
+                    <div class="form-group"><label>Date *</label>
+                        <input name="date" type="date" required value="${todayISO()}"></div>
+                    <div class="form-group"><label>Their credit note #</label>
+                        <input name="ref_number" placeholder="optional"></div>
+                    <div class="form-group"><label>Tax Rate (%)</label>
+                        <input name="tax_rate" type="number" step="0.01" value="0"></div>
+                    ${classGroup}
+                </div>
+                <h3 style="margin:12px 0 8px;font-size:14px;">Credit Lines</h3>
+                <table class="line-items-table">
+                    <thead><tr><th scope="col">Item</th><th scope="col">Account</th><th scope="col">Description</th><th scope="col" class="col-qty">Qty</th><th scope="col" class="col-rate">Rate</th></tr></thead>
+                    <tbody id="vc-lines">${VendorCreditsPage.lineHtml(0)}</tbody>
+                </table>
+                <button type="button" class="btn btn-sm btn-secondary" style="margin-top:8px;" onclick="VendorCreditsPage.addLine()">+ Add Line</button>
+                <div class="form-group" style="margin-top:12px;"><label>Notes</label>
+                    <textarea name="notes"></textarea></div>
+                <div class="form-actions">
+                    <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Create Vendor Credit</button>
+                </div>
+            </form>`);
+    },
+
+    lineHtml(idx) {
+        const itemOpts = VendorCreditsPage._items.map(i => `<option value="${i.id}">${escapeHtml(i.name)}</option>`).join('');
+        const acctOpts = VendorCreditsPage._accounts.map(a => `<option value="${a.id}">${escapeHtml(a.account_number + ' ' + a.name)}</option>`).join('');
+        return `<tr data-vcline="${idx}">
+                <td><select class="line-item"><option value="">--</option>${itemOpts}</select></td>
+                <td><select class="line-account"><option value="">Default</option>${acctOpts}</select></td>
+                <td><input class="line-desc"></td>
+                <td><input class="line-qty" type="number" step="0.01" value="1"></td>
+                <td><input class="line-rate" type="number" step="0.01" value="0"></td>
+            </tr>`;
+    },
+
+    addLine() {
+        $('#vc-lines').insertAdjacentHTML('beforeend', VendorCreditsPage.lineHtml(VendorCreditsPage.lineCount++));
+    },
+
+    async save(e) {
+        e.preventDefault();
+        const form = e.target;
+        const lines = [];
+        $$('#vc-lines tr').forEach((row, i) => {
+            const acct = row.querySelector('.line-account')?.value;
+            lines.push({
+                item_id: row.querySelector('.line-item')?.value ? parseInt(row.querySelector('.line-item').value) : null,
+                account_id: acct ? parseInt(acct) : null,
+                description: row.querySelector('.line-desc')?.value || '',
+                quantity: parseFloat(row.querySelector('.line-qty')?.value) || 1,
+                rate: parseFloat(row.querySelector('.line-rate')?.value) || 0,
+                line_order: i,
+            });
+        });
+        try {
+            await API.post('/vendor-credits', {
+                vendor_id: parseInt(form.vendor_id.value),
+                date: form.date.value,
+                ref_number: form.ref_number.value || null,
+                tax_rate: (parseFloat(form.tax_rate.value) || 0) / 100,
+                notes: form.notes.value || null,
+                class_id: classIdFromForm(form),
+                lines,
+            });
+            toast('Vendor credit created');
+            closeModal();
+            App.navigate('#/vendor-credits');
+        } catch (err) { toast(err.message, 'error'); }
+    },
+
+    async showApply(vcId) {
+        const vc = await API.get(`/vendor-credits/${vcId}`);
+        const bills = await API.get(`/bills?vendor_id=${vc.vendor_id}`);
+        const open = bills.filter(b => b.status !== 'void' && b.status !== 'paid' && parseFloat(b.balance_due) > 0);
+
+        let rows = open.map(b => `
+            <tr>
+                <td>${escapeHtml(b.bill_number)}</td>
+                <td>${formatDate(b.date)}</td>
+                <td class="amount">${formatCurrency(b.balance_due)}</td>
+                <td><input type="number" step="0.01" class="vc-apply-amt" data-bill="${b.id}" value="0" style="width:90px;"></td>
+            </tr>`).join('');
+        if (!rows) rows = '<tr><td colspan="4">No open bills for this vendor. The credit stays on their account until there is one.</td></tr>';
+
+        openModal(`Apply Credit ${escapeHtml(vc.credit_number)}`, `
+            <p style="margin-bottom:8px;">Credit remaining: <strong>${formatCurrency(vc.balance_remaining)}</strong></p>
+            <div class="table-container"><table>
+                <thead><tr><th scope="col">Bill</th><th scope="col">Date</th><th scope="col" class="amount">Balance</th><th scope="col" class="amount">Apply</th></tr></thead>
+                <tbody>${rows}</tbody>
+            </table></div>
+            <div class="form-actions">
+                <button class="btn btn-secondary" onclick="closeModal()">Cancel</button>
+                <button class="btn btn-primary" onclick="VendorCreditsPage.doApply(${vcId})">Apply Credit</button>
+            </div>`);
+    },
+
+    async doApply(vcId) {
+        const inputs = $$('.vc-apply-amt');
+        let applied = 0;
+        for (const input of inputs) {
+            const amt = parseFloat(input.value) || 0;
+            if (amt > 0) {
+                try {
+                    await API.post(`/vendor-credits/${vcId}/apply`, {
+                        bill_id: parseInt(input.dataset.bill), amount: amt,
+                    });
+                    applied += amt;
+                } catch (err) { toast(err.message, 'error'); return; }
+            }
+        }
+        if (!applied) { toast('Enter an amount to apply', 'error'); return; }
+        toast('Credit applied');
+        closeModal();
+        App.navigate('#/vendor-credits');
+    },
+};

--- a/app/static/whats-new.json
+++ b/app/static/whats-new.json
@@ -1,4 +1,12 @@
 {
+  "2.11.0": {
+    "title": "Record a credit from a supplier",
+    "items": [
+      "Vendor Credits: when a supplier credits you for a return, a short shipment or an overcharge, record it as its own document. It reduces what you owe that vendor, and you choose which bill it settles — or leave it on their account for the next one",
+      "A/P and A/R aging now show credits you are holding. A credit you had not yet applied was invisible on both reports, so they read higher than the account they are supposed to agree with",
+      "Returning stock to a supplier takes it off the shelf and out of Inventory, instead of leaving an asset on the balance sheet for goods that are gone"
+    ]
+  },
   "2.10.3": {
     "title": "Attachments follow a company file between computers",
     "items": [

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -32,6 +32,9 @@ files under `migrations/versions/`; for model code, see `app/models/`.
 | `bill_payment_allocations` | Maps bill payments to bills |
 | `credit_memos` | Customer credit memos |
 | `credit_memo_lines` | Credit memo line items |
+| `vendor_credits` | Supplier credits against Accounts Payable |
+| `vendor_credit_lines` | Vendor credit line items (carry the expense account, like bill lines) |
+| `vendor_credit_applications` | Which bill a vendor credit settled, and for how much |
 | `credit_applications` | Maps credit memos to invoices |
 | `recurring_invoices` | Recurring invoice templates |
 | `recurring_invoice_lines` | Recurring invoice line items |
@@ -68,7 +71,8 @@ files under `migrations/versions/`; for model code, see `app/models/`.
 
 `job_id` (nullable FK) lives on: transactions, transaction_lines, invoices,
 invoice_lines, bills, bill_lines, estimates, estimate_lines, purchase_orders,
-purchase_order_lines, credit_memos, recurring_invoices, time_entries.
+purchase_order_lines, credit_memos, vendor_credits, vendor_credit_lines,
+recurring_invoices, time_entries.
 `class_id` was added to transaction_lines, invoice_lines and bill_lines.
 Attribution rule for reports: `coalesce(line.job_id, transaction.job_id)`.
 Migration `e9f0a1b2c3d4_add_jobs`.

--- a/docs/features.md
+++ b/docs/features.md
@@ -21,6 +21,7 @@ pass, and the per-integration setup guides ([Stripe](setup-stripe.md),
 - **Recurring Invoices** — Schedule automatic invoice generation (weekly/monthly/quarterly/yearly) with manual "Generate Now" or cron script
 - **Batch Payments** — Apply payments to multiple invoices across multiple customers in a single transaction
 - **Credit Memos** — Issue credits against customers, apply to invoices to reduce balance due. Proper reversing journal entries
+- **Vendor Credits** — Record a credit a supplier gave you for a return, a short shipment or an overcharge. Debits Accounts Payable and credits the expense (or Inventory, for stock going back), then applies to any of that vendor's open bills or sits on their account until there is one. Applying posts nothing — A/P moved when the credit was issued
 - **Quick Entry Mode** — Batch invoice entry for paper invoice backlog. Save & Next (Ctrl+Enter) with running log
 
 ![Invoices with IRS Pub 583 Mock Data](../screenshots/invoices.png)
@@ -470,6 +471,9 @@ All endpoints under `/api/`. Swagger docs at `/docs`. 300+ routes across 50 rout
 | `/api/bill-payments` | POST | Pay vendor bills with allocation |
 | `/api/credit-memos` | GET, POST | Credit memo CRUD |
 | `/api/credit-memos/{id}/apply` | POST | Apply credit to invoices |
+| `/api/vendor-credits` | GET, POST | Vendor credit list and create |
+| `/api/vendor-credits/{id}` | GET | One vendor credit with its lines |
+| `/api/vendor-credits/{id}/apply` | POST | Apply a vendor credit to a bill |
 
 ### Productivity
 | Endpoint | Methods | Description |
@@ -536,6 +540,7 @@ All payroll, HR, tax-form, and self-service portal endpoints are documented with
 | `/api/donors/{id}/giving-statement/pdf`, `/api/donors/giving-statements/{pdf,batch-email}` | GET, POST | Year-end giving statements |
 | `/api/invoices/{id}/write-off` | POST | Write an open balance off to Bad Debt Expense |
 | `/api/credit-memos/{id}/void` | POST | Void a credit memo (unwinds applications) |
+| `/api/vendor-credits/{id}/void` | POST | Void a vendor credit (unwinds applications, returns stock) |
 
 ### Import/Export
 | Endpoint | Methods | Description |

--- a/index.html
+++ b/index.html
@@ -110,6 +110,8 @@
                         <span class="nav-icon">&#9997;</span> Purchase Orders</a></li>
                     <li><a href="#/bills" class="nav-link" data-page="bills">
                         <span class="nav-icon">&#9830;</span> Bills</a></li>
+                    <li><a href="#/vendor-credits" class="nav-link" data-page="vendor-credits">
+                        <span class="nav-icon">&#8722;</span> Vendor Credits</a></li>
                     <li><a href="#/job-costs" class="nav-link" data-page="job-costs">
                         <span class="nav-icon">&#9874;</span> Job Costs</a></li>
                     <li><a href="#/expenses" class="nav-link" data-page="expenses">
@@ -256,6 +258,7 @@
     <script src="/static/js/bills.js"></script>
     <script src="/static/js/expenses.js"></script>
     <script src="/static/js/credit_memos.js"></script>
+    <script src="/static/js/vendor_credits.js"></script>
     <!-- Phase 3: Productivity -->
     <script src="/static/js/recurring.js"></script>
     <script src="/static/js/batch_payments.js"></script>

--- a/migrations/versions/f8a9b0c1d2e3_vendor_credits.py
+++ b/migrations/versions/f8a9b0c1d2e3_vendor_credits.py
@@ -1,0 +1,199 @@
+"""vendor credits (issue #129)
+
+The AP-side counterpart of a customer credit memo. A supplier issuing a
+credit for returned or short-shipped materials had nowhere correct to go:
+bills and expenses both reject a negative amount and both point at credit
+memos, which only accept a customer. A manual journal entry against
+Accounts Payable moves the general ledger but not the vendor sub-ledger,
+so A/P aging and the vendor balance stop agreeing with account 2000 —
+the same split #119 was about.
+
+Three tables, mirroring credit_memos / credit_memo_lines /
+credit_applications:
+
+- vendor_credits: header, with the running amount_applied and
+  balance_remaining that make an unapplied credit a real open item.
+- vendor_credit_lines: carries account_id (the expense account being
+  credited back) because bill lines do, where a credit-memo line takes
+  its account from the item's income side because invoice lines do.
+- vendor_credit_applications: which bill a credit settled, and for how
+  much. Applying posts nothing — the credit already moved A/P when it
+  was issued.
+
+Data-only note: nothing is backfilled. There is no earlier
+representation of a vendor credit to migrate from; that absence is the
+issue.
+
+Revision ID: f8a9b0c1d2e3
+Revises: e7f8a9b0c1d2
+Create Date: 2026-09-10
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "f8a9b0c1d2e3"
+down_revision: Union[str, None] = "e7f8a9b0c1d2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "vendor_credits",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("credit_number", sa.String(length=50), nullable=False),
+        sa.Column("vendor_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "DRAFT",
+                "ISSUED",
+                "APPLIED",
+                "VOID",
+                name="vendorcreditstatus",
+            ),
+            nullable=True,
+        ),
+        sa.Column("original_bill_id", sa.Integer(), nullable=True),
+        sa.Column("ref_number", sa.String(length=100), nullable=True),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("subtotal", sa.Numeric(12, 2), nullable=True),
+        sa.Column("tax_rate", sa.Numeric(5, 4), nullable=True),
+        sa.Column("tax_amount", sa.Numeric(12, 2), nullable=True),
+        sa.Column("total", sa.Numeric(12, 2), nullable=True),
+        sa.Column("amount_applied", sa.Numeric(12, 2), nullable=True),
+        sa.Column("balance_remaining", sa.Numeric(12, 2), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("transaction_id", sa.Integer(), nullable=True),
+        sa.Column("class_id", sa.Integer(), nullable=True),
+        sa.Column("job_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+        ),
+        sa.ForeignKeyConstraint(
+            ["vendor_id"], ["vendors.id"], name="fk_vendor_credits_vendor_id"
+        ),
+        sa.ForeignKeyConstraint(
+            ["original_bill_id"], ["bills.id"], name="fk_vendor_credits_bill_id"
+        ),
+        sa.ForeignKeyConstraint(
+            ["transaction_id"],
+            ["transactions.id"],
+            name="fk_vendor_credits_transaction_id",
+        ),
+        sa.ForeignKeyConstraint(
+            ["class_id"], ["classes.id"], name="fk_vendor_credits_class_id"
+        ),
+        sa.ForeignKeyConstraint(
+            ["job_id"], ["jobs.id"], name="fk_vendor_credits_job_id"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("credit_number", name="uq_vendor_credits_credit_number"),
+    )
+    op.create_index(
+        "ix_vendor_credits_vendor_id", "vendor_credits", ["vendor_id"], unique=False
+    )
+    op.create_index("ix_vendor_credits_id", "vendor_credits", ["id"], unique=False)
+
+    op.create_table(
+        "vendor_credit_lines",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("vendor_credit_id", sa.Integer(), nullable=False),
+        sa.Column("item_id", sa.Integer(), nullable=True),
+        sa.Column("account_id", sa.Integer(), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("quantity", sa.Numeric(10, 2), nullable=True),
+        sa.Column("rate", sa.Numeric(12, 2), nullable=True),
+        sa.Column("amount", sa.Numeric(12, 2), nullable=True),
+        sa.Column("job_id", sa.Integer(), nullable=True),
+        sa.Column("class_id", sa.Integer(), nullable=True),
+        sa.Column("cost_code_id", sa.Integer(), nullable=True),
+        sa.Column("line_order", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["vendor_credit_id"],
+            ["vendor_credits.id"],
+            name="fk_vendor_credit_lines_vendor_credit_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["item_id"], ["items.id"], name="fk_vendor_credit_lines_item_id"
+        ),
+        sa.ForeignKeyConstraint(
+            ["account_id"], ["accounts.id"], name="fk_vendor_credit_lines_account_id"
+        ),
+        sa.ForeignKeyConstraint(
+            ["job_id"], ["jobs.id"], name="fk_vendor_credit_lines_job_id"
+        ),
+        sa.ForeignKeyConstraint(
+            ["class_id"], ["classes.id"], name="fk_vendor_credit_lines_class_id"
+        ),
+        sa.ForeignKeyConstraint(
+            ["cost_code_id"],
+            ["cost_codes.id"],
+            name="fk_vendor_credit_lines_cost_code_id",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_vendor_credit_lines_vendor_credit_id",
+        "vendor_credit_lines",
+        ["vendor_credit_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_vendor_credit_lines_id", "vendor_credit_lines", ["id"], unique=False
+    )
+
+    op.create_table(
+        "vendor_credit_applications",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("vendor_credit_id", sa.Integer(), nullable=False),
+        sa.Column("bill_id", sa.Integer(), nullable=False),
+        sa.Column("amount", sa.Numeric(12, 2), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["vendor_credit_id"],
+            ["vendor_credits.id"],
+            name="fk_vendor_credit_applications_vendor_credit_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["bill_id"], ["bills.id"], name="fk_vendor_credit_applications_bill_id"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_vendor_credit_applications_vendor_credit_id",
+        "vendor_credit_applications",
+        ["vendor_credit_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_vendor_credit_applications_bill_id",
+        "vendor_credit_applications",
+        ["bill_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_vendor_credit_applications_id",
+        "vendor_credit_applications",
+        ["id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("vendor_credit_applications")
+    op.drop_table("vendor_credit_lines")
+    op.drop_table("vendor_credits")
+    # The Enum is a real type on PostgreSQL and must be dropped by name;
+    # on SQLite it is a CHECK constraint that went with the table.
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        sa.Enum(name="vendorcreditstatus").drop(bind, checkfirst=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,7 @@ from app.models import (  # noqa: F401,E402
     companies,
     contacts,
     credit_memos,
+    vendor_credits,
     deductions,
     document_audit as document_audit_model,
     email_log,

--- a/tests/test_migration_banking_ledger.py
+++ b/tests/test_migration_banking_ledger.py
@@ -120,10 +120,17 @@ def test_upgrade_flags_bank_accounts_links_feeds_and_remaps_statement_lines(tmp_
     assert "transaction_line_id" in {
         r[1] for r in con.execute("PRAGMA table_info(bank_transactions)")
     }
-    assert (
-        con.execute("SELECT version_num FROM alembic_version").fetchone()[0]
-        == "e7f8a9b0c1d2"
-    )
+    # The upgrade ran all the way to the repo's head. Asserting a literal
+    # revision here made this test fail on the next release instead of on a
+    # real defect, so ask alembic what head is.
+    from alembic.script import ScriptDirectory
+
+    head = ScriptDirectory.from_config(cfg).get_current_head()
+    assert con.execute("SELECT version_num FROM alembic_version").fetchone()[0] == head
+    # ...and this revision is part of how it got there.
+    assert "e7f8a9b0c1d2" in {
+        r.revision for r in ScriptDirectory.from_config(cfg).walk_revisions()
+    }
     con.close()
 
 

--- a/tests/test_vendor_credits.py
+++ b/tests/test_vendor_credits.py
@@ -1,0 +1,594 @@
+"""Vendor credits — the AP-side counterpart of a customer credit memo
+(issue #129, CimarronSiteServices).
+
+A bill posts DR Expense / CR A/P. A vendor credit is its mirror. Applying
+one to a bill posts nothing: A/P already moved when the credit was issued.
+
+The tests that matter here are the ones that tie the vendor sub-ledger to
+account 2000, because the reporter's own objection to using a journal entry
+was that a JE moves one and not the other.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from app.models.accounts import Account
+from app.models.items import InventoryMovement, MovementType
+from app.models.transactions import Transaction, TransactionLine
+
+
+@pytest.fixture
+def vendor(client):
+    r = client.post("/api/vendors", json={"name": "Acme Supply"})
+    assert r.status_code in (200, 201), r.text
+    return r.json()
+
+
+def _bill(client, vendor, seed_accounts, amount="1000.00", day=1):
+    r = client.post(
+        "/api/bills",
+        json={
+            "vendor_id": vendor["id"],
+            "bill_number": f"B-{day:03d}",
+            "date": f"2026-04-{day:02d}",
+            "due_date": f"2026-04-{day:02d}",
+            "lines": [
+                {
+                    "description": "materials",
+                    "quantity": 1,
+                    "rate": amount,
+                    "account_id": seed_accounts["6000"].id,
+                    "line_order": 0,
+                }
+            ],
+        },
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _credit(client, vendor, seed_accounts, amount="300.00", day=5, **extra):
+    body = {
+        "vendor_id": vendor["id"],
+        "date": f"2026-04-{day:02d}",
+        "lines": [
+            {
+                "description": "returned materials",
+                "quantity": 1,
+                "rate": amount,
+                "account_id": seed_accounts["6000"].id,
+                "line_order": 0,
+            }
+        ],
+    }
+    body.update(extra)
+    r = client.post("/api/vendor-credits", json=body)
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _gl(db, account_id):
+    """Signed balance of one account: debits minus credits."""
+    lines = (
+        db.query(TransactionLine).filter(TransactionLine.account_id == account_id).all()
+    )
+    return sum(Decimal(str(x.debit or 0)) - Decimal(str(x.credit or 0)) for x in lines)
+
+
+# ── The document posts the mirror of a bill ──────────────────────────────
+
+
+def test_a_vendor_credit_debits_ap_and_credits_the_expense(
+    client, db_session, seed_accounts, vendor
+):
+    vc = _credit(client, vendor, seed_accounts, "300.00")
+    assert vc["credit_number"].startswith("VC-")
+    assert vc["status"] == "issued"
+    assert Decimal(vc["balance_remaining"]) == Decimal("300.00")
+
+    txn = (
+        db_session.query(Transaction)
+        .filter(
+            Transaction.source_type == "vendor_credit",
+            Transaction.source_id == vc["id"],
+        )
+        .one()
+    )
+    by_acct = {ln.account_id: ln for ln in txn.lines}
+    assert by_acct[seed_accounts["2000"].id].debit == Decimal("300.00")
+    assert by_acct[seed_accounts["6000"].id].credit == Decimal("300.00")
+    assert sum(ln.debit for ln in txn.lines) == sum(ln.credit for ln in txn.lines)
+
+
+def test_a_bill_and_a_credit_that_reverses_it_net_to_nothing(
+    client, db_session, seed_accounts, vendor
+):
+    _bill(client, vendor, seed_accounts, "1000.00")
+    _credit(client, vendor, seed_accounts, "1000.00")
+    assert _gl(db_session, seed_accounts["2000"].id) == Decimal("0")
+    assert _gl(db_session, seed_accounts["6000"].id) == Decimal("0")
+
+
+def test_the_tax_charged_on_the_bill_comes_back(
+    client, db_session, seed_accounts, vendor
+):
+    vc = _credit(client, vendor, seed_accounts, "100.00", tax_rate=0.10)
+    assert Decimal(vc["tax_amount"]) == Decimal("10.00")
+    assert Decimal(vc["total"]) == Decimal("110.00")
+    txn = (
+        db_session.query(Transaction)
+        .filter(Transaction.source_id == vc["id"])
+        .filter(Transaction.source_type == "vendor_credit")
+        .one()
+    )
+    by_acct = {ln.account_id: ln for ln in txn.lines}
+    assert by_acct[seed_accounts["2200"].id].credit == Decimal("10.00")
+    assert by_acct[seed_accounts["2000"].id].debit == Decimal("110.00")
+
+
+def test_a_line_with_no_account_falls_back_to_the_vendors_default_then_6000(
+    client, db_session, seed_accounts, vendor
+):
+    r = client.post(
+        "/api/vendor-credits",
+        json={
+            "vendor_id": vendor["id"],
+            "date": "2026-04-05",
+            "lines": [{"description": "credit", "quantity": 1, "rate": "50.00"}],
+        },
+    )
+    assert r.status_code == 201, r.text
+    txn = (
+        db_session.query(Transaction)
+        .filter(Transaction.source_id == r.json()["id"])
+        .filter(Transaction.source_type == "vendor_credit")
+        .one()
+    )
+    by_acct = {ln.account_id: ln for ln in txn.lines}
+    assert by_acct[seed_accounts["6000"].id].credit == Decimal("50.00")
+
+
+def test_a_zero_credit_is_refused(client, seed_accounts, vendor):
+    r = client.post(
+        "/api/vendor-credits",
+        json={
+            "vendor_id": vendor["id"],
+            "date": "2026-04-05",
+            "lines": [{"description": "nothing", "quantity": 1, "rate": 0}],
+        },
+    )
+    assert r.status_code == 400
+    assert "more than zero" in r.json()["detail"]
+
+
+def test_a_negative_line_is_refused_by_the_schema(client, vendor):
+    r = client.post(
+        "/api/vendor-credits",
+        json={
+            "vendor_id": vendor["id"],
+            "date": "2026-04-05",
+            "lines": [{"description": "backwards", "quantity": 1, "rate": -50}],
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_an_unknown_vendor_is_a_404(client, seed_accounts):
+    r = client.post(
+        "/api/vendor-credits",
+        json={
+            "vendor_id": 999999,
+            "date": "2026-04-05",
+            "lines": [{"description": "x", "quantity": 1, "rate": 10}],
+        },
+    )
+    assert r.status_code == 404
+
+
+def test_a_credit_cannot_name_another_vendors_bill(client, seed_accounts, vendor):
+    other = client.post("/api/vendors", json={"name": "Other Supply"}).json()
+    bill = _bill(client, other, seed_accounts, "100.00")
+    r = client.post(
+        "/api/vendor-credits",
+        json={
+            "vendor_id": vendor["id"],
+            "date": "2026-04-05",
+            "original_bill_id": bill["id"],
+            "lines": [{"description": "x", "quantity": 1, "rate": 10}],
+        },
+    )
+    assert r.status_code == 400
+    assert "different vendor" in r.json()["detail"]
+
+
+# ── Applying ─────────────────────────────────────────────────────────────
+
+
+def test_applying_a_credit_pays_down_the_bill_and_posts_nothing(
+    client, db_session, seed_accounts, vendor
+):
+    bill = _bill(client, vendor, seed_accounts, "1000.00")
+    vc = _credit(client, vendor, seed_accounts, "300.00")
+    before = db_session.query(Transaction).count()
+
+    r = client.post(
+        f"/api/vendor-credits/{vc['id']}/apply",
+        json={"bill_id": bill["id"], "amount": 300.0},
+    )
+    assert r.status_code == 200, r.text
+    assert db_session.query(Transaction).count() == before, "apply must not post"
+
+    db_session.expire_all()
+    got = client.get(f"/api/vendor-credits/{vc['id']}").json()
+    assert got["status"] == "applied"
+    assert Decimal(got["balance_remaining"]) == Decimal("0")
+    b = client.get(f"/api/bills/{bill['id']}").json()
+    assert Decimal(str(b["balance_due"])) == Decimal("700.00")
+    assert b["status"] == "partial"
+
+
+def test_a_credit_that_settles_a_bill_exactly_marks_it_paid(
+    client, seed_accounts, vendor
+):
+    bill = _bill(client, vendor, seed_accounts, "300.00")
+    vc = _credit(client, vendor, seed_accounts, "300.00")
+    client.post(
+        f"/api/vendor-credits/{vc['id']}/apply",
+        json={"bill_id": bill["id"], "amount": 300.0},
+    )
+    assert client.get(f"/api/bills/{bill['id']}").json()["status"] == "paid"
+
+
+def test_a_credit_cannot_be_applied_beyond_its_balance(client, seed_accounts, vendor):
+    bill = _bill(client, vendor, seed_accounts, "1000.00")
+    vc = _credit(client, vendor, seed_accounts, "300.00")
+    r = client.post(
+        f"/api/vendor-credits/{vc['id']}/apply",
+        json={"bill_id": bill["id"], "amount": 400.0},
+    )
+    assert r.status_code == 400
+    assert "exceeds credit balance" in r.json()["detail"]
+
+
+def test_a_credit_cannot_be_applied_beyond_the_bill(client, seed_accounts, vendor):
+    bill = _bill(client, vendor, seed_accounts, "100.00")
+    vc = _credit(client, vendor, seed_accounts, "300.00")
+    r = client.post(
+        f"/api/vendor-credits/{vc['id']}/apply",
+        json={"bill_id": bill["id"], "amount": 200.0},
+    )
+    assert r.status_code == 400
+    assert "exceeds bill balance" in r.json()["detail"]
+
+
+def test_a_credit_cannot_be_applied_to_another_vendors_bill(
+    client, seed_accounts, vendor
+):
+    other = client.post("/api/vendors", json={"name": "Other Supply"}).json()
+    bill = _bill(client, other, seed_accounts, "1000.00")
+    vc = _credit(client, vendor, seed_accounts, "300.00")
+    r = client.post(
+        f"/api/vendor-credits/{vc['id']}/apply",
+        json={"bill_id": bill["id"], "amount": 100.0},
+    )
+    assert r.status_code == 400
+    assert "different vendor" in r.json()["detail"]
+
+
+def test_two_partial_applications_spend_the_credit_once(client, seed_accounts, vendor):
+    b1 = _bill(client, vendor, seed_accounts, "200.00", day=1)
+    b2 = _bill(client, vendor, seed_accounts, "200.00", day=2)
+    vc = _credit(client, vendor, seed_accounts, "300.00")
+
+    assert (
+        client.post(
+            f"/api/vendor-credits/{vc['id']}/apply",
+            json={"bill_id": b1["id"], "amount": 200.0},
+        ).status_code
+        == 200
+    )
+    assert (
+        client.post(
+            f"/api/vendor-credits/{vc['id']}/apply",
+            json={"bill_id": b2["id"], "amount": 100.0},
+        ).status_code
+        == 200
+    )
+    over = client.post(
+        f"/api/vendor-credits/{vc['id']}/apply",
+        json={"bill_id": b2["id"], "amount": 1.0},
+    )
+    assert over.status_code == 400
+
+
+# ── The thing the reporter actually asked for ────────────────────────────
+
+
+def test_ap_aging_ties_to_account_2000_with_an_unapplied_credit(
+    client, db_session, seed_accounts, vendor
+):
+    """This is the whole point of #129.
+
+    A manual journal entry against A/P was rejected by the reporter because
+    it moves the general ledger and not the vendor sub-ledger. A vendor
+    credit that did the same would be no better, so: with a 1,000 bill and
+    an unapplied 300 credit, A/P aging must read 700, the same as GL 2000.
+    """
+    _bill(client, vendor, seed_accounts, "1000.00")
+    _credit(client, vendor, seed_accounts, "300.00")
+
+    gl = _gl(db_session, seed_accounts["2000"].id)
+    aging = client.get("/api/reports/ap-aging?as_of_date=2026-04-30").json()
+    sub = Decimal(str(aging["totals"]["total"]))
+    assert -gl == Decimal("700.00")
+    assert sub == Decimal("700.00"), f"aging {sub} does not tie to GL {-gl}"
+
+    row = [i for i in aging["items"] if i["vendor_id"] == vendor["id"]][0]
+    assert Decimal(str(row["total"])) == Decimal("700.00")
+    assert Decimal(str(row["unapplied_credits"])) == Decimal("300.00")
+
+
+def test_applying_the_credit_does_not_change_the_aging_total(
+    client, seed_accounts, vendor
+):
+    """Applying moves the credit from 'unapplied' to 'off the bill'. The
+    vendor still owes the same 700 either way, which is what proves the
+    unapplied case was being counted correctly."""
+    bill = _bill(client, vendor, seed_accounts, "1000.00")
+    vc = _credit(client, vendor, seed_accounts, "300.00")
+    before = client.get("/api/reports/ap-aging?as_of_date=2026-04-30").json()
+    client.post(
+        f"/api/vendor-credits/{vc['id']}/apply",
+        json={"bill_id": bill["id"], "amount": 300.0},
+    )
+    after = client.get("/api/reports/ap-aging?as_of_date=2026-04-30").json()
+    assert Decimal(str(before["totals"]["total"])) == Decimal("700.00")
+    assert Decimal(str(after["totals"]["total"])) == Decimal("700.00")
+    assert Decimal(str(after["totals"]["unapplied_credits"])) == Decimal("0")
+
+
+def test_ar_aging_ties_to_1100_with_an_unapplied_credit_memo(
+    client, db_session, seed_accounts
+):
+    """The same hole existed on the receivable side and is fixed with it.
+    An unapplied credit memo credited GL 1100 and was invisible to A/R
+    aging, so the report overstated what customers owed."""
+    cust = client.post("/api/customers", json={"name": "Probe Co"}).json()
+    client.post(
+        "/api/invoices",
+        json={
+            "customer_id": cust["id"],
+            "date": "2026-03-01",
+            "due_date": "2026-03-31",
+            "lines": [
+                {"description": "work", "quantity": 1, "rate": 1000, "line_order": 0}
+            ],
+        },
+    )
+    client.post(
+        "/api/credit-memos",
+        json={
+            "customer_id": cust["id"],
+            "date": "2026-03-05",
+            "lines": [
+                {"description": "return", "quantity": 1, "rate": 300, "line_order": 0}
+            ],
+        },
+    )
+    gl = _gl(db_session, seed_accounts["1100"].id)
+    aging = client.get("/api/reports/ar-aging?as_of_date=2026-03-31").json()
+    assert gl == Decimal("700.00")
+    assert Decimal(str(aging["totals"]["total"])) == Decimal("700.00")
+    assert Decimal(str(aging["totals"]["unapplied_credits"])) == Decimal("300.00")
+
+
+# ── Void ─────────────────────────────────────────────────────────────────
+
+
+def test_voiding_reverses_the_entry_and_puts_the_credit_back_on_the_bill(
+    client, db_session, seed_accounts, vendor
+):
+    bill = _bill(client, vendor, seed_accounts, "1000.00")
+    vc = _credit(client, vendor, seed_accounts, "300.00")
+    client.post(
+        f"/api/vendor-credits/{vc['id']}/apply",
+        json={"bill_id": bill["id"], "amount": 300.0},
+    )
+
+    r = client.post(f"/api/vendor-credits/{vc['id']}/void")
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "void"
+
+    rev = (
+        db_session.query(Transaction)
+        .filter(
+            Transaction.source_type == "vendor_credit_void",
+            Transaction.source_id == vc["id"],
+        )
+        .one()
+    )
+    by_acct = {ln.account_id: ln for ln in rev.lines}
+    assert by_acct[seed_accounts["2000"].id].credit == Decimal("300.00")
+    assert by_acct[seed_accounts["6000"].id].debit == Decimal("300.00")
+
+    db_session.expire_all()
+    b = client.get(f"/api/bills/{bill['id']}").json()
+    assert Decimal(str(b["balance_due"])) == Decimal("1000.00")
+    assert b["status"] == "unpaid"
+
+    dr = sum(Decimal(str(x[0] or 0)) for x in db_session.query(TransactionLine.debit))
+    cr = sum(Decimal(str(x[0] or 0)) for x in db_session.query(TransactionLine.credit))
+    assert dr == cr
+
+
+def test_voiding_twice_is_refused(client, seed_accounts, vendor):
+    vc = _credit(client, vendor, seed_accounts, "300.00")
+    assert client.post(f"/api/vendor-credits/{vc['id']}/void").status_code == 200
+    r = client.post(f"/api/vendor-credits/{vc['id']}/void")
+    assert r.status_code == 400
+    assert "already void" in r.json()["detail"]
+
+
+def test_a_voided_credit_cannot_be_applied(client, seed_accounts, vendor):
+    bill = _bill(client, vendor, seed_accounts, "1000.00")
+    vc = _credit(client, vendor, seed_accounts, "300.00")
+    client.post(f"/api/vendor-credits/{vc['id']}/void")
+    r = client.post(
+        f"/api/vendor-credits/{vc['id']}/apply",
+        json={"bill_id": bill["id"], "amount": 100.0},
+    )
+    assert r.status_code == 400
+
+
+def test_a_voided_credit_leaves_the_books_where_it_found_them(
+    client, db_session, seed_accounts, vendor
+):
+    _bill(client, vendor, seed_accounts, "1000.00")
+    ap_before = _gl(db_session, seed_accounts["2000"].id)
+    vc = _credit(client, vendor, seed_accounts, "300.00")
+    client.post(f"/api/vendor-credits/{vc['id']}/void")
+    db_session.expire_all()
+    assert _gl(db_session, seed_accounts["2000"].id) == ap_before
+
+
+# ── Inventory ────────────────────────────────────────────────────────────
+
+
+def _inventory_item(db_session, seed_accounts, name="Widget"):
+    from app.models.items import Item as ItemModel, ItemType
+
+    it = ItemModel(
+        name=name,
+        item_type=ItemType.PRODUCT,
+        rate=Decimal("25.00"),
+        track_inventory=True,
+        asset_account_id=seed_accounts["1300"].id,
+        is_taxable=False,
+    )
+    db_session.add(it)
+    db_session.commit()
+    db_session.refresh(it)
+    return it
+
+
+def test_returning_stock_credits_inventory_not_an_expense(
+    client, db_session, seed_accounts, vendor
+):
+    """A bill receives stock into Inventory 1300. The credit that returns it
+    must take it back out of 1300, not out of an expense account — otherwise
+    the asset stays on the balance sheet for goods that are gone."""
+    item = _inventory_item(db_session, seed_accounts)
+    r = client.post(
+        "/api/bills",
+        json={
+            "vendor_id": vendor["id"],
+            "bill_number": "B-INV",
+            "date": "2026-04-01",
+            "lines": [
+                {
+                    "item_id": item.id,
+                    "quantity": 10,
+                    "rate": "10.00",
+                    "line_order": 0,
+                }
+            ],
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert _gl(db_session, seed_accounts["1300"].id) == Decimal("100.00")
+
+    vc = client.post(
+        "/api/vendor-credits",
+        json={
+            "vendor_id": vendor["id"],
+            "date": "2026-04-05",
+            "lines": [
+                {"item_id": item.id, "quantity": 4, "rate": "10.00", "line_order": 0}
+            ],
+        },
+    )
+    assert vc.status_code == 201, vc.text
+    db_session.expire_all()
+    assert _gl(db_session, seed_accounts["1300"].id) == Decimal("60.00")
+
+    move = (
+        db_session.query(InventoryMovement)
+        .filter(
+            InventoryMovement.source_type == "vendor_credit",
+            InventoryMovement.source_id == vc.json()["id"],
+        )
+        .one()
+    )
+    assert move.movement_type == MovementType.RETURN_OUT
+    assert Decimal(str(move.quantity)) == Decimal("-4")
+
+    on_hand = client.get(f"/api/items/{item.id}").json()["quantity_on_hand"]
+    assert Decimal(str(on_hand)) == Decimal("6")
+
+
+def test_an_inventory_item_with_nowhere_to_post_is_refused(
+    client, db_session, seed_accounts, vendor
+):
+    item = _inventory_item(db_session, seed_accounts)
+    db_session.query(Account).filter(Account.id == seed_accounts["1300"].id).update(
+        {"account_number": "1399"}
+    )
+    db_session.commit()
+    from app.models.items import Item as ItemModel
+
+    db_session.query(ItemModel).filter(ItemModel.id == item.id).update(
+        {"asset_account_id": None}
+    )
+    db_session.commit()
+
+    r = client.post(
+        "/api/vendor-credits",
+        json={
+            "vendor_id": vendor["id"],
+            "date": "2026-04-05",
+            "lines": [
+                {"item_id": item.id, "quantity": 1, "rate": "10.00", "line_order": 0}
+            ],
+        },
+    )
+    assert r.status_code == 400
+    assert "inventory-tracked" in r.json()["detail"]
+
+
+# ── Housekeeping ─────────────────────────────────────────────────────────
+
+
+def test_the_closing_date_is_enforced(client, seed_accounts, vendor):
+    r = client.put("/api/settings", json={"closing_date": "2026-12-31"})
+    assert r.status_code in (200, 201), r.text
+    r = client.post(
+        "/api/vendor-credits",
+        json={
+            "vendor_id": vendor["id"],
+            "date": "2026-04-05",
+            "lines": [{"description": "x", "quantity": 1, "rate": 10}],
+        },
+    )
+    assert r.status_code == 403
+
+
+def test_credits_are_numbered_in_their_own_series(client, seed_accounts, vendor):
+    a = _credit(client, vendor, seed_accounts, "10.00")
+    b = _credit(client, vendor, seed_accounts, "20.00")
+    assert a["credit_number"] == "VC-0001"
+    assert b["credit_number"] == "VC-0002"
+
+
+def test_the_list_filters_by_vendor_and_status(client, seed_accounts, vendor):
+    other = client.post("/api/vendors", json={"name": "Other Supply"}).json()
+    _credit(client, vendor, seed_accounts, "10.00")
+    _credit(client, other, seed_accounts, "20.00")
+    mine = client.get(f"/api/vendor-credits?vendor_id={vendor['id']}").json()
+    assert len(mine) == 1
+    assert mine[0]["vendor_name"] == "Acme Supply"
+    assert client.get("/api/vendor-credits?status=issued").json().__len__() == 2
+
+
+def test_unknown_credit_is_a_404(client):
+    assert client.get("/api/vendor-credits/999999").status_code == 404


### PR DESCRIPTION
**Vendor credits, and one reporting defect found while building them.** The Bank of America CSV work is deliberately *not* here — see the note at the bottom.

## Vendor credits — issue #129 (@CimarronSiteServices)

A supplier issues a credit for returned or short-shipped materials and there is nowhere correct to put it. A bill with a negative line is refused, an expense with a negative amount is refused, and **both refusals point at credit memos, which only accept a customer**. The reporter checked bills, expenses, credit memos, card charges and journal entries before opening the issue, and was right that none of them was the answer.

A bill posts DR Expense / CR A/P. A vendor credit is its mirror. It reduces what you owe the moment it is entered; applying it to a bill **posts nothing**, because A/P already moved and the application only decides which bill it settles. That is exactly how a credit memo behaves against an invoice.

He also named why a manual journal entry against A/P was not good enough, and that is the reason this is a document: a JE moves the general ledger without moving the vendor sub-ledger, so A/P aging and the vendor's balance stop agreeing with account 2000. Same split as #119.

**Returning stock takes it off the shelf.** A bill receives inventory into 1300 rather than an expense, so a credit for returned goods takes it back out of 1300, writes a `return_out` movement and drops quantity on hand. An inventory item with no asset account is refused rather than quietly posted to an expense — the same refusal `create_bill` already makes.

## Both aging reports were hiding credits

Found while building the payable side, and measured before fixing it. An unapplied credit memo credits A/R the moment it is issued, but A/R aging summed only invoice balances:

| | |
|---|---|
| GL 1100 | 700.00 |
| A/R aging total | 1,000.00 |

The report overstated what customers owed by every credit not yet applied, and the sub-ledger did not tie to the control account. The payable side would have inherited the identical hole, so **both are fixed together**, and both reports now carry an `unapplied_credits` column — "you owe 700" and "you owe 1,000 and hold a 300 credit" are different facts to someone about to pay a vendor.

Also: `.badge-issued` and `.badge-applied` had no CSS rule and never have, so every credit memo has rendered an unstyled badge since the day they shipped. Both documents use those words; both are styled now.

The banking-ledger migration test no longer pins a literal head revision — it asks alembic — so it fails on a defect rather than on the next release.

## Not in this release: Bank of America CSV (#130)

@Lazyjimpressions' contribution is competent and I merged it as written, but the layout has never been checked against a file the bank actually produced — the test fixture is synthetic, which he said plainly. SlowBooks builds importers against real exports.

An importer that is absent fails loudly: "Unknown CSV format", the header names, nothing reaches the books. One that is present and wrong is silent, and the numbers land in someone's accounts.

So it lives on **`parked/bofa-detail-csv`** with his commit and authorship intact, plus three fixes on top and `docs/parked-bofa-csv.md` listing the four unknowns. A scrubbed real export has been asked for on #130. That branch merges when one arrives; nothing about it is advertised in the changelog, the README or What's New until then.

## State

- Suite **2082 passed / 0 failed** on Linux; `black` and `ruff` clean at CI scope
- Linux gate on `9c7ebdb`: native + Docker/PostgreSQL, fixture 42/42, trial balance **4,021,445.56**
- New migration `f8a9b0c1d2e3`, revising `e7f8a9b0c1d2`, with a mirror downgrade
- 27 new tests in `tests/test_vendor_credits.py`
- Version 2.11.0; changelog, What's New, README, `docs/features.md`, `docs/data-model.md` updated

**Not merging until the three-platform gate passes and Trent says so.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DaDm82ccTQi7awPEQrrW3