### PR TITLE
v2.11.1 — Wave imports work, and you can copy an API token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
+### v2.11.1 — Wave imports work, and you can copy an API token
+
+Both fixes in this release came from @rchanks, and both were found the way
+we most want things found: against a real file and a real workflow.
+
+**Importing from Wave brought in nothing and said it had worked.** Wave's
+**Account Transactions** report — the plain export any Wave user can pull,
+with no plan restrictions — failed on two independent faults at once.
+
+`parse_gl()` looked for `Account Name`, `Debit Amount` and `Credit Amount`.
+The report's real headers are `ACCOUNT NUMBER`, `DEBIT (In Business
+Currency)` and `CREDIT (In Business Currency)`. None matched, so every row
+parsed as an empty account with zero on both sides — and the dry run then
+reported the file **balanced**, because zero equals zero. It failed once, on
+a deduplicated message about an account named `''` that never changed no
+matter how the source file was reshaped, because the parser had never read
+the file's amounts or account names to begin with.
+
+A dry run that passes because everything is zero is worse than one that
+fails, and that lesson is not specific to Wave.
+
+The second fault was the filename. The bundle classifier checked the
+fragment `account` before `transaction`, and Wave's own export is named
+`Account Transactions.csv` — so an unambiguously-ledger file was always
+taken for the chart of accounts and collided with the real chart upload.
+Ledger fragments are checked first now.
+
+That reorder was measured rather than assumed. Across realistic export
+filenames from the four sources that share the classifier, fourteen classify
+identically and nine move, **eight of the nine from wrong to right** — so it
+corrects files beyond Wave. The ninth, a chart of accounts named something
+like `General Account List.csv`, would now be read as a ledger. That is
+inherent to first-match-wins rather than to the new order, which is right far
+more often than the old one, and it is recorded so the trade stays
+deliberate.
+
+Found while migrating a real business's several years of Wave history: a
+six-year, 2000-transaction export that now imports with a zero-difference
+trial balance.
+
+**An API token is shown exactly once, and had to be copied by hand.** It sat
+in a styled block with no button and no shortcut, so getting it meant
+triple-clicking and hoping — which failed often enough that one person
+recovered their token by screenshotting it. A secret ending up in a camera
+roll is a security outcome, not an inconvenience. There is a Copy button now,
+with a clear message to fall back on if the browser refuses.
+
 ### v2.11.0 — Record a credit from a supplier
 
 **A supplier credit had nowhere correct to go.** Reported by

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 # Single source of truth for the application version: app/main.py reports
 # it on the FastAPI app and /health, /api/system serves it to the frontend
 # footer, and the Windows release workflow parses it for the installer.
-__version__ = "2.11.0"
+__version__ = "2.11.1"

--- a/app/static/whats-new.json
+++ b/app/static/whats-new.json
@@ -1,4 +1,12 @@
 {
+  "2.11.1": {
+    "title": "Wave imports work, and you can copy an API token",
+    "items": [
+      "Importing from Wave's Account Transactions report now works. It read every row as empty and then reported the books as balanced, because zero equals zero — so the import appeared to check out and brought nothing in. Found and fixed by rchanks against a real six-year Wave export",
+      "A file Wave names \"Account Transactions\" is now treated as the ledger it is, instead of being mistaken for your chart of accounts. Several other exports that contain both words were being misfiled the same way",
+      "A Copy button on a newly created API token. The token is shown once and had to be selected by hand, which went wrong often enough that one person recovered theirs from a screenshot"
+    ]
+  },
   "2.11.0": {
     "title": "Record a credit from a supplier",
     "items": [


### PR DESCRIPTION
Bundles the two contributions from @rchanks, both already merged to `main` as-is with their commits and authorship intact (#134, #135). This branch adds only the release metadata: version, What's New, CHANGELOG.

## What is in it

**Wave's Account Transactions report imported nothing and reported success** (#134). Two independent faults.

`parse_gl()` looked for `Account Name` / `Debit Amount` / `Credit Amount`. The report's real headers are `ACCOUNT NUMBER`, `DEBIT (In Business Currency)` and `CREDIT (In Business Currency)`. Nothing matched, so every row parsed as an empty account with zero on both sides — and the dry run then reported the file **balanced**, because zero equals zero. It failed once on a deduplicated complaint about an account named `''`, a message that never changed however the source file was reshaped, because the parser had never read the file's amounts or account names at all.

A dry run that passes because everything is zero is worse than one that fails.

The second fault was the filename: the classifier checked `account` before `transaction`, and Wave's own export is literally `Account Transactions.csv`, so an unambiguous ledger file was always taken for the chart of accounts.

Found against a **real six-year, 2000-transaction Wave export**, which now imports with a zero-difference trial balance.

**An API token could only be copied by hand** (#135). Shown exactly once, in a styled block, with no button and no shortcut. One person recovered theirs by screenshotting it — a secret in a camera roll is a security outcome, not an inconvenience.

## The one thing worth a second look

The classifier reorder is a first-match-wins tuple shared by four import sources (Wave, GnuCash, Sage, Zoho), so I measured it instead of trusting it. Across 23 realistic export filenames, **14 classify identically and 9 move, all `coa` → `gl`**:

```
Account Transactions.csv               coa -> gl   ← the fix
Account Ledger.csv                     coa -> gl   correct
General Ledger Accounts.csv            coa -> gl   correct
Journal by Account.csv                 coa -> gl   correct
Account Journal.csv                    coa -> gl   correct
acct_transactions.csv                  coa -> gl   correct
Accounts Receivable Transactions.csv   coa -> gl   correct
Accounts - General Ledger.csv          coa -> gl   correct
General Account List.csv               coa -> gl   ← the cost
```

Eight of nine were already being misclassified and now land correctly, so this fixes more than Wave. The ninth reads like a chart of accounts and would now be taken for a ledger. That is inherent to first-match-wins rather than to this ordering, the old order had the mirror-image problem and hit it more often, and it is recorded in the changelog so the trade stays deliberate.

## State

- Suite **2083 passed / 0 failed**; `black` and `ruff` clean at CI scope
- No schema change, no migration — `f8a9b0c1d2e3` remains head
- Both contributor commits are ancestors of this branch with their authorship

## Known gap going into the gate

@rchanks flagged honestly that the Copy button was **not clicked in a running instance**. `navigator.clipboard.writeText` needs a secure context and a user gesture, and `http://127.0.0.1` plus a click satisfies both — but this app runs inside pywebview, and it shipped eight versions with `window.pywebview.api` arriving empty on macOS WKWebView because of a policy interaction Chromium ignores. So the clipboard call is the one thing that has to be exercised on both desktops rather than reasoned about.

**Not merging until the three-platform gate passes and Trent says so.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DaDm82ccTQi7awPEQrrW3