### PR TITLE
Add a Copy button for newly-created API tokens

### DIFF
--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -417,7 +417,10 @@ const SettingsPage = {
                     </p>
                     <div id="api-token-reveal" style="display:none; margin-bottom:12px; padding:10px; border:1px solid var(--qb-gold); border-radius:4px; background:rgba(224,158,36,0.08); font-size:12px;">
                         <strong>Copy this token now — it will never be shown again:</strong>
-                        <div style="font-family:var(--font-mono); margin-top:6px; word-break:break-all;" id="api-token-secret"></div>
+                        <div style="display:flex; align-items:center; gap:8px; margin-top:6px;">
+                            <div style="font-family:var(--font-mono); word-break:break-all; flex:1;" id="api-token-secret"></div>
+                            <button type="button" class="btn btn-sm btn-secondary" onclick="SettingsPage.copyApiTokenSecret()">Copy</button>
+                        </div>
                     </div>
                     <div id="api-token-list" style="margin-bottom:12px;"></div>
                     <div class="form-grid" style="align-items:end;">
@@ -517,6 +520,19 @@ const SettingsPage = {
             toast('Token created — copy it now, it will not be shown again');
             SettingsPage.loadApiTokens();
         } catch (err) { toast(err.message, 'error'); }
+    },
+
+    copyApiTokenSecret() {
+        const text = $('#api-token-secret').textContent;
+        if (!text) return;
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(
+                () => toast('Token copied to clipboard'),
+                () => toast('Couldn\'t copy — select the token above and copy manually.', 'error'),
+            );
+        } else {
+            toast('Clipboard API unavailable — select the token above and copy manually.', 'error');
+        }
     },
 
     async updateApiToken(id, patch) {


### PR DESCRIPTION
## Summary

- The API token reveal box (Settings → API Tokens → Create Token) shows the secret exactly once, in a plain `<div>` with no click handler, no copy-on-click styling, and no keyboard shortcut. Confirmed by grepping `settings.js` and the stylesheet for anything targeting `#api-token-secret` - there's nothing there.
- Copying it today means manually triple-click-selecting styled text, which is unreliable: easy to grab a stray character or miss part of a long token. In one real case this failed outright and the user had to recover the token by screenshotting it instead.
- Adds a **Copy** button next to the secret, using the exact same `navigator.clipboard.writeText` + `toast()` pattern already used for portal links (`employees.js`) and payment links (`invoices.js`) - consistent with existing conventions, not a new one.

## Test plan

- [x] `node --check app/static/js/settings.js` passes
- [x] Diff mirrors the already-tested clipboard pattern from `employees.js`/`invoices.js` line for line
- [ ] Not manually clicked through in a running instance of this branch - I don't have a way to launch this app's full stack (DB, auth, etc.) from here. Worth a manual click-through before merge.
- No JS test harness exists in this repo (pytest covers the backend only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBu74Lb7YLTyMwxVNy769Z