### PR TITLE
Fix Wave Account Transactions report import (blank GL account + misclassification)

### DIFF
--- a/app/services/migration_common.py
+++ b/app/services/migration_common.py
@@ -319,14 +319,19 @@ def build_code_map(accounts: list[dict]) -> dict[str, str]:
 
 # Filename fragments shared by every source's bundle classifier; dialects
 # can extend (e.g. Wave/GnuCash "transactions" exports are the GL).
+#
+# GL fragments are checked before "account"/"acct": Wave's own export for
+# this bundle's GL file is literally named "Account Transactions.csv", and
+# with "account" checked first that unambiguously-GL file matched "coa"
+# instead, before "transaction" ever got a look.
 BASE_FILE_KINDS = (
     ("chart", "coa"),
-    ("account", "coa"),
-    ("acct", "coa"),  # real users type "acct_tree"
     ("general", "gl"),
     ("ledger", "gl"),
     ("journal", "gl"),
     ("transaction", "gl"),
+    ("account", "coa"),
+    ("acct", "coa"),  # real users type "acct_tree"
     ("trial", "tb"),
 )
 

--- a/app/services/wave_import.py
+++ b/app/services/wave_import.py
@@ -124,16 +124,36 @@ def parse_coa(csv_text: str) -> tuple[list[dict], list[str]]:
 def parse_gl(csv_text: str) -> tuple[list[dict], list[str]]:
     rows, errors = [], []
     for i, row in enumerate(sniff_reader(csv_text), start=2):
-        account = field(row, "account name", "account")
+        # Wave's "Account Transactions" report — a plain export any Wave
+        # user can pull with no plan restrictions — uses "ACCOUNT NUMBER"
+        # as the header over what is actually the account name for every
+        # data row (the numeric-code use of that column is vanishingly
+        # rare in practice), and suffixes its money columns with
+        # "(In Business Currency)". Neither matched below, so every row
+        # silently parsed as account="" / debit=credit=0: the dry-run
+        # "balanced" only because everything was zero, and the GL-account
+        # check failed once, deduped, on the empty name.
+        account = field(row, "account name", "account", "account number")
         date_raw = field(row, "transaction date", "date")
         if not account and not date_raw:
             continue
         try:
-            debit = parse_amount(field(row, "debit amount", "debit"))
-            credit = parse_amount(field(row, "credit amount", "credit"))
+            debit = parse_amount(
+                field(row, "debit amount", "debit", "debit (in business currency)")
+            )
+            credit = parse_amount(
+                field(row, "credit amount", "credit", "credit (in business currency)")
+            )
             if debit == 0 and credit == 0:
                 # Single signed Amount column: positive = debit
-                signed = parse_amount(field(row, "amount (one column)", "amount"))
+                signed = parse_amount(
+                    field(
+                        row,
+                        "amount (one column)",
+                        "amount",
+                        "amount (in business currency)",
+                    )
+                )
                 if signed > 0:
                     debit = signed
                 elif signed < 0:

--- a/tests/test_wave_import.py
+++ b/tests/test_wave_import.py
@@ -1,0 +1,56 @@
+"""Wave import: the "Account Transactions" report is a plain export any
+Wave user can pull with no plan restrictions, but its headers
+("ACCOUNT NUMBER" for what is actually the account name on every data
+row, "DEBIT (In Business Currency)" / "CREDIT (In Business Currency)"
+for the money columns) didn't match parse_gl()'s alias list. Every row
+silently parsed as account="" / debit=credit=0, so the dry-run
+"balanced" on all-zero amounts and failed once, deduped, on the GL
+account-name check ("GL references account '' not present in the
+chart of accounts") — regardless of what the CSV actually contained.
+"""
+
+import io
+
+COA_CSV = (
+    "Name,Account Code,Account Type,Account Sub-Type,Currency Code,"
+    "Is Archived,Description\n"
+    "Checking,,Asset,Cash and Bank,USD,FALSE,\n"
+    "Office Supplies,,Expense,Operating Expense,USD,FALSE,\n"
+)
+
+# Real column headers from Wave's Account Transactions report export.
+ACCOUNT_TRANSACTIONS_REPORT_CSV = (
+    "ACCOUNT NUMBER,DATE,DESCRIPTION,DEBIT (In Business Currency),"
+    "CREDIT (In Business Currency),BALANCE (In Business Currency)\n"
+    "Office Supplies,2024-01-15,Staples,$10.00,,\n"
+    "Checking,2024-01-15,Staples,,$10.00,\n"
+)
+
+
+def _files(**named):
+    return [
+        ("files", (name, io.BytesIO(text.encode()), "text/csv"))
+        for name, text in named.items()
+    ]
+
+
+def test_account_transactions_report_headers_parse(client, db_session, seed_accounts):
+    resp = client.post(
+        "/api/migration/wave/dry-run",
+        files=_files(
+            **{
+                # Wave's actual export filenames for this bundle - not a
+                # renamed workaround. "Account Transactions.csv" contains
+                # both "account" and "transaction"; this must classify as
+                # the GL file, not collide with the chart of accounts.
+                "Chart of Accounts.csv": COA_CSV,
+                "Account Transactions.csv": ACCOUNT_TRANSACTIONS_REPORT_CSV,
+            }
+        ),
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["ok"] is True, data
+    assert data["errors"] == []
+    assert data["accounts"] == 2
+    assert data["journals"] == 1


### PR DESCRIPTION
## Summary

Wave's real **Account Transactions** report - the plain export any Wave user can pull, no plan restrictions - fails to import via two independent bugs in the migration engine. Found while migrating a real business's several years of Wave history.

1. **`parse_gl()` never matched this report's actual column headers.** It looks for `"account name"`/`"account"`, `"debit amount"`/`"debit"`, `"credit amount"`/`"credit"` via `field()`'s exact (post-lowercase) alias match. But the Account Transactions report's real headers are `ACCOUNT NUMBER` (holds the account *name* on every data row - the numeric-code use of that column is vanishingly rare in practice), `DEBIT (In Business Currency)`, and `CREDIT (In Business Currency)`. None matched, so every row silently parsed as `account=""`, `debit=credit=0`. The dry-run "balanced" trivially (0 = 0) and failed once, deduped, on `"GL references account '' not present in the chart of accounts"` - a message that never changed no matter how the input CSV was reshaped, because the parser was never actually reading the file's amounts or account names in the first place.

2. **Filename classification collision.** `BASE_FILE_KINDS` in `migration_common.py` checks the `"account"` fragment before `"transaction"`. Wave's own filename for this export is literally `Account Transactions.csv` - contains both fragments - so it always classified as the chart-of-accounts file instead of the GL file, colliding with the real COA upload with `"... has different columns than the other coa file(s)"`.

## Fix

- `wave_import.py`: `parse_gl()` now also recognizes `"account number"`, `"debit (in business currency)"`, `"credit (in business currency)"`, and `"amount (in business currency)"` as header aliases.
- `migration_common.py`: GL fragments (`general`/`ledger`/`journal`/`transaction`) are now checked before the COA `account`/`acct` fragments, so a filename containing both (like Wave's) lands on the more specific match.
- Added `tests/test_wave_import.py` reproducing the real report's exact header shapes end-to-end through `/api/migration/wave/dry-run`.

## Test plan

- [x] New test `test_account_transactions_report_headers_parse` passes
- [x] `tests/test_wave_import.py tests/test_migration_sources.py tests/test_migration_banking_ledger.py tests/test_xero_import.py tests/test_myob_import.py tests/test_qb_report_import.py` — 49 passed, no regressions from the classifier reorder
- [x] Full suite: 2039 passed, 44 skipped (missing optional native libs - unrelated to this change)
- [x] Verified end-to-end against a real ~6-year, 2000+ transaction Wave export: dry-run now returns `ok: true` with zero errors, and the real import posts cleanly (trial balance nets to $0 difference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBu74Lb7YLTyMwxVNy769Z