### PR TITLE
Your chart, your templates, your clipboard — v2.12.0 (#132, #137, #139, #140, #141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,63 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
+### v2.11.2 — Your chart of accounts is yours
+
+**A new company arrives with 57 accounts, and not one of them could be
+removed or hidden.** Reported by @tresero (issue #139), coming from hledger
+with a chart of his own and finding no way to use it.
+
+Delete refused every seeded account, because all 57 are flagged as created
+by the software and the rule rejected anything carrying that flag —
+permanently, even on a company with no transactions in it. Deactivate was
+not on the page at all: the account form offered number, name, type and
+description, and nothing else. Our own delete error told people to
+"deactivate it instead", which the interface could not do.
+
+So the only thing an operator could do to our chart was rename it.
+
+**That is the same wrong flag 2.10.2 found hiding the Edit button, in a
+second place.** The gate is the control-account registry now, not the
+system flag: fifteen numbers the posting code resolves literally, where a
+document that cannot find one is issue #119. Those can be renamed and
+deactivated but never removed. The other forty-two are ordinary accounts and
+go when you say so.
+
+**Deactivate, Reactivate and Delete are on the Chart of Accounts page**, with
+a button to show inactive accounts — because hiding something with no way
+back to it is a trap, not a feature. Delete is not offered on a control
+account at all, rather than offered and then refused.
+
+**Deleting names what is in the way.** An account still referenced by an
+item, a vendor default, a bank feed or a budget is refused with the count
+and the table, instead of "referenced by other records", which told the
+operator nothing about where to go and undo it. That check walks the schema
+rather than a hand-kept list: thirty-five columns across seventeen models
+reference an account today and vendor credits added one this week, so a list
+maintained by hand would be wrong within a release — and the symptom of it
+being wrong is a foreign-key violation surfacing as a server error.
+
+### Emailing an invoice failed on every install
+
+Reported by @mdornich (issue #140). The Email Invoice dialog posts a
+`message` field. The route accepts `recipient` and `subject` and rejects
+anything else. **So every send from the interface failed validation before
+it reached the sending code** — the Message box did not merely get ignored,
+it broke the button it sat on.
+
+Nothing caught it because every test called that endpoint with a payload the
+endpoint accepts, rather than the payload the page actually sends. That is
+the shape of 2.10.3's unreachable attachment route: a test of the handler is
+not a test of what the interface does. There is now a check that reads the
+fields out of the page and out of the request model and fails if they drift
+apart again.
+
+The message you type is the message that goes out, escaped on both the
+templated and fallback paths, since it is operator text landing in an HTML
+email. The rest of @mdornich's report — the saved template being ignored,
+and template selection keyed off a document label — is his branch to open,
+and it is the better fix.
+
 ### v2.11.1 — Wave imports work, and you can copy an API token
 
 Both fixes in this release came from @rchanks, and both were found the way

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,62 +7,91 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
-### v2.11.2 — Your chart of accounts is yours
+### v2.12.0 — Your chart, your templates, your clipboard
+
+Five reader-reported defects, closed together. Two of them had been breaking
+something on every install.
 
 **A new company arrives with 57 accounts, and not one of them could be
-removed or hidden.** Reported by @tresero (issue #139), coming from hledger
-with a chart of his own and finding no way to use it.
+removed or hidden** (#139, @tresero, coming from hledger with a chart of his
+own). Delete refused every seeded account, because all 57 are flagged as
+created by the software and the rule rejected anything with that flag —
+permanently, even on a company with no transactions. Deactivate was not on
+the page at all, and our own delete error told people to "deactivate it
+instead", which the interface could not do. The only thing an operator could
+do to our chart was rename it.
 
-Delete refused every seeded account, because all 57 are flagged as created
-by the software and the rule rejected anything carrying that flag —
-permanently, even on a company with no transactions in it. Deactivate was
-not on the page at all: the account form offered number, name, type and
-description, and nothing else. Our own delete error told people to
-"deactivate it instead", which the interface could not do.
+That is the same wrong flag 2.10.2 found hiding the Edit button, in a second
+place. The gate is the control-account registry now: fifteen numbers the
+posting code resolves literally, where a document that cannot find one is
+issue #119. Those rename and deactivate but never delete. The other
+forty-two go when you say so.
 
-So the only thing an operator could do to our chart was rename it.
+Deactivate, Reactivate and Delete are on the page, with a button to show
+inactive accounts — hiding something with no way back to it is a trap.
+Delete is not offered on a control account at all, rather than offered and
+refused. And a blocked delete now names what is in the way and how many,
+rather than "referenced by other records", which told the operator nothing
+about where to go and undo it.
 
-**That is the same wrong flag 2.10.2 found hiding the Edit button, in a
-second place.** The gate is the control-account registry now, not the
-system flag: fifteen numbers the posting code resolves literally, where a
-document that cannot find one is issue #119. Those can be renamed and
-deactivated but never removed. The other forty-two are ordinary accounts and
-go when you say so.
+**The email template you save is now the email that gets sent** (#140,
+@mdornich). Editing `invoice_email` under Settings saved correctly and
+changed nothing: the invoice email was always built from a fixed layout, and
+the machinery for rendering a saved template existed with exactly one caller,
+the donor acknowledgment. Four releases of a settings page that did nothing.
 
-**Deactivate, Reactivate and Delete are on the Chart of Accounts page**, with
-a button to show inactive accounts — because hiding something with no way
-back to it is a trap, not a feature. Delete is not offered on a control
-account at all, rather than offered and then refused.
+The template is found by name and never by the document's face — selecting on
+the label would have skipped the saved template for every sales receipt,
+which is ordinary businesses and not only nonprofit installs. A template with
+a mistake in it falls through to the built-in body rather than stopping the
+mail.
 
-**Deleting names what is in the way.** An account still referenced by an
-item, a vendor default, a bank feed or a budget is refused with the count
-and the table, instead of "referenced by other records", which told the
-operator nothing about where to go and undo it. That check walks the schema
-rather than a hand-kept list: thirty-five columns across seventeen models
-reference an account today and vendor credits added one this week, so a list
-maintained by hand would be wrong within a release — and the symptom of it
-being wrong is a foreign-key violation surfacing as a server error.
+**There is a preview in the Email Invoice dialog**, rendered by the same
+server code that sends, so what an operator reads is what a customer
+receives. An operator editing a template previously had no way to see the
+result short of mailing a real customer.
 
-### Emailing an invoice failed on every install
-
-Reported by @mdornich (issue #140). The Email Invoice dialog posts a
-`message` field. The route accepts `recipient` and `subject` and rejects
-anything else. **So every send from the interface failed validation before
-it reached the sending code** — the Message box did not merely get ignored,
-it broke the button it sat on.
-
+**And emailing an invoice failed on every install.** The dialog posts a
+`message` field; the route accepted `recipient` and `subject` and rejected
+anything else, so every send failed validation before reaching the sending
+code. The Message box did not get ignored — it broke the button it sat on.
 Nothing caught it because every test called that endpoint with a payload the
-endpoint accepts, rather than the payload the page actually sends. That is
-the shape of 2.10.3's unreachable attachment route: a test of the handler is
-not a test of what the interface does. There is now a check that reads the
-fields out of the page and out of the request model and fails if they drift
-apart again.
+endpoint accepts rather than the payload the page sends, which is the shape
+of 2.10.3's unreachable attachment route.
 
-The message you type is the message that goes out, escaped on both the
-templated and fallback paths, since it is operator text landing in an HTML
-email. The rest of @mdornich's report — the saved template being ignored,
-and template selection keyed off a document label — is his branch to open,
-and it is the better fix.
+The message now appears as a paragraph at the top of the email, always,
+rather than as something a saved template has to remember to include. A
+template that forgot would have dropped it silently, which is the same defect
+wearing a different hat.
+
+**Copy buttons worked on the machine running SlowBooks and silently failed
+everywhere else** (#137). Copying to the clipboard requires a secure
+connection, and the desktop app gets one only because a loopback address
+counts as secure. Anyone reaching SlowBooks over a network address — Server
+Edition, Docker on a host address, a tablet on the Wi-Fi — got a button that
+appeared to do nothing.
+
+Nobody who could reproduce that was in a position to see it: a developer runs
+on loopback, and so does every test machine. It was found by measuring why
+the clipboard was permitted rather than being satisfied that it was.
+
+All four copy buttons go through one helper now. It names the cause when it
+knows it, and leaves the text selected so recovery is one keystroke. Two of
+the four had no fallback at all — the payment link reported a clipboard
+refusal as a server error.
+
+**The app refuses to start against a company file older than itself** (#132).
+It used to create the new tables without altering the existing ones and
+without recording the upgrade, after which the file could never be migrated
+again. The damage was silent when it happened and surfaced much later as a
+start failure with no obvious cause. Neither the desktop app nor the Docker
+image could reach it; a self-managed deployment could.
+
+**One HarfBuzz in the macOS bundle** (#141, @mdornich). Two copies of the
+same text-shaping library were being collected under one name, so whichever
+loaded first won for the whole process — and the pieces did not match, which
+killed the first PDF render on a locally built app. The build now fails
+loudly if it ever contains anything other than exactly one.
 
 ### v2.11.1 — Wave imports work, and you can copy an API token
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,33 @@ on what the software does, not on what sprint shipped what.
 
 ### v2.12.0 — Your chart, your templates, your clipboard
 
-Five reader-reported defects, closed together. Two of them had been breaking
-something on every install.
+Five reader-reported defects and one privately reported security issue,
+closed together. Two of them had been breaking something on every install.
+
+**Security: an editable email template could read stored credentials**
+(GHSA-c3v4-f43f-4wqm, reported privately). The settings dictionary handed to
+an email template was the decrypted one, so a template containing
+`{{ company.smtp_password }}` rendered the live password, and `{{ company }}`
+dumped every credential at once — into an email addressed to whoever sent it.
+The settings screen has always shown these as asterisks to every role
+including the administrator, so the intent was never in doubt; the template
+simply walked around it.
+
+It is a privilege escalation: a bookkeeper cannot read or write those values
+through the settings API, but could edit a template and send.
+
+Every credential is now replaced before a template ever sees it, at the point
+the context is built rather than at each place that sends, so a renderer
+added later inherits the protection instead of repeating the mistake. The two
+lists of which settings are secret — one used for encryption, one for the
+settings screen — were identical and are now literally the same list, because
+a credential added to one and not the other would be encrypted at rest and
+printed in plaintext by an email.
+
+**This release found the wider half of it.** The acknowledgment letter has
+been affected since v2.9.0 on nonprofit installs. Making the invoice template
+render, below, would have taken that to every install sending an invoice.
+Caught before release; both paths are closed and both have tests.
 
 **A new company arrives with 57 accounts, and not one of them could be
 removed or hidden** (#139, @tresero, coming from hledger with a chart of his

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,16 @@ again. The damage was silent when it happened and surfaced much later as a
 start failure with no obvious cause. Neither the desktop app nor the Docker
 image could reach it; a self-managed deployment could.
 
+**And a file it has already happened to can now be repaired.** Refusing to
+start protects files going forward and does nothing for one already damaged,
+where the ordinary upgrade command fails on a table that already exists —
+so the refusal was printing advice that could not work for exactly the
+people who hit it. `scripts/repair-schema.py` drops the empty tables left
+behind and then upgrades. It will not touch a table with anything in it: the
+mechanism that causes this only ever creates, so what it left behind is
+empty, and a table with rows was made by something else. The startup message
+now tells the two situations apart and names the right remedy for each.
+
 **One HarfBuzz in the macOS bundle** (#141, @mdornich). Two copies of the
 same text-shaping library were being collected under one name, so whichever
 loaded first won for the whole process — and the pieces did not match, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,8 +115,17 @@ image could reach it; a self-managed deployment could.
 **One HarfBuzz in the macOS bundle** (#141, @mdornich). Two copies of the
 same text-shaping library were being collected under one name, so whichever
 loaded first won for the whole process — and the pieces did not match, which
-killed the first PDF render on a locally built app. The build now fails
-loudly if it ever contains anything other than exactly one.
+killed the first PDF render on a locally built app. The module that brings
+the second copy is excluded, and the build now fails loudly if a bundle ever
+contains anything other than exactly one.
+
+The first attempt at this removed the duplicate library after it had been
+collected, which was wrong in two ways that only appear on a machine that has
+the problem. On its own it left no usable copy at all, so an affected builder
+could not build. Repairing that produced a bundle that looked complete,
+signed and notarized, and still died at the first PDF. Both were found by
+deliberately reproducing the fault on a machine that did not have it, rather
+than by a build passing.
 
 ### v2.11.1 — Wave imports work, and you can copy an API token
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 # Single source of truth for the application version: app/main.py reports
 # it on the FastAPI app and /health, /api/system serves it to the frontend
 # footer, and the Windows release workflow parses it for the installer.
-__version__ = "2.11.1"
+__version__ = "2.11.2"

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 # Single source of truth for the application version: app/main.py reports
 # it on the FastAPI app and /health, /api/system serves it to the frontend
 # footer, and the Windows release workflow parses it for the installer.
-__version__ = "2.11.2"
+__version__ = "2.12.0"

--- a/app/main.py
+++ b/app/main.py
@@ -206,7 +206,80 @@ def _run_startup_security_checks():
             )
 
     # Only after the cheap checks pass do we open a DB connection.
+    _refuse_a_database_behind_head()
     _create_missing_tables()
+
+
+def _refuse_a_database_behind_head() -> None:
+    """Refuse to start against a database the migrations have not reached.
+
+    Issue #132, found by the macOS QA agent while gating 2.11.0.
+    `_create_missing_tables()` runs `create_all()` on EVERY start. Point that
+    at a database behind the migration head and it half-upgrades it: tables
+    the new revision ADDS are created, tables it ALTERS are untouched, and
+    `alembic_version` does not move. Alembic can then never run on that
+    database again — the upgrade tries to create tables that already exist.
+
+    The damage is silent at the moment it happens and loud much later, in a
+    different session, as a start failure with no obvious cause.
+
+    Neither shipped path reaches it: `desktop_launcher.py` runs
+    `alembic upgrade head` before serving, and `docker-entrypoint.sh` runs it
+    at line 21. A self-managed deployment that sets DATABASE_URL, runs
+    uvicorn directly and treats migrations as a separate step is on exactly
+    that path — and so is `--_serve`, which is how the agent met it.
+
+    A database with no `alembic_version` at all is a NEW one and is allowed
+    through: that is how a fresh company file and a fresh Docker volume both
+    start.
+    """
+    from sqlalchemy import inspect as _inspect, text as _text
+
+    try:
+        insp = _inspect(engine)
+        if not insp.has_table("alembic_version"):
+            return  # fresh database — create_all is how it gets built
+        with engine.connect() as conn:
+            row = conn.execute(_text("SELECT version_num FROM alembic_version")).first()
+        current = row[0] if row else None
+    except Exception:
+        # A guard that cannot read the thing it guards must not pass it
+        # silently. The agent's own version of this check had `except:
+        # return`, which let a file through BY FAILING TO READ IT while it
+        # was mid-copy. Say so and let the start proceed: refusing here
+        # would turn any transient DB blip into a failure to boot.
+        logging.getLogger(__name__).exception(
+            "could not read alembic_version; skipping the migration-head check"
+        )
+        return
+
+    if current is None:
+        return
+
+    try:
+        from alembic.config import Config
+        from alembic.script import ScriptDirectory
+
+        root = Path(__file__).resolve().parent.parent
+        cfg = Config(str(root / "alembic.ini"))
+        cfg.set_main_option("script_location", str(root / "migrations"))
+        head = ScriptDirectory.from_config(cfg).get_current_head()
+    except Exception:
+        logging.getLogger(__name__).exception(
+            "could not determine the migration head; skipping the check"
+        )
+        return
+
+    if head and current != head:
+        raise RuntimeError(
+            f"FATAL: this database is at migration '{current}' and this build "
+            f"expects '{head}'. Starting anyway would create the new tables "
+            f"without altering the existing ones and without moving the "
+            f"revision, after which migrations can never run on it again. "
+            f"Run `alembic upgrade head` against it first. "
+            f"(The desktop app and the Docker entrypoint both do this for you; "
+            f"a self-managed deployment must run it as its own step.)"
+        )
 
 
 def _create_missing_tables() -> None:

--- a/app/main.py
+++ b/app/main.py
@@ -271,14 +271,36 @@ def _refuse_a_database_behind_head() -> None:
         return
 
     if head and current != head:
+        # Two different situations, and only one of them is fixed by the
+        # obvious command. An ORDINARY old file upgrades cleanly. A file a
+        # server has already half-upgraded does NOT: the tables the pending
+        # revisions create are already there, so the upgrade dies on
+        # "already exists". Printing `alembic upgrade head` at someone in
+        # that state is advice that fails — the same shape as #139's delete
+        # error saying "deactivate it instead" when nothing could deactivate.
+        from app.services.schema_repair import looks_half_upgraded
+
+        if looks_half_upgraded(engine):
+            remedy = (
+                "A server has already been started against this database "
+                "while it was behind, so `alembic upgrade head` will fail on "
+                "a table that already exists. Repair it with:\n"
+                "    python3 scripts/repair-schema.py --database-url <url>\n"
+                "which drops only the empty tables left behind and then "
+                "upgrades. Take a copy first."
+            )
+        else:
+            remedy = (
+                "Run `alembic upgrade head` against it first. (The desktop "
+                "app and the Docker entrypoint both do this for you; a "
+                "self-managed deployment must run it as its own step.)"
+            )
         raise RuntimeError(
             f"FATAL: this database is at migration '{current}' and this build "
             f"expects '{head}'. Starting anyway would create the new tables "
             f"without altering the existing ones and without moving the "
-            f"revision, after which migrations can never run on it again. "
-            f"Run `alembic upgrade head` against it first. "
-            f"(The desktop app and the Docker entrypoint both do this for you; "
-            f"a self-managed deployment must run it as its own step.)"
+            f"revision, after which migrations could never run on it again. "
+            f"{remedy}"
         )
 
 

--- a/app/routes/accounts.py
+++ b/app/routes/accounts.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -143,11 +144,61 @@ def update_account(account_id: int, data: AccountUpdate, db: Session = Depends(g
     return account
 
 
+def _referencing_rows(db: Session, account_id: int) -> list[tuple[str, int]]:
+    """[(table, count)] for every row in the database pointing at this
+    account, derived from the schema rather than a hand-kept list.
+
+    Thirty-five columns across seventeen models reference `accounts.id`, and
+    that number grows with every feature — vendor credits added one this
+    week. A list maintained by hand would be wrong within a release, and the
+    symptom of it being wrong is a foreign-key violation surfacing as a 500.
+    Walking the metadata cannot fall behind the schema.
+    """
+    from app.database import Base
+
+    found: list[tuple[str, int]] = []
+    for table in Base.metadata.sorted_tables:
+        for fk in table.foreign_keys:
+            if fk.column.table.name != "accounts":
+                continue
+            n = (
+                db.query(func.count())
+                .select_from(table)
+                .filter(fk.parent == account_id)
+                .scalar()
+            ) or 0
+            if n:
+                found.append((table.name.replace("_", " "), n))
+    return found
+
+
 @router.delete("/{account_id}")
 def delete_account(account_id: int, db: Session = Depends(get_db)):
     account = get_or_404(db, Account, account_id)
-    if account.is_system:
-        raise HTTPException(status_code=400, detail="Cannot delete system account")
+
+    # Gated on the control-account registry, NOT on is_system.
+    #
+    # Every one of the 57 accounts a new company is seeded with carries
+    # is_system, so gating on it refused all of them — which left an operator
+    # with someone else's chart of accounts and no way to shrink it: delete
+    # refused, and there was no deactivate control on the page either. That
+    # is the same wrong flag 2.10.2 found hiding the Edit button, in a second
+    # place (issue #139, reported by tresero coming from hledger).
+    #
+    # Fifteen numbers genuinely cannot go: the posting code resolves them
+    # literally, and a document that cannot find one is #119. Those can be
+    # renamed, not removed. The other forty-two are ordinary accounts.
+    if control_accounts.is_control_number(account.account_number):
+        name, purpose = control_accounts.describe(account.account_number)
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"{account.account_number} {name} is a control account — the "
+                f"software posts to it by number for {purpose}, so it cannot "
+                f"be deleted. You can rename it, or deactivate it to hide it "
+                f"from new entries."
+            ),
+        )
 
     # An account carrying ledger history must not be deleted — the postings
     # would lose their anchor. Refusing is correct; the bug was that the
@@ -165,6 +216,24 @@ def delete_account(account_id: int, db: Session = Depends(get_db)):
                 f"'{account.name}' has {posted} posted transaction line(s) and "
                 f"cannot be deleted. Deactivate it instead (set is_active=false) "
                 f"to hide it from new entries while preserving history."
+            ),
+        )
+
+    # Anything else still pointing at it — an item's income account, a
+    # vendor's default expense account, a bank feed, a budget line. Named,
+    # because "referenced by other records" tells the operator nothing about
+    # where to go and undo it.
+    others = [
+        (t, n) for t, n in _referencing_rows(db, account_id) if t != "transaction lines"
+    ]
+    if others:
+        where = ", ".join(f"{n} in {t}" for t, n in others)
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"'{account.name}' is still in use: {where}. Point those at "
+                f"another account first, or deactivate this one to hide it "
+                f"from new entries."
             ),
         )
 

--- a/app/routes/invoices/documents.py
+++ b/app/routes/invoices/documents.py
@@ -16,7 +16,7 @@ from app.routes.invoices._router import router
 
 
 class _EmailInvoiceRequest(StrictModel):
-    recipient: str
+    recipient: _Optional[str] = None
     subject: _Optional[str] = None
     # The Email Invoice dialog has always posted `message`, and this model
     # is a StrictModel — so every send from the interface was rejected 422
@@ -78,6 +78,38 @@ def invoice_print_preview(invoice_id: int, db: Session = Depends(get_db)):
     return HTMLResponse(content=html_str)
 
 
+@router.post("/{invoice_id}/email-preview")
+def email_invoice_preview(
+    invoice_id: int,
+    data: _EmailInvoiceRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    """Exactly what the send would produce, without sending it.
+
+    Read-only: no mail, no EmailLog row, no PDF rendered. It exists because
+    an operator editing the `invoice_email` template had no way to see the
+    result short of mailing a real customer — and for four releases the
+    template they were editing was not used at all.
+    """
+    inv = db.query(Invoice).filter(Invoice.id == invoice_id).first()
+    if not inv:
+        raise HTTPException(status_code=404, detail="Invoice not found")
+    company = get_settings(db)
+
+    from app.services.email_service import render_invoice_email_parts
+    from app.services.payments import enabled_providers
+
+    pay_url = None
+    if inv.payment_token and enabled_providers(db):
+        pay_url = f"{str(request.base_url).rstrip('/')}/pay/{inv.payment_token}"
+
+    subject, html_body = render_invoice_email_parts(
+        inv, company, pay_url=pay_url, note=data.message, db=db, subject=data.subject
+    )
+    return {"recipient": data.recipient, "subject": subject, "html_body": html_body}
+
+
 @router.post("/{invoice_id}/email")
 def email_invoice(
     invoice_id: int,
@@ -90,13 +122,8 @@ def email_invoice(
     if not inv:
         raise HTTPException(status_code=404, detail="Invoice not found")
     company = get_settings(db)
-    from app.services.email_service import invoice_email_label
-
-    subject = (
-        data.subject or f"{invoice_email_label(inv, company)} #{inv.invoice_number}"
-    )
     try:
-        from app.services.email_service import send_email, render_invoice_email
+        from app.services.email_service import send_email, render_invoice_email_parts
         from app.models.email_log import EmailLog
 
         pdf_bytes = generate_invoice_pdf(inv, company)
@@ -110,8 +137,16 @@ def email_invoice(
             base_url = str(request.base_url).rstrip("/")
             pay_url = f"{base_url}/pay/{inv.payment_token}"
 
-        html_body = render_invoice_email(
-            inv, company, pay_url=pay_url, note=data.message
+        # One renderer for the preview and the send, so what an operator is
+        # shown is what a customer receives. `db` is what makes the saved
+        # `invoice_email` template load at all — it never did before (#140).
+        subject, html_body = render_invoice_email_parts(
+            inv,
+            company,
+            pay_url=pay_url,
+            note=data.message,
+            db=db,
+            subject=data.subject,
         )
         # send_email() writes its own EmailLog row on every path (sent,
         # failed, and SMTP-not-configured), so the route must not log again

--- a/app/routes/invoices/documents.py
+++ b/app/routes/invoices/documents.py
@@ -18,6 +18,11 @@ from app.routes.invoices._router import router
 class _EmailInvoiceRequest(StrictModel):
     recipient: str
     subject: _Optional[str] = None
+    # The Email Invoice dialog has always posted `message`, and this model
+    # is a StrictModel — so every send from the interface was rejected 422
+    # before it reached any of the code below. The box was not merely
+    # ignored; it broke the button it sat on (issue #140, mdornich).
+    message: _Optional[str] = None
 
 
 @router.get("/{invoice_id}/pdf")
@@ -105,7 +110,9 @@ def email_invoice(
             base_url = str(request.base_url).rstrip("/")
             pay_url = f"{base_url}/pay/{inv.payment_token}"
 
-        html_body = render_invoice_email(inv, company, pay_url=pay_url)
+        html_body = render_invoice_email(
+            inv, company, pay_url=pay_url, note=data.message
+        )
         # send_email() writes its own EmailLog row on every path (sent,
         # failed, and SMTP-not-configured), so the route must not log again
         # or every send produces two rows.

--- a/app/routes/settings.py
+++ b/app/routes/settings.py
@@ -13,7 +13,13 @@ from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.models.settings import DEFAULT_SETTINGS
-from app.services.settings_service import get_all_settings, set_setting
+from app.services.settings_service import (
+    ENCRYPTED_SETTINGS_KEYS,
+    SECRET_PLACEHOLDER,
+    get_all_settings,
+    redact_secrets,
+    set_setting,
+)
 
 # Aliases used by upstream Phase 9/10 routes that import from this module
 _get_all = get_all_settings
@@ -26,31 +32,13 @@ _set = set_setting
 # period override password. Empty values still report as empty so the UI
 # can render an unconfigured state; non-empty values report SECRET_PLACEHOLDER
 # so the operator can tell the value is set without exposing it.
-SECRET_KEYS = frozenset(
-    {
-        "closing_date_password",
-        "smtp_password",
-        "stripe_secret_key",
-        "stripe_webhook_secret",
-        "paypal_client_secret",
-        "square_access_token",
-        "square_webhook_signature_key",
-        "qbo_client_secret",
-        "qbo_access_token",
-        "qbo_refresh_token",
-        "simplefin_access_url",
-    }
-)
-SECRET_PLACEHOLDER = "********"
-
-
-def _redact_secrets(settings: dict) -> dict:
-    """Return a copy of `settings` with secret values replaced by the
-    placeholder when non-empty."""
-    return {
-        k: (SECRET_PLACEHOLDER if (k in SECRET_KEYS and v) else v)
-        for k, v in settings.items()
-    }
+# ONE list, in settings_service, beside the encryption it mirrors. This file
+# used to carry a second frozenset identical to ENCRYPTED_SETTINGS_KEYS; they
+# happened to agree, and nothing would have said so if they stopped. A
+# credential added to one and not the other is encrypted at rest and rendered
+# in plaintext by an email template (GHSA-c3v4-f43f-4wqm).
+SECRET_KEYS = ENCRYPTED_SETTINGS_KEYS
+_redact_secrets = redact_secrets
 
 
 # Settings whose value is one of a fixed set. The SPA renders a <select>;

--- a/app/services/donor_documents.py
+++ b/app/services/donor_documents.py
@@ -244,6 +244,8 @@ def render_acknowledgment(db, company: dict, customer, gift: dict) -> tuple[str,
     'donation_acknowledgment' (Settings -> Email Templates), falling back
     to the built-in text when the row has not been seeded. Rendered in the
     sandboxed environment, autoescaped."""
+    from app.services.settings_service import redact_secrets
+
     from jinja2.sandbox import SandboxedEnvironment
 
     from app.services.email_service import render_template_from_db
@@ -253,7 +255,8 @@ def render_acknowledgment(db, company: dict, customer, gift: dict) -> tuple[str,
         "donor": customer,
         "donor_name": customer.name,
         "customer_name": customer.name,
-        "company": company,
+        # GHSA-c3v4-f43f-4wqm — see settings_service.redact_secrets.
+        "company": redact_secrets(company),
         "gift": gift,
         "irs": gift_irs(company, gift),
     }

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -167,8 +167,16 @@ def invoice_email_label(invoice, company_settings: dict) -> str:
     }.get(kind, kind)
 
 
-def render_invoice_email(invoice, company_settings: dict, pay_url: str = None) -> str:
-    """Render the invoice email HTML body."""
+def render_invoice_email(
+    invoice, company_settings: dict, pay_url: str = None, note: str = None
+) -> str:
+    """Render the invoice email HTML body.
+
+    `note` is the operator's own message from the Email Invoice dialog. It
+    is escaped and rendered as a paragraph above the standard text — the
+    box has existed in the interface for a long time and, until #140, was
+    not merely discarded but made the whole request fail validation.
+    """
     from app.services.terminology import terms_for
 
     doc_label = invoice_email_label(invoice, company_settings)
@@ -179,6 +187,7 @@ def render_invoice_email(invoice, company_settings: dict, pay_url: str = None) -
             company=company_settings,
             pay_url=pay_url,
             doc_label=doc_label,
+            note=(note or "").strip() or None,
             terms=terms_for(company_settings),
         )
     except Exception:
@@ -196,9 +205,19 @@ def render_invoice_email(invoice, company_settings: dict, pay_url: str = None) -
         )
         company_name = _html.escape(company_settings.get("company_name", "Our Company"))
         invoice_number = _html.escape(str(invoice.invoice_number))
+        # The operator's own message has to survive this path too, or it
+        # vanishes exactly when the template is missing.
+        opening = (
+            f"<p>{_html.escape(note.strip())}</p>"
+            if note and note.strip()
+            else (
+                f"<p>Please find attached {doc_label} #{invoice_number} "
+                f"for ${float(invoice.total):,.2f}.</p>"
+            )
+        )
         return f"""<html><body>
         <p>Dear {customer_name},</p>
-        <p>Please find attached {doc_label} #{invoice_number} for ${float(invoice.total):,.2f}.</p>
+        {opening}
         <p>Payment is due by {invoice.due_date}.</p>
         <p>{'Thank you for your support.' if terms_for(company_settings).is_nonprofit else 'Thank you for your business.'}</p>
         <p>{company_name}</p>

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -176,13 +176,19 @@ def invoice_email_context(invoice, company_settings: dict, pay_url: str = None) 
     Kept in one place so the preview and the send cannot drift — the reason
     they could before is that there was no shared renderer at all.
     """
+    from app.services.settings_service import redact_secrets
     from app.services.terminology import terms_for
 
     terms = terms_for(company_settings)
     return {
         "invoice": invoice,
         "inv": invoice,  # the file template's name for it
-        "company": company_settings,
+        # GHSA-c3v4-f43f-4wqm. The `invoice_email` template is operator-
+        # editable and, since #140, actually rendered — so `{{ company }}`
+        # would dump every decrypted credential into an email addressed to
+        # whoever the sender chooses. Redacted at the point the context is
+        # built, so no caller can forget.
+        "company": redact_secrets(company_settings),
         "customer_name": (
             invoice.customer.name if invoice.customer else terms("Customer")
         ),

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -3,6 +3,7 @@
 # Feature 8: Infrastructure B (smtplib + email.mime)
 # ============================================================================
 
+import logging
 import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -14,6 +15,8 @@ from sqlalchemy.orm import Session
 
 from app.models.email_log import EmailLog
 from app.models.settings import Settings
+
+logger = logging.getLogger(__name__)
 
 TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
 _jinja_env = Environment(loader=FileSystemLoader(str(TEMPLATE_DIR)), autoescape=True)
@@ -167,58 +170,119 @@ def invoice_email_label(invoice, company_settings: dict) -> str:
     }.get(kind, kind)
 
 
-def render_invoice_email(
-    invoice, company_settings: dict, pay_url: str = None, note: str = None
-) -> str:
-    """Render the invoice email HTML body.
+def invoice_email_context(invoice, company_settings: dict, pay_url: str = None) -> dict:
+    """What a saved `invoice_email` template can reference.
 
-    `note` is the operator's own message from the Email Invoice dialog. It
-    is escaped and rendered as a paragraph above the standard text — the
-    box has existed in the interface for a long time and, until #140, was
-    not merely discarded but made the whole request fail validation.
+    Kept in one place so the preview and the send cannot drift — the reason
+    they could before is that there was no shared renderer at all.
     """
     from app.services.terminology import terms_for
 
-    doc_label = invoice_email_label(invoice, company_settings)
-    try:
-        template = _jinja_env.get_template("invoice_email.html")
-        return template.render(
-            inv=invoice,
-            company=company_settings,
-            pay_url=pay_url,
-            doc_label=doc_label,
-            note=(note or "").strip() or None,
-            terms=terms_for(company_settings),
-        )
-    except Exception:
-        # Fallback simple email. Customer name + company name are escaped
-        # via html.escape() since they can contain user-controlled text
-        # (e.g. a customer named `<script>...`). Invoice number is a
-        # generated string but escaped defensively. Float and date come
-        # from server-side formatting — no need to escape.
-        import html as _html
+    terms = terms_for(company_settings)
+    return {
+        "invoice": invoice,
+        "inv": invoice,  # the file template's name for it
+        "company": company_settings,
+        "customer_name": (
+            invoice.customer.name if invoice.customer else terms("Customer")
+        ),
+        "pay_url": pay_url,
+        "doc_label": invoice_email_label(invoice, company_settings),
+        "terms": terms,
+    }
 
-        customer_name = _html.escape(
-            invoice.customer.name
-            if invoice.customer
-            else terms_for(company_settings)("Customer")
-        )
-        company_name = _html.escape(company_settings.get("company_name", "Our Company"))
-        invoice_number = _html.escape(str(invoice.invoice_number))
-        # The operator's own message has to survive this path too, or it
-        # vanishes exactly when the template is missing.
-        opening = (
-            f"<p>{_html.escape(note.strip())}</p>"
-            if note and note.strip()
-            else (
-                f"<p>Please find attached {doc_label} #{invoice_number} "
-                f"for ${float(invoice.total):,.2f}.</p>"
-            )
-        )
-        return f"""<html><body>
+
+def _note_paragraph(note: str) -> str:
+    """The operator's own message, as an escaped paragraph.
+
+    It is prepended to whatever body we end up with and is deliberately NOT
+    a template variable. A `{{ note }}` a saved template can omit would drop
+    the operator's message silently — the same failure class #140 is about,
+    moved rather than fixed. @mdornich's call, and it is the right one:
+    placement control is additive later, a silently dropped message is not.
+    """
+    import html as _html
+
+    note = (note or "").strip()
+    return f"<p>{_html.escape(note)}</p>\n" if note else ""
+
+
+def render_invoice_email_parts(
+    invoice,
+    company_settings: dict,
+    pay_url: str = None,
+    note: str = None,
+    db=None,
+    subject: str = None,
+) -> tuple[str, str]:
+    """(subject, html_body) for an invoice email — the one renderer.
+
+    Order, and the whole point of #140: **the template saved under Settings
+    -> Email Templates is used if it exists.** Before this it was never
+    loaded by anything; `render_template_from_db` existed and had exactly
+    one caller, the donor acknowledgment. Editing `invoice_email` saved
+    correctly and changed nothing about the email a customer received.
+
+    The template is looked up by the fixed name `invoice_email`, never by
+    the document's face. `invoice_email_label()` answers "Sales Receipt" or
+    "Donation Receipt" for those kinds, so selecting on it would skip the
+    saved template for every sales receipt — which is ordinary businesses,
+    not only nonprofit installs (#140, third part).
+    """
+    ctx = invoice_email_context(invoice, company_settings, pay_url=pay_url)
+    default_subject = f"{ctx['doc_label']} #{invoice.invoice_number}"
+
+    body = None
+    tpl_subject = None
+    if db is not None:
+        try:
+            tpl_subject, tpl_body = render_template_from_db(db, "invoice_email", ctx)
+            if tpl_body:
+                body = tpl_body
+        except Exception:
+            # A saved template with a bad expression must not stop the mail
+            # going out; fall through to the built-in body.
+            logger.exception("saved invoice_email template failed to render")
+
+    if body is None:
+        try:
+            body = _jinja_env.get_template("invoice_email.html").render(**ctx)
+        except Exception:
+            body = _fallback_invoice_body(invoice, company_settings, ctx)
+
+    return (subject or tpl_subject or default_subject), _note_paragraph(note) + body
+
+
+def render_invoice_email(
+    invoice, company_settings: dict, pay_url: str = None, note: str = None, db=None
+) -> str:
+    """The HTML body alone. Kept because callers and tests use it."""
+    return render_invoice_email_parts(
+        invoice, company_settings, pay_url=pay_url, note=note, db=db
+    )[1]
+
+
+def _fallback_invoice_body(invoice, company_settings: dict, ctx: dict) -> str:
+    """Last resort when neither a saved nor a file template renders.
+
+    Escaped by hand because there is no Jinja autoescape on this path:
+    customer and company names are user-controlled text.
+    """
+    import html as _html
+
+    customer_name = _html.escape(ctx["customer_name"])
+    company_name = _html.escape(company_settings.get("company_name", "Our Company"))
+    invoice_number = _html.escape(str(invoice.invoice_number))
+    doc_label = ctx["doc_label"]
+    thanks = (
+        "Thank you for your support."
+        if ctx["terms"].is_nonprofit
+        else "Thank you for your business."
+    )
+    return f"""<html><body>
         <p>Dear {customer_name},</p>
-        {opening}
+        <p>Please find attached {doc_label} #{invoice_number} for ${float(invoice.total):,.2f}.</p>
         <p>Payment is due by {invoice.due_date}.</p>
-        <p>{'Thank you for your support.' if terms_for(company_settings).is_nonprofit else 'Thank you for your business.'}</p>
+        <p>{thanks}</p>
         <p>{company_name}</p>
         </body></html>"""

--- a/app/services/schema_repair.py
+++ b/app/services/schema_repair.py
@@ -1,0 +1,205 @@
+"""Recover a database that was half-upgraded by `create_all()` (issue #132).
+
+The damage, and why `alembic upgrade head` cannot undo it: a server started
+against a database behind the migration head ran `Base.metadata.create_all()`,
+which **creates** the tables a pending revision would add, does **not** alter
+the ones it would change, and does **not** move `alembic_version`. The next
+upgrade then fails on `table <x> already exists` and the file is stuck — the
+newer tables are present and empty, the older ones are missing their new
+columns, and the revision stamp is behind both.
+
+Refusing to start (see `app.main._refuse_a_database_behind_head`) stops that
+happening again. It does nothing for a file it has already happened to, and
+telling that operator to run `alembic upgrade head` is advice that fails —
+the same shape as an error saying "deactivate it instead" when nothing on the
+page could deactivate (#139).
+
+The repair is the manual one, automated and bounded: run the upgrade, and
+when it fails because a table already exists, **verify the table is empty**,
+drop it, and try again. Empty is the whole safety argument. `create_all()`
+only ever creates; anything it made carries no rows. A table with rows in it
+was made by something else and this refuses to touch it.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from sqlalchemy import create_engine, inspect, text
+
+logger = logging.getLogger(__name__)
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+
+# "table vendor_credits already exists" (SQLite),
+# 'relation "vendor_credits" already exists' (PostgreSQL)
+_ALREADY_EXISTS = re.compile(
+    r'(?:table|relation)\s+"?([A-Za-z_][A-Za-z0-9_]*)"?\s+already exists', re.I
+)
+
+# One drop per pending revision is already generous; this only bounds a
+# pathological loop, it is not an expected number.
+MAX_ROUNDS = 25
+
+
+@dataclass
+class RepairResult:
+    ok: bool
+    started_at: str | None = None
+    now_at: str | None = None
+    dropped: list[str] = field(default_factory=list)
+    message: str = ""
+
+
+def _alembic_cfg(url: str):
+    from alembic.config import Config
+
+    cfg = Config(str(ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(ROOT / "migrations"))
+    cfg.attributes["database_url"] = url
+    return cfg
+
+
+def _current_revision(engine) -> str | None:
+    if not inspect(engine).has_table("alembic_version"):
+        return None
+    with engine.connect() as conn:
+        row = conn.execute(text("SELECT version_num FROM alembic_version")).first()
+    return row[0] if row else None
+
+
+def _row_count(engine, table: str) -> int:
+    with engine.connect() as conn:
+        return conn.execute(text(f'SELECT COUNT(*) FROM "{table}"')).scalar() or 0
+
+
+def repair(url: str, dry_run: bool = False) -> RepairResult:
+    """Bring `url` to head, dropping only EMPTY tables that block the way.
+
+    Returns a RepairResult rather than raising, so a caller can report the
+    reason. The one thing it will not do is drop a table with rows in it.
+    """
+    from alembic import command
+
+    engine = create_engine(url)
+    try:
+        started = _current_revision(engine)
+        result = RepairResult(ok=False, started_at=started, now_at=started)
+
+        for _ in range(MAX_ROUNDS):
+            try:
+                if dry_run:
+                    result.ok = True
+                    result.message = "dry run: would upgrade to head" + (
+                        f", after dropping {result.dropped}" if result.dropped else ""
+                    )
+                    return result
+                command.upgrade(_alembic_cfg(url), "head")
+                result.ok = True
+                result.now_at = _current_revision(engine)
+                result.message = f"upgraded {started} -> {result.now_at}" + (
+                    f"; dropped {len(result.dropped)} empty table(s) "
+                    f"left behind by create_all: {', '.join(result.dropped)}"
+                    if result.dropped
+                    else ""
+                )
+                return result
+            except Exception as exc:  # noqa: BLE001 — inspected below
+                m = _ALREADY_EXISTS.search(str(exc))
+                if not m:
+                    result.message = f"upgrade failed for another reason: {exc}"
+                    return result
+
+                table = m.group(1)
+                if not inspect(engine).has_table(table):
+                    result.message = (
+                        f"upgrade says '{table}' already exists but it is not "
+                        f"there; not guessing further"
+                    )
+                    return result
+
+                rows = _row_count(engine, table)
+                if rows:
+                    # The safety argument in one line. create_all() only ever
+                    # creates, so anything it made is empty; a table with data
+                    # was made by something else and dropping it loses records.
+                    result.message = (
+                        f"refusing to repair: '{table}' is in the way of the "
+                        f"upgrade but holds {rows} row(s), so it was not left "
+                        f"behind by create_all. This needs a person."
+                    )
+                    return result
+
+                logger.warning("schema repair: dropping empty table %s", table)
+                with engine.begin() as conn:
+                    conn.execute(text(f'DROP TABLE "{table}"'))
+                result.dropped.append(table)
+
+        result.message = f"gave up after {MAX_ROUNDS} rounds; dropped {result.dropped}"
+        return result
+    finally:
+        engine.dispose()
+
+
+_CREATE_TABLE = re.compile(r"""op\.create_table\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']""")
+
+
+def tables_pending_revisions_would_create(url: str, current: str) -> set[str]:
+    """Table names the not-yet-applied revisions call `op.create_table` for.
+
+    Read out of our own migration scripts. That is cheap, and it is precise in
+    the way that matters: if a pending revision is going to create table X and
+    X is already there, a `create_all()` put it there. The alternative —
+    "behind head and has an empty table this build expects" — is true of
+    almost every ordinary old file, because most tables are legitimately
+    empty. That version told every upgrading user to run a repair script.
+    """
+    from alembic.script import ScriptDirectory
+
+    sd = ScriptDirectory.from_config(_alembic_cfg(url))
+    head = sd.get_current_head()
+    names: set[str] = set()
+    # walk_revisions goes head -> base; everything after `current` is pending.
+    for rev in sd.walk_revisions(base=current or "base", head=head or "heads"):
+        if rev.revision == current:
+            continue
+        try:
+            names |= set(_CREATE_TABLE.findall(Path(rev.path).read_text()))
+        except OSError:
+            logger.warning("could not read migration %s", rev.path)
+    return names
+
+
+def looks_half_upgraded(engine) -> bool:
+    """True when a table a PENDING revision would create is already present.
+
+    That is the signature of `create_all()` having run against a database
+    behind head, and it is the only case where `alembic upgrade head` cannot
+    recover the file.
+
+    Advisory only: it chooses which of two messages the startup refusal
+    prints, never whether anything is dropped. `repair()` re-checks emptiness
+    itself at the moment it acts.
+    """
+    try:
+        current = _current_revision(engine)
+        if current is None:
+            return False
+        url = str(engine.url)
+        from alembic.script import ScriptDirectory
+
+        head = ScriptDirectory.from_config(_alembic_cfg(url)).get_current_head()
+        if not head or current == head:
+            return False
+
+        pending = tables_pending_revisions_would_create(url, current)
+        if not pending:
+            return False
+        present = set(inspect(engine).get_table_names())
+        return bool(pending & present)
+    except Exception:
+        logger.exception("could not tell whether the database is half-upgraded")
+        return False

--- a/app/services/settings_service.py
+++ b/app/services/settings_service.py
@@ -39,6 +39,30 @@ ENCRYPTED_SETTINGS_KEYS = frozenset(
 )
 
 
+SECRET_PLACEHOLDER = "********"
+
+
+def redact_secrets(settings: dict) -> dict:
+    """A copy of the settings with every credential replaced.
+
+    GHSA-c3v4-f43f-4wqm. `get_all_settings()` decrypts on the way out, and
+    anything handed the result can read a live credential. `GET /api/settings`
+    redacts for every role including admin, so the intent has always been that
+    these values do not leave the server — but an editable email template
+    rendered against the raw dict walks straight around that, and Jinja's
+    sandbox is no help because `company` is a plain dict and reading a key
+    from it is an ordinary permitted operation.
+
+    It lives here, beside `ENCRYPTED_SETTINGS_KEYS`, so a credential added
+    later is redacted by the same act that encrypts it. Two lists in two files
+    is how they drift.
+    """
+    return {
+        k: (SECRET_PLACEHOLDER if k in ENCRYPTED_SETTINGS_KEYS and v else v)
+        for k, v in settings.items()
+    }
+
+
 def _maybe_decrypt(key: str, value):
     if key in ENCRYPTED_SETTINGS_KEYS and value:
         return decrypt_value(value)

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -154,12 +154,25 @@ const App = {
         }
     },
 
+    // Inactive accounts are hidden by default — that is the point of
+    // deactivating one. But they must be reachable, or deactivating is a
+    // one-way trip with no way back to the row (issue #139).
+    _showInactiveAccounts: false,
+
+    toggleInactiveAccounts() {
+        App._showInactiveAccounts = !App._showInactiveAccounts;
+        App.navigate('#/accounts');
+    },
+
     async renderAccounts() {
         const accounts = await API.get('/accounts');
         const grouped = {};
+        let inactiveCount = 0;
         for (const a of accounts) {
             if (!grouped[a.account_type]) grouped[a.account_type] = [];
-            if (a.is_active !== false) grouped[a.account_type].push(a);
+            const inactive = a.is_active === false;
+            if (inactive) inactiveCount++;
+            if (!inactive || App._showInactiveAccounts) grouped[a.account_type].push(a);
         }
 
         const typeOrder = ['asset', 'liability', 'equity', 'income', 'cogs', 'expense'];
@@ -169,10 +182,13 @@ const App = {
         let html = `
             <div class="page-header">
                 <h2>Chart of Accounts</h2>
-                <button class="btn btn-primary" onclick="App.showAccountForm()">New Account</button>
+                <div>
+                    ${inactiveCount ? `<button class="btn btn-sm btn-secondary" onclick="App.toggleInactiveAccounts()">${App._showInactiveAccounts ? 'Hide' : 'Show'} ${inactiveCount} inactive</button> ` : ''}
+                    <button class="btn btn-primary" onclick="App.showAccountForm()">New Account</button>
+                </div>
             </div>
             <div class="table-container"><table>
-                <thead><tr><th scope="col" style="width:80px;">Number</th><th scope="col">Name</th><th scope="col" style="width:100px;">Type</th><th scope="col" class="amount" style="width:100px;">Balance</th><th scope="col" style="width:60px;">Actions</th></tr></thead>
+                <thead><tr><th scope="col" style="width:80px;">Number</th><th scope="col">Name</th><th scope="col" style="width:100px;">Type</th><th scope="col" class="amount" style="width:100px;">Balance</th><th scope="col" style="width:190px;">Actions</th></tr></thead>
                 <tbody>`;
 
         for (const type of typeOrder) {
@@ -180,13 +196,18 @@ const App = {
             if (accts.length === 0) continue;
             html += `<tr style="background:linear-gradient(180deg, #e8ecf2 0%, #dde2ea 100%);"><td colspan="5" style="font-weight:700; color:var(--qb-navy); font-size:11px; padding:4px 10px;">${typeNames[type]}</td></tr>`;
             for (const a of accts) {
-                html += `<tr>
+                const inactive = a.is_active === false;
+                html += `<tr${inactive ? ' style="opacity:.55;"' : ''}>
                     <td style="font-family:var(--font-mono);">${escapeHtml(a.account_number || '')}</td>
-                    <td><strong>${escapeHtml(a.name)}</strong>${a.is_control ? ` <span class="badge-control" title="${escapeHtml(a.control_purpose || 'the software finds this account by its number')}">control</span>` : ''}</td>
+                    <td><strong>${escapeHtml(a.name)}</strong>${a.is_control ? ` <span class="badge-control" title="${escapeHtml(a.control_purpose || 'the software finds this account by its number')}">control</span>` : ''}${inactive ? ' <span class="badge badge-draft">inactive</span>' : ''}</td>
                     <td>${a.account_type}</td>
                     <td class="amount">${formatCurrency(a.balance)}</td>
                     <td class="actions">
                         <button class="btn btn-sm btn-secondary" onclick="App.showAccountForm(${a.id})">Edit</button>
+                        ${inactive
+                            ? `<button class="btn btn-sm btn-secondary" onclick="App.setAccountActive(${a.id}, true)">Reactivate</button>`
+                            : `<button class="btn btn-sm btn-secondary" onclick="App.setAccountActive(${a.id}, false)">Deactivate</button>`}
+                        ${a.is_control ? '' : `<button class="btn btn-sm btn-secondary" onclick="App.deleteAccount(${a.id}, ${JSON.stringify(a.name)})">Delete</button>`}
                     </td>
                 </tr>`;
             }
@@ -232,6 +253,26 @@ const App = {
                     <button type="submit" class="btn btn-primary">${id ? 'Update' : 'Create'} Account</button>
                 </div>
             </form>`);
+    },
+
+    async setAccountActive(id, active) {
+        try {
+            await API.put(`/accounts/${id}`, { is_active: active });
+            toast(active ? 'Account reactivated' : 'Account deactivated — it is hidden from new entries');
+            App.navigate('#/accounts');
+        } catch (err) { toast(err.message, 'error'); }
+    },
+
+    async deleteAccount(id, name) {
+        // Deleting is for an account that was never used. Anything with
+        // history, or anything the books resolve by number, is refused by
+        // the server with a reason — deactivating is the answer there.
+        if (!confirm(`Delete "${name}"? This only works if nothing has ever posted to it. If it has history, deactivate it instead.`)) return;
+        try {
+            await API.del(`/accounts/${id}`);
+            toast('Account deleted');
+            App.navigate('#/accounts');
+        } catch (err) { toast(err.message, 'error'); }
     },
 
     async saveAccount(e, id) {

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -207,7 +207,7 @@ const App = {
                         ${inactive
                             ? `<button class="btn btn-sm btn-secondary" onclick="App.setAccountActive(${a.id}, true)">Reactivate</button>`
                             : `<button class="btn btn-sm btn-secondary" onclick="App.setAccountActive(${a.id}, false)">Deactivate</button>`}
-                        ${a.is_control ? '' : `<button class="btn btn-sm btn-secondary" onclick="App.deleteAccount(${a.id}, ${JSON.stringify(a.name)})">Delete</button>`}
+                        ${a.is_control ? '' : `<button class="btn btn-sm btn-secondary" onclick="App.deleteAccount(${a.id})">Delete</button>`}
                     </td>
                 </tr>`;
             }
@@ -263,7 +263,26 @@ const App = {
         } catch (err) { toast(err.message, 'error'); }
     },
 
-    async deleteAccount(id, name) {
+    // Only the id crosses into the attribute. It used to carry the name as
+    // well, via JSON.stringify inside a double-quoted onclick — so the JSON's
+    // own first quote closed the attribute, the handler was the fragment
+    // `App.deleteAccount(5, `, and clicking raised a SyntaxError. Silently:
+    // no request, no toast, no dialog, on EVERY row, because the break is in
+    // the quoting rather than in any particular name.
+    //
+    // Found at the GUI by both QA agents on the 2.12.0 gate. @skytech checked
+    // launcher.log and established that this application had never issued a
+    // single DELETE /api/accounts/* — the button was not being refused, it
+    // never asked. Nothing automated caught it: the endpoint is correct and
+    // well covered, and no test rendered the row and clicked it.
+    //
+    // The name is looked up here instead. An attribute that carries only
+    // numbers cannot be broken by punctuation in somebody's data.
+    async deleteAccount(id) {
+        let name = `account ${id}`;
+        try {
+            name = (await API.get(`/accounts/${id}`)).name || name;
+        } catch (err) { /* fall back to the id in the prompt */ }
         // Deleting is for an account that was never used. Anything with
         // history, or anything the books resolve by number, is refused by
         // the server with a reason — deactivating is the answer there.

--- a/app/static/js/employees.js
+++ b/app/static/js/employees.js
@@ -420,14 +420,7 @@ const EmployeesPage = {
 
     _copyPortalLink(url) {
         if (!url) { toast('No portal URL yet — generate a token first.', 'error'); return; }
-        if (navigator.clipboard && navigator.clipboard.writeText) {
-            navigator.clipboard.writeText(url).then(
-                () => toast('Portal link copied to clipboard'),
-                () => toast('Couldn\'t copy — select the link and copy manually.', 'error'),
-            );
-        } else {
-            toast('Clipboard API unavailable — select the URL above and copy manually.', 'error');
-        }
+        return copyToClipboard(url, 'Portal link');
     },
 
     _emailPortalLink(url) {

--- a/app/static/js/invoices.js
+++ b/app/static/js/invoices.js
@@ -188,15 +188,50 @@ const InvoicesPage = {
                     <div class="form-group full-width"><label>Recipient Email *</label>
                         <input name="recipient" type="email" required value="${escapeHtml(email)}"></div>
                     <div class="form-group full-width"><label>Subject</label>
-                        <input name="subject" value="${InvoicesPage.docLabel(inv)} #${escapeHtml(inv.invoice_number)} from ${escapeHtml(inv.customer_name || 'us')}"></div>
-                    <div class="form-group full-width"><label>Message</label>
-                        <textarea name="message">Please find attached Invoice #${escapeHtml(inv.invoice_number)}.</textarea></div>
+                        <input name="subject" placeholder="Loading from your template…"></div>
+                    <div class="form-group full-width"><label>Message <span class="form-hint">Appears at the top of the email. Leave it blank to send your template as it is.</span></label>
+                        <textarea name="message" oninput="InvoicesPage.queueEmailPreview(${id})"></textarea></div>
                 </div>
+                <details style="margin-top:4px;" open>
+                    <summary style="cursor:pointer; font-size:12px; font-weight:600;">Preview — this is what will be sent</summary>
+                    <div id="email-preview" style="border:1px solid var(--border); border-radius:4px; padding:10px; margin-top:6px; max-height:260px; overflow:auto; background:#fff; color:#333;">
+                        <em>Loading…</em>
+                    </div>
+                </details>
                 <div class="form-actions">
                     <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
                     <button type="submit" class="btn btn-primary">Send Email</button>
                 </div>
             </form>`);
+        InvoicesPage.refreshEmailPreview(id, true);
+    },
+
+    // The preview is rendered by the SAME server code that sends, so what an
+    // operator reads here is what the customer receives. Before #140 the
+    // dialog showed a hardcoded subject and the saved template was never
+    // loaded at all — so there was nothing to preview and no way to tell.
+    _previewTimer: null,
+
+    queueEmailPreview(id) {
+        clearTimeout(InvoicesPage._previewTimer);
+        InvoicesPage._previewTimer = setTimeout(() => InvoicesPage.refreshEmailPreview(id), 350);
+    },
+
+    async refreshEmailPreview(id, fillSubject = false) {
+        const form = $('#modal-body form');
+        if (!form) return;
+        const target = $('#email-preview');
+        try {
+            const out = await API.post(`/invoices/${id}/email-preview`, {
+                recipient: form.recipient.value || null,
+                subject: fillSubject ? null : (form.subject.value || null),
+                message: form.message.value || null,
+            });
+            if (fillSubject && !form.subject.value) form.subject.value = out.subject;
+            if (target) target.innerHTML = out.html_body;
+        } catch (err) {
+            if (target) target.textContent = `Preview unavailable: ${err.message}`;
+        }
     },
 
     async sendEmail(e, id) {

--- a/app/static/js/invoices.js
+++ b/app/static/js/invoices.js
@@ -150,11 +150,14 @@ const InvoicesPage = {
     },
 
     async copyPaymentLink(id) {
+        let data;
         try {
-            const data = await API.get(`/payments/payment-link/${id}`);
-            await navigator.clipboard.writeText(data.url);
-            toast('Payment link copied to clipboard');
-        } catch (err) { toast(err.message, 'error'); }
+            data = await API.get(`/payments/payment-link/${id}`);
+        } catch (err) { toast(err.message, 'error'); return; }
+        // Fetching the link and copying it fail for unrelated reasons, and
+        // reporting a clipboard refusal as an API error sent people looking
+        // in the wrong place.
+        return copyToClipboard(data.url, 'Payment link');
     },
 
     // Desktop-mode fallback: webhooks can't reach 127.0.0.1, so poll the

--- a/app/static/js/reseller_permits.js
+++ b/app/static/js/reseller_permits.js
@@ -443,14 +443,7 @@ const ResellerPermitsPage = {
     },
 
     async _copy(text, label) {
-        try {
-            await navigator.clipboard.writeText(text);
-            toast(`${label} copied to clipboard`);
-        } catch {
-            // Older browsers / non-secure contexts. Fall back to a prompt
-            // so the operator can manually copy.
-            window.prompt(`${label} (copy with Ctrl+C):`, text);
-        }
+        return copyToClipboard(text, label);
     },
 
     // Live format check fired from the form's onkeyup. Updates the hint

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -517,22 +517,14 @@ const SettingsPage = {
             $('#api-token-secret').textContent = created.token;
             $('#api-token-reveal').style.display = '';
             $('#token-new-label').value = '';
-            toast('Token created — copy it now, it will not be shown again');
+            toast('Token created — press Copy below, it will not be shown again');
             SettingsPage.loadApiTokens();
         } catch (err) { toast(err.message, 'error'); }
     },
 
     copyApiTokenSecret() {
-        const text = $('#api-token-secret').textContent;
-        if (!text) return;
-        if (navigator.clipboard && navigator.clipboard.writeText) {
-            navigator.clipboard.writeText(text).then(
-                () => toast('Token copied to clipboard'),
-                () => toast('Couldn\'t copy — select the token above and copy manually.', 'error'),
-            );
-        } else {
-            toast('Clipboard API unavailable — select the token above and copy manually.', 'error');
-        }
+        const el = $('#api-token-secret');
+        return copyToClipboard(el ? el.textContent : '', 'Token', el);
     },
 
     async updateApiToken(id, patch) {

--- a/app/static/js/utils.js
+++ b/app/static/js/utils.js
@@ -506,3 +506,81 @@ function currencyPayloadFromForm(form) {
     const rate = form.exchange_rate ? parseFloat(form.exchange_rate.value) : null;
     return { currency: currency || null, exchange_rate: rate || null };
 }
+
+// ---------------------------------------------------------------------------
+// Clipboard — one helper, because the failure is invisible to whoever built it
+//
+// `navigator.clipboard` requires a SECURE CONTEXT. The desktop app is served
+// over plain HTTP and it works anyway, for exactly one reason: loopback is a
+// secure origin by specification. `http://127.0.0.1` and `http://localhost`
+// qualify; `http://192.168.x.x` does not.
+//
+// So every copy button in this application works on the machine running it and
+// silently stops working for anyone reaching it over a LAN — `--serve-lan`,
+// Server Edition, Docker published on a host address, a tablet on the Wi-Fi.
+// A developer cannot reproduce that, and neither can a QA gate: both run on
+// loopback. Found on the 2.11.1 gate by measuring `isSecureContext` rather
+// than by anything failing (issue #137).
+//
+// Hence: name the real cause when we know it, and leave the text SELECTED so
+// the fallback is one keystroke rather than an instruction to aim a mouse.
+function _selectElementText(el) {
+    if (!el || !window.getSelection || !document.createRange) return false;
+    try {
+        const range = document.createRange();
+        range.selectNodeContents(el);
+        const sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
+        return true;
+    } catch (e) {
+        return false;
+    }
+}
+
+/**
+ * Copy `text`, reporting honestly when it cannot.
+ *
+ * @param {string} text      what to copy
+ * @param {string} label     what to call it in the message, e.g. 'Token'
+ * @param {Element} [el]     the element showing it; selected on failure so
+ *                           the operator can just press the copy shortcut
+ * @returns {Promise<boolean>} whether it reached the clipboard
+ */
+async function copyToClipboard(text, label = 'Text', el = null) {
+    if (!text) {
+        toast(`No ${label.toLowerCase()} to copy.`, 'error');
+        return false;
+    }
+
+    const manual = _selectElementText(el)
+        ? 'It is selected — press Ctrl+C (⌘C on a Mac).'
+        : `Select the ${label.toLowerCase()} and copy it manually.`;
+
+    // The cause worth naming, because it is the one nobody can reproduce.
+    if (!window.isSecureContext) {
+        toast(
+            `Copying needs a secure connection, and this page was opened over `
+            + `plain HTTP on a network address. ${manual} `
+            + `(Opening SlowBooks on this machine copies normally.)`,
+            'error',
+        );
+        return false;
+    }
+
+    if (!navigator.clipboard || !navigator.clipboard.writeText) {
+        toast(`This browser will not let the page copy for you. ${manual}`, 'error');
+        return false;
+    }
+
+    try {
+        await navigator.clipboard.writeText(text);
+        toast(`${label} copied to clipboard`);
+        return true;
+    } catch (e) {
+        // Permission refused, or the window was not focused at the moment of
+        // the write. Both are recoverable by hand.
+        toast(`Couldn't copy. ${manual}`, 'error');
+        return false;
+    }
+}

--- a/app/static/whats-new.json
+++ b/app/static/whats-new.json
@@ -2,6 +2,7 @@
   "2.12.0": {
     "title": "Your chart, your templates, your clipboard",
     "items": [
+      "Security: an email template could be edited to read stored passwords and API keys — the SMTP password, payment-provider keys, accounting-integration tokens — and mail them out. The settings screen has always hidden these, and the template walked around it. Credentials are now removed before any template can see them. Reported privately",
       "You can remove accounts you do not use. A new company arrives with 57 accounts and, until now, not one of them could be deleted or hidden — so anyone whose business does not look like ours was stuck with a chart they did not choose. Deactivate, Reactivate and Delete are on the Chart of Accounts page now, with a button to show the inactive ones",
       "Fifteen accounts still cannot be removed, because the software finds them by number when it posts. You can rename them to whatever you call them",
       "The email template you save is the email that gets sent. Editing it under Settings saved correctly and changed nothing at all — the invoice email was always built from a fixed layout. There is a preview in the Email Invoice dialog now, rendered by the same code that sends, so you can see what a customer will get before they get it",

--- a/app/static/whats-new.json
+++ b/app/static/whats-new.json
@@ -8,7 +8,7 @@
       "The email template you save is the email that gets sent. Editing it under Settings saved correctly and changed nothing at all — the invoice email was always built from a fixed layout. There is a preview in the Email Invoice dialog now, rendered by the same code that sends, so you can see what a customer will get before they get it",
       "Emailing an invoice works again. The Send button failed on every install, because the dialog sent a Message field the server refused. The message you type appears at the top of the email",
       "Copy buttons explain themselves when they cannot copy, and leave the text selected so one keystroke finishes the job. Copying silently did nothing for anyone opening SlowBooks from another machine on the network",
-      "The app refuses to start against a company file older than itself, instead of starting and quietly making it impossible to upgrade"
+      "The app refuses to start against a company file older than itself, instead of starting and quietly making it impossible to upgrade. A file that has already been damaged this way can be repaired with scripts/repair-schema.py, which will not touch a table with anything in it"
     ]
   },
   "2.11.1": {

--- a/app/static/whats-new.json
+++ b/app/static/whats-new.json
@@ -1,11 +1,13 @@
 {
-  "2.11.2": {
-    "title": "Your chart of accounts is yours",
+  "2.12.0": {
+    "title": "Your chart, your templates, your clipboard",
     "items": [
-      "You can remove accounts you do not use. A new company arrives with 57 accounts and, until now, not one of them could be deleted or hidden — so anyone whose business does not look like ours was stuck with a chart they did not choose",
-      "Deactivate and Reactivate are on the Chart of Accounts page, with a button to show the inactive ones. Deactivating hides an account from new entries and keeps its history",
+      "You can remove accounts you do not use. A new company arrives with 57 accounts and, until now, not one of them could be deleted or hidden — so anyone whose business does not look like ours was stuck with a chart they did not choose. Deactivate, Reactivate and Delete are on the Chart of Accounts page now, with a button to show the inactive ones",
       "Fifteen accounts still cannot be removed, because the software finds them by number when it posts. You can rename them to whatever you call them",
-      "Emailing an invoice works again. The Send button failed on every install — the dialog sent a Message field the server refused, so the request never reached the sending code. The message you type is now the message that goes out"
+      "The email template you save is the email that gets sent. Editing it under Settings saved correctly and changed nothing at all — the invoice email was always built from a fixed layout. There is a preview in the Email Invoice dialog now, rendered by the same code that sends, so you can see what a customer will get before they get it",
+      "Emailing an invoice works again. The Send button failed on every install, because the dialog sent a Message field the server refused. The message you type appears at the top of the email",
+      "Copy buttons explain themselves when they cannot copy, and leave the text selected so one keystroke finishes the job. Copying silently did nothing for anyone opening SlowBooks from another machine on the network",
+      "The app refuses to start against a company file older than itself, instead of starting and quietly making it impossible to upgrade"
     ]
   },
   "2.11.1": {

--- a/app/static/whats-new.json
+++ b/app/static/whats-new.json
@@ -1,4 +1,13 @@
 {
+  "2.11.2": {
+    "title": "Your chart of accounts is yours",
+    "items": [
+      "You can remove accounts you do not use. A new company arrives with 57 accounts and, until now, not one of them could be deleted or hidden — so anyone whose business does not look like ours was stuck with a chart they did not choose",
+      "Deactivate and Reactivate are on the Chart of Accounts page, with a button to show the inactive ones. Deactivating hides an account from new entries and keeps its history",
+      "Fifteen accounts still cannot be removed, because the software finds them by number when it posts. You can rename them to whatever you call them",
+      "Emailing an invoice works again. The Send button failed on every install — the dialog sent a Message field the server refused, so the request never reached the sending code. The message you type is now the message that goes out"
+    ]
+  },
   "2.11.1": {
     "title": "Wave imports work, and you can copy an API token",
     "items": [

--- a/app/templates/invoice_email.html
+++ b/app/templates/invoice_email.html
@@ -17,7 +17,9 @@ td { padding: 8px; border-bottom: 1px solid #eee; }
 </div>
 <div class="content">
     <p>Dear {{ inv.customer.name if inv.customer else terms('Customer') }},</p>
-    <p>Please find attached <strong>{{ doc_label }} #{{ inv.invoice_number }}</strong>.</p>
+    {% if note %}<p>{{ note }}</p>
+    {% else %}<p>Please find attached <strong>{{ doc_label }} #{{ inv.invoice_number }}</strong>.</p>
+    {% endif %}
 
     <table>
         <tr><th>{{ doc_label }} #</th><td>{{ inv.invoice_number }}</td></tr>

--- a/app/templates/invoice_email.html
+++ b/app/templates/invoice_email.html
@@ -17,9 +17,7 @@ td { padding: 8px; border-bottom: 1px solid #eee; }
 </div>
 <div class="content">
     <p>Dear {{ inv.customer.name if inv.customer else terms('Customer') }},</p>
-    {% if note %}<p>{{ note }}</p>
-    {% else %}<p>Please find attached <strong>{{ doc_label }} #{{ inv.invoice_number }}</strong>.</p>
-    {% endif %}
+    <p>Please find attached <strong>{{ doc_label }} #{{ inv.invoice_number }}</strong>.</p>
 
     <table>
         <tr><th>{{ doc_label }} #</th><td>{{ inv.invoice_number }}</td></tr>

--- a/packaging/macos/SlowBooksPro-mac.spec
+++ b/packaging/macos/SlowBooksPro-mac.spec
@@ -110,6 +110,69 @@ a = Analysis(
     excludes=["psycopg2", "psycopg2_binary"],
     noarchive=False,
 )
+# ---------------------------------------------------------------------------
+# One HarfBuzz, and it must be Homebrew's (issue #141, reported by mdornich)
+# ---------------------------------------------------------------------------
+# PyInstaller collects TWO HarfBuzz builds into the bundle:
+#
+#   Contents/Frameworks/PIL/.dylibs/libharfbuzz.0.dylib   Pillow's,   ~1.81 MB
+#   Contents/Frameworks/libharfbuzz.dylib                 Homebrew's, ~1.32 MB
+#   Contents/Frameworks/libharfbuzz-subset.0.dylib        Homebrew's, ~1.36 MB
+#
+# Both answer to the install name @rpath/libharfbuzz.0.dylib, so whichever
+# loads first wins for the whole process. The `binaries` list above seeds
+# Homebrew's under the VERSIONED name, but PyInstaller's PIL hook wins the
+# filename collision and turns Contents/Frameworks/libharfbuzz.0.dylib into a
+# symlink into PIL/. Homebrew's real library then sits in the bundle under the
+# unversioned name where nothing resolves to it.
+#
+# Pango therefore gets Pillow's HarfBuzz while libharfbuzz-subset is
+# Homebrew's — and `libharfbuzz-subset` only exists in the Homebrew build. The
+# first PDF render dies in native code.
+#
+# Dropping Pillow's copy is safe, and that was checked rather than assumed:
+# the pinned pillow wheel ships neither libraqm nor libfribidi, so complex
+# shaping is off and `PIL.features.check('harfbuzz')` is False; and nothing in
+# app/ draws text with Pillow at all — it appears only in ocr_service.py and
+# ocr_regions.py, for image preprocessing. All 25 hb_* symbols _imagingft
+# imports are exported by Homebrew's build.
+#
+# The assertion below is the important half. Getting this wrong in the other
+# direction — removing Pillow's copy while Homebrew's sits under the
+# unversioned name — turns a PDF crash into an import failure, which is worse
+# and easier to ship by accident. So the build FAILS here rather than
+# producing a bundle nobody looks inside.
+_PIL_HARFBUZZ = [
+    (dest, src, kind)
+    for (dest, src, kind) in a.binaries
+    if "libharfbuzz" in os.path.basename(dest) and "PIL" in dest.split(os.sep)
+]
+for entry in _PIL_HARFBUZZ:
+    a.binaries.remove(entry)
+    print(f"[spec] #141: dropped Pillow's HarfBuzz: {entry[0]}")
+
+_HARFBUZZ_VERSIONED = [
+    dest
+    for (dest, _src, _kind) in a.binaries
+    if os.path.basename(dest) == "libharfbuzz.0.dylib"
+]
+if len(_HARFBUZZ_VERSIONED) != 1:
+    raise SystemExit(
+        f"[spec] #141: expected exactly one libharfbuzz.0.dylib in the bundle, "
+        f"found {len(_HARFBUZZ_VERSIONED)}: {_HARFBUZZ_VERSIONED}. Pango "
+        f"resolves @rpath/libharfbuzz.0.dylib; zero copies is an import "
+        f"failure and two is a silent collision that kills the first PDF "
+        f"render."
+    )
+if "PIL" in _HARFBUZZ_VERSIONED[0].split(os.sep):
+    raise SystemExit(
+        f"[spec] #141: the only libharfbuzz.0.dylib is Pillow's "
+        f"({_HARFBUZZ_VERSIONED[0]}); libharfbuzz-subset is Homebrew's and "
+        f"they are not interchangeable."
+    )
+print(f"[spec] #141: one HarfBuzz, at {_HARFBUZZ_VERSIONED[0]}")
+
+
 pyz = PYZ(a.pure)
 
 exe = EXE(

--- a/packaging/macos/SlowBooksPro-mac.spec
+++ b/packaging/macos/SlowBooksPro-mac.spec
@@ -107,50 +107,56 @@ a = Analysis(
     binaries=binaries,
     datas=datas,
     hiddenimports=hiddenimports,
-    excludes=["psycopg2", "psycopg2_binary"],
+    excludes=[
+        "psycopg2",
+        "psycopg2_binary",
+        # #141 — see the HarfBuzz block below. These bring Pillow's own
+        # HarfBuzz, which collides with the one Pango needs.
+        "PIL._imagingft",
+        "PIL.ImageFont",
+    ],
     noarchive=False,
 )
 # ---------------------------------------------------------------------------
 # One HarfBuzz, and it must be Homebrew's (issue #141, reported by mdornich)
 # ---------------------------------------------------------------------------
-# PyInstaller collects TWO HarfBuzz builds into the bundle:
+# When Pillow's `_imagingft` is collected, PyInstaller brings Pillow's own
+# HarfBuzz with it and the two builds collide under one install name:
 #
-#   Contents/Frameworks/PIL/.dylibs/libharfbuzz.0.dylib   Pillow's,   ~1.81 MB
-#   Contents/Frameworks/libharfbuzz.dylib                 Homebrew's, ~1.32 MB
-#   Contents/Frameworks/libharfbuzz-subset.0.dylib        Homebrew's, ~1.36 MB
+#   PIL/.dylibs/libharfbuzz.0.dylib   Pillow's,   ~1.81 MB  <- owns the VERSIONED name
+#   libharfbuzz.dylib                 Homebrew's, ~1.24 MB  <- unversioned ONLY
+#   libharfbuzz-subset.0.dylib        Homebrew's, ~1.43 MB
 #
-# Both answer to the install name @rpath/libharfbuzz.0.dylib, so whichever
-# loads first wins for the whole process. The `binaries` list above seeds
-# Homebrew's under the VERSIONED name, but PyInstaller's PIL hook wins the
-# filename collision and turns Contents/Frameworks/libharfbuzz.0.dylib into a
-# symlink into PIL/. Homebrew's real library then sits in the bundle under the
-# unversioned name where nothing resolves to it.
+# The `binaries` list above seeds Homebrew's under the versioned name, but
+# PIL's hook wins the filename and Homebrew's real library lands unversioned
+# where nothing resolves to it. Pango asks for @rpath/libharfbuzz.0.dylib and
+# gets Pillow's, while libharfbuzz-subset is Homebrew's — and those symbols
+# exist only in the Homebrew build. The first PDF render dies in native code.
 #
-# Pango therefore gets Pillow's HarfBuzz while libharfbuzz-subset is
-# Homebrew's — and `libharfbuzz-subset` only exists in the Homebrew build. The
-# first PDF render dies in native code.
+# EXCLUDE THE MODULE, DO NOT DROP THE LIBRARY. That distinction is @macbase1's
+# and it was measured, not argued. Removing Pillow's dylib from `a.binaries`
+# after Analysis is too late, and fails two ways:
 #
-# Dropping Pillow's copy is safe, and that was checked rather than assumed:
-# the pinned pillow wheel ships neither libraqm nor libfribidi, so complex
-# shaping is off and `PIL.features.check('harfbuzz')` is False; and nothing in
-# app/ draws text with Pillow at all — it appears only in ocr_service.py and
-# ocr_regions.py, for image preprocessing. All 25 hb_* symbols _imagingft
-# imports are exported by Homebrew's build.
+#   * on its own it leaves ZERO versioned copies, because Homebrew's is
+#     already sitting under the unversioned name — an affected builder then
+#     cannot build at all;
+#   * re-seeding Homebrew's versioned name afterwards BUILDS, and produces a
+#     DANGLING SYMLINK into PIL/, because PyInstaller creates the cross-link
+#     before the spec removes the file under it. That bundle signs, notarizes,
+#     and dies at the first PDF — the original symptom, reached by the repair.
 #
-# The assertion below is the important half. Getting this wrong in the other
-# direction — removing Pillow's copy while Homebrew's sits under the
-# unversioned name — turns a PDF crash into an import failure, which is worse
-# and easier to ship by accident. So the build FAILS here rather than
-# producing a bundle nobody looks inside.
-_PIL_HARFBUZZ = [
-    (dest, src, kind)
-    for (dest, src, kind) in a.binaries
-    if "libharfbuzz" in os.path.basename(dest) and "PIL" in dest.split(os.sep)
-]
-for entry in _PIL_HARFBUZZ:
-    a.binaries.remove(entry)
-    print(f"[spec] #141: dropped Pillow's HarfBuzz: {entry[0]}")
-
+# Excluding `PIL._imagingft` / `PIL.ImageFont` is early enough: the library is
+# never collected, so Homebrew's keeps the versioned name it was seeded with.
+#
+# Safe because nothing in app/ draws text with Pillow — it appears only in
+# ocr_service.py and ocr_regions.py, for image preprocessing, and neither
+# imports ImageFont or ImageDraw. tests/test_macos_harfbuzz_collision.py fails
+# if that ever stops being true.
+#
+# (An earlier version of this comment claimed the pinned wheel ships no raqm
+# or fribidi, so shaping is off. @macbase1 measured pillow 12.3.0 from that
+# same pin reporting `harfbuzz: True, raqm: True`. The conclusion stands but
+# it rests only on the argument above, not on that one.)
 _HARFBUZZ_VERSIONED = [
     dest
     for (dest, _src, _kind) in a.binaries
@@ -162,7 +168,8 @@ if len(_HARFBUZZ_VERSIONED) != 1:
         f"found {len(_HARFBUZZ_VERSIONED)}: {_HARFBUZZ_VERSIONED}. Pango "
         f"resolves @rpath/libharfbuzz.0.dylib; zero copies is an import "
         f"failure and two is a silent collision that kills the first PDF "
-        f"render."
+        f"render. If Pillow's copy is back, something is pulling in "
+        f"PIL._imagingft past the excludes below."
     )
 if "PIL" in _HARFBUZZ_VERSIONED[0].split(os.sep):
     raise SystemExit(

--- a/scripts/repair-schema.py
+++ b/scripts/repair-schema.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Bring a company file or database to the current migration head, including
+one that a server half-upgraded (issue #132).
+
+    python3 scripts/repair-schema.py --database-url sqlite:////path/to/company.db
+    python3 scripts/repair-schema.py --database-url "$DATABASE_URL" --dry-run
+
+`alembic upgrade head` is the right tool for an ordinary old file and cannot
+recover a half-upgraded one: a server started against a database behind head
+runs `create_all()`, which creates the tables a pending revision would add
+without altering the ones it would change and without moving the revision
+stamp. The upgrade then fails on `table <x> already exists`.
+
+This runs the upgrade and, when a table blocks it, drops that table **only if
+it is empty** before trying again. `create_all()` only ever creates, so
+anything it left behind carries no rows; a table with data was made by
+something else and this refuses to touch it.
+
+Take a copy first. This edits the database it is pointed at.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.services.schema_repair import repair  # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--database-url", required=True, help="SQLAlchemy URL")
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="say what would happen without changing anything",
+    )
+    args = ap.parse_args()
+
+    result = repair(args.database_url, dry_run=args.dry_run)
+    print(f"revision before : {result.started_at}")
+    print(f"revision now    : {result.now_at}")
+    if result.dropped:
+        print(f"dropped (empty) : {', '.join(result.dropped)}")
+    print(f"result          : {'OK' if result.ok else 'FAILED'} — {result.message}")
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_chart_of_accounts_cleanup.py
+++ b/tests/test_chart_of_accounts_cleanup.py
@@ -187,6 +187,13 @@ def test_the_page_offers_deactivate_reactivate_and_delete():
     )
     assert "setAccountActive(" in js
     assert "deleteAccount(" in js
+    # These assert the call EXISTS, which is what let the 2.12.0 gate's HIGH
+    # through: the Delete handler was in the source and the markup around it
+    # did not parse, so the button never fired. A test of a string is not a
+    # test of a document — see tests/test_onclick_attributes_parse.py.
+    assert (
+        "JSON.stringify" not in js.split("renderAccounts()")[1].split("saveAccount")[0]
+    ), "a stringified value in the accounts row markup again"
     assert "API.del(" in js, "API exposes del(), not delete()"
     # A deactivated account must stay reachable, or deactivating is one-way.
     assert "_showInactiveAccounts" in js

--- a/tests/test_chart_of_accounts_cleanup.py
+++ b/tests/test_chart_of_accounts_cleanup.py
@@ -1,0 +1,195 @@
+"""An operator can shrink a chart of accounts they did not choose (#139).
+
+Reported by tresero, arriving from hledger with their own chart. A new
+company is seeded with 57 accounts and, before this, **none of them could be
+removed or hidden**:
+
+  * `delete_account` refused anything carrying `is_system`, and all 57 carry
+    it — so delete was refused for every seeded account, forever, even on a
+    company with no transactions;
+  * the Chart of Accounts page had no deactivate control at all, so the
+    "Deactivate it instead" advice in our own delete error was something the
+    interface could not do.
+
+That is the same wrong flag 2.10.2 found hiding the Edit button, in a second
+place. The gate is the control-account registry: fifteen numbers the posting
+code resolves literally and a document that cannot find one is #119. Those
+can be renamed, never removed. The other forty-two are ordinary accounts.
+"""
+
+import pytest
+
+from app.models.accounts import Account
+from app.services import control_accounts
+
+
+def _seeded_ordinary(db):
+    """A seeded account that is NOT a control account — the case that was
+    refused for the wrong reason."""
+    acct = (
+        db.query(Account)
+        .filter(Account.is_system.is_(True))
+        .filter(Account.account_number.notin_(list(control_accounts.CONTROL_ACCOUNTS)))
+        .first()
+    )
+    assert acct is not None, "no seeded non-control account to test with"
+    return acct
+
+
+def test_a_seeded_account_with_no_history_can_be_deleted(
+    client, db_session, seed_accounts
+):
+    acct = _seeded_ordinary(db_session)
+    assert acct.is_system is True, "the point of this test is that is_system is set"
+    number = acct.account_number
+
+    r = client.delete(f"/api/accounts/{acct.id}")
+    assert r.status_code == 200, r.text
+    assert (
+        db_session.query(Account).filter(Account.account_number == number).first()
+        is None
+    )
+
+
+def test_a_control_account_is_refused_and_told_why(client, db_session, seed_accounts):
+    ar = seed_accounts["1100"]
+    r = client.delete(f"/api/accounts/{ar.id}")
+    assert r.status_code == 400
+    detail = r.json()["detail"]
+    assert "1100" in detail and "control account" in detail
+    # It must say what it IS good for, and what you can do instead.
+    assert "rename" in detail.lower()
+    assert db_session.query(Account).filter(Account.id == ar.id).first() is not None
+
+
+@pytest.mark.parametrize("number", sorted(control_accounts.CONTROL_ACCOUNTS))
+def test_every_control_number_is_protected(client, db_session, seed_accounts, number):
+    """The registry is the gate, so every number in it must be refused —
+    not just the famous ones."""
+    acct = db_session.query(Account).filter(Account.account_number == number).first()
+    if acct is None:
+        pytest.skip(f"{number} is created on demand, not seeded")
+    assert client.delete(f"/api/accounts/{acct.id}").status_code == 400
+
+
+def test_an_account_with_postings_is_refused_with_its_count(
+    client, db_session, seed_accounts
+):
+    """Unchanged behaviour, re-pinned on an ordinary account: history anchors
+    to the account, so it can be hidden but never removed."""
+    acct = _seeded_ordinary(db_session)
+    vendor = client.post("/api/vendors", json={"name": "Probe Supply"}).json()
+    r = client.post(
+        "/api/expenses",
+        json={
+            "date": "2026-05-01",
+            "vendor_id": vendor["id"],
+            "expense_account_id": acct.id,
+            "paid_from_account_id": seed_accounts["1000"].id,
+            "amount": "42.00",
+        },
+    )
+    assert r.status_code == 201, r.text
+
+    r = client.delete(f"/api/accounts/{acct.id}")
+    assert r.status_code == 409, r.text
+    detail = r.json()["detail"]
+    assert "posted transaction line" in detail
+    assert "Deactivate it instead" in detail
+
+
+def test_an_account_in_use_elsewhere_names_where(client, db_session, seed_accounts):
+    """A reference that is not a posting — an item's income account. The old
+    message said only 'referenced by other records', which does not tell the
+    operator where to go and undo it."""
+    acct = _seeded_ordinary(db_session)
+    r = client.post(
+        "/api/items",
+        json={
+            "name": "Widget",
+            "item_type": "service",
+            "rate": "10.00",
+            "income_account_id": acct.id,
+        },
+    )
+    assert r.status_code in (200, 201), r.text
+
+    r = client.delete(f"/api/accounts/{acct.id}")
+    assert r.status_code == 409, r.text
+    detail = r.json()["detail"]
+    assert "items" in detail, detail
+    assert "deactivate" in detail.lower()
+
+
+def test_the_reference_scan_is_derived_from_the_schema_not_a_list():
+    """Thirty-five columns across seventeen models reference accounts.id and
+    the count grows with every feature — vendor credits added one this week.
+    A hand-kept list would be wrong within a release, and the symptom of it
+    being wrong is a foreign-key violation surfacing as a 500."""
+    from app.database import Base
+
+    referencing = {
+        table.name
+        for table in Base.metadata.sorted_tables
+        for fk in table.foreign_keys
+        if fk.column.table.name == "accounts"
+    }
+    # A sample from opposite ends of the app; the scan walks all of them.
+    for expected in ("items", "transaction_lines", "vendor_credit_lines"):
+        assert expected in referencing
+
+
+def test_deactivating_hides_an_account_without_deleting_it(
+    client, db_session, seed_accounts
+):
+    """The answer for anything that cannot be deleted, including all fifteen
+    control accounts. It was supported by the API and had no control on the
+    page, which is why the delete error's advice was unfollowable."""
+    acct = _seeded_ordinary(db_session)
+    r = client.put(f"/api/accounts/{acct.id}", json={"is_active": False})
+    assert r.status_code == 200, r.text
+    assert r.json()["is_active"] is False
+
+    db_session.expire_all()
+    assert db_session.query(Account).filter(Account.id == acct.id).first() is not None
+
+    r = client.put(f"/api/accounts/{acct.id}", json={"is_active": True})
+    assert r.status_code == 200 and r.json()["is_active"] is True
+
+
+def test_a_control_account_can_be_deactivated_and_renamed(
+    client, db_session, seed_accounts
+):
+    """What the reporter is actually offered for the fifteen: they stay, but
+    they can carry his names and drop out of the pickers."""
+    ar = seed_accounts["1100"]
+    assert (
+        client.put(f"/api/accounts/{ar.id}", json={"name": "Trade debtors"}).status_code
+        == 200
+    )
+    assert (
+        client.put(f"/api/accounts/{ar.id}", json={"is_active": False}).status_code
+        == 200
+    )
+    db_session.expire_all()
+    got = db_session.query(Account).filter(Account.id == ar.id).first()
+    assert got.name == "Trade debtors" and got.account_number == "1100"
+
+
+def test_the_page_offers_deactivate_reactivate_and_delete():
+    """The gap was never only the rule — there was no control on the page.
+    Guarded at the source for the same reason as the clipboard and CSS
+    checks: the defect lives in code no Python test can execute."""
+    from pathlib import Path
+
+    js = (Path(__file__).resolve().parents[1] / "app/static/js/app.js").read_text(
+        encoding="utf-8"
+    )
+    assert "setAccountActive(" in js
+    assert "deleteAccount(" in js
+    assert "API.del(" in js, "API exposes del(), not delete()"
+    # A deactivated account must stay reachable, or deactivating is one-way.
+    assert "_showInactiveAccounts" in js
+    assert "toggleInactiveAccounts" in js
+    # Never offer Delete on a control account; the server refuses it anyway.
+    assert "a.is_control ? '' :" in js

--- a/tests/test_clipboard_helper.py
+++ b/tests/test_clipboard_helper.py
@@ -1,0 +1,97 @@
+"""Every copy button goes through one helper, and that helper names the
+cause it can name (issues #137, #138).
+
+`navigator.clipboard` requires a secure context. The desktop app is served
+over plain HTTP and copying works anyway, for exactly one reason: loopback
+is a secure origin by specification. `http://127.0.0.1` qualifies;
+`http://192.168.x.x` does not.
+
+So every copy button in the product works on the machine running it and
+silently stops working for anyone reaching it over a LAN. Nobody who can
+reproduce that is looking at it: a developer runs on loopback, and so does
+every QA gate on all three platforms. It was found on the 2.11.1 gate by
+measuring `isSecureContext`, not by anything failing.
+
+These are source guards rather than behavioural tests for the same reason
+`test_css_hidden_and_contrast.py` is: there is no JS harness in this repo,
+and the defect lives in code no Python test can execute. A guard that
+catches the regression is worth more than no guard at all.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+JS = ROOT / "app/static/js"
+UTILS = (JS / "utils.js").read_text(encoding="utf-8")
+
+# Every file that offers the operator a copy button.
+CALL_SITES = ("settings.js", "employees.js", "invoices.js", "reseller_permits.js")
+
+
+def test_the_helper_exists_and_is_in_utils():
+    """utils.js loads before every page script in index.html, so the helper
+    has to live there for the call sites to see it."""
+    assert "async function copyToClipboard(" in UTILS
+    index = (ROOT / "index.html").read_text(encoding="utf-8")
+    utils_at = index.index("/static/js/utils.js")
+    for name in CALL_SITES:
+        assert index.index(f"/static/js/{name}") > utils_at, (
+            f"{name} is loaded before utils.js; copyToClipboard would be undefined"
+        )
+
+
+@pytest.mark.parametrize("name", CALL_SITES)
+def test_no_page_calls_the_clipboard_api_directly(name):
+    """The whole point of the helper is that the four call sites cannot
+    drift apart again. Before this, `invoices.js` had no guard at all and
+    reported a clipboard refusal as an API error, `reseller_permits.js`
+    fell back to a `window.prompt`, and the other two carried two slightly
+    different copies of the same check."""
+    src = (JS / name).read_text(encoding="utf-8")
+    assert "navigator.clipboard" not in src, (
+        f"{name} calls navigator.clipboard directly instead of copyToClipboard()"
+    )
+
+
+def test_the_helper_names_the_insecure_context_case():
+    """`isSecureContext` is the whole diagnosis. Without it the message is
+    'clipboard unavailable', which tells a LAN user nothing they can act
+    on — and they are the only people who ever see it."""
+    assert "window.isSecureContext" in UTILS
+    branch = UTILS[UTILS.index("window.isSecureContext"):]
+    branch = branch[: branch.index("}")]
+    assert "secure connection" in branch.lower()
+
+
+def test_the_fallback_selects_the_text():
+    """The point of selecting it is that the recovery becomes one keystroke
+    instead of an instruction to aim a mouse at a monospace blob — which is
+    how somebody ended up screenshotting an API token to keep it."""
+    assert "_selectElementText" in UTILS
+    assert "selectNodeContents" in UTILS
+    assert "Ctrl+C" in UTILS
+
+
+def test_the_api_token_reveal_passes_its_element_to_the_helper():
+    """The token is the case that matters most: shown exactly once, and the
+    element is on screen when the copy fails, so it can be selected."""
+    src = (JS / "settings.js").read_text(encoding="utf-8")
+    m = re.search(r"copyApiTokenSecret\(\)\s*\{(.+?)\n    \},", src, re.S)
+    assert m, "copyApiTokenSecret() not found"
+    assert "copyToClipboard(" in m.group(1)
+    assert "el)" in m.group(1), (
+        "the reveal element is not passed, so the fallback cannot select the token"
+    )
+
+
+def test_the_created_toast_tells_you_to_press_copy():
+    """Issue #138. 'copy it now' reads as a report of something already
+    done — a tester read it that way, went to paste, and got nothing. On a
+    secret shown exactly once, believing it is already on the clipboard
+    costs you your only look."""
+    src = (JS / "settings.js").read_text(encoding="utf-8")
+    assert "Token created — press Copy below" in src
+    assert "Token created — copy it now" not in src

--- a/tests/test_clipboard_helper.py
+++ b/tests/test_clipboard_helper.py
@@ -38,9 +38,9 @@ def test_the_helper_exists_and_is_in_utils():
     index = (ROOT / "index.html").read_text(encoding="utf-8")
     utils_at = index.index("/static/js/utils.js")
     for name in CALL_SITES:
-        assert index.index(f"/static/js/{name}") > utils_at, (
-            f"{name} is loaded before utils.js; copyToClipboard would be undefined"
-        )
+        assert (
+            index.index(f"/static/js/{name}") > utils_at
+        ), f"{name} is loaded before utils.js; copyToClipboard would be undefined"
 
 
 @pytest.mark.parametrize("name", CALL_SITES)
@@ -51,9 +51,9 @@ def test_no_page_calls_the_clipboard_api_directly(name):
     fell back to a `window.prompt`, and the other two carried two slightly
     different copies of the same check."""
     src = (JS / name).read_text(encoding="utf-8")
-    assert "navigator.clipboard" not in src, (
-        f"{name} calls navigator.clipboard directly instead of copyToClipboard()"
-    )
+    assert (
+        "navigator.clipboard" not in src
+    ), f"{name} calls navigator.clipboard directly instead of copyToClipboard()"
 
 
 def test_the_helper_names_the_insecure_context_case():
@@ -61,7 +61,7 @@ def test_the_helper_names_the_insecure_context_case():
     'clipboard unavailable', which tells a LAN user nothing they can act
     on — and they are the only people who ever see it."""
     assert "window.isSecureContext" in UTILS
-    branch = UTILS[UTILS.index("window.isSecureContext"):]
+    branch = UTILS[UTILS.index("window.isSecureContext") :]
     branch = branch[: branch.index("}")]
     assert "secure connection" in branch.lower()
 
@@ -82,9 +82,9 @@ def test_the_api_token_reveal_passes_its_element_to_the_helper():
     m = re.search(r"copyApiTokenSecret\(\)\s*\{(.+?)\n    \},", src, re.S)
     assert m, "copyApiTokenSecret() not found"
     assert "copyToClipboard(" in m.group(1)
-    assert "el)" in m.group(1), (
-        "the reveal element is not passed, so the fallback cannot select the token"
-    )
+    assert "el)" in m.group(
+        1
+    ), "the reveal element is not passed, so the fallback cannot select the token"
 
 
 def test_the_created_toast_tells_you_to_press_copy():

--- a/tests/test_email_invoice_dialog.py
+++ b/tests/test_email_invoice_dialog.py
@@ -1,0 +1,107 @@
+"""The Email Invoice dialog's own payload was rejected (issue #140, mdornich).
+
+`_EmailInvoiceRequest` is a StrictModel accepting `recipient` and `subject`.
+The dialog in `app/static/js/invoices.js` has always also posted `message`,
+so **every send from the interface failed validation with a 422** before
+reaching any of the sending code. The Message box did not merely get
+ignored; it broke the button it sat on.
+
+No test caught it because every test called the endpoint with a payload the
+endpoint accepted, rather than the payload the interface sends. That is the
+same shape as 2.10.3's shadowed download route: a test of the handler is not
+a test of what the page does.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def invoice(client):
+    cust = client.post(
+        "/api/customers", json={"name": "Probe Co", "email": "a@b.com"}
+    ).json()
+    r = client.post(
+        "/api/invoices",
+        json={
+            "customer_id": cust["id"],
+            "date": "2026-06-01",
+            "due_date": "2026-06-30",
+            "lines": [
+                {"description": "work", "quantity": 1, "rate": 100, "line_order": 0}
+            ],
+        },
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def test_the_payload_the_dialog_actually_sends_is_accepted(
+    client, seed_accounts, invoice
+):
+    """Not 422. SMTP is unconfigured in tests, so the honest outcome is a
+    502 from the send itself — which means validation passed and the request
+    reached the sending code."""
+    r = client.post(
+        f"/api/invoices/{invoice['id']}/email",
+        json={
+            "recipient": "a@b.com",
+            "subject": f"Invoice #{invoice['invoice_number']} from us",
+            "message": f"Please find attached Invoice #{invoice['invoice_number']}.",
+        },
+    )
+    assert r.status_code != 422, r.text
+    assert r.status_code == 502, r.text
+
+
+def test_the_dialog_and_the_route_agree_on_their_fields():
+    """The tripwire. These two drifted apart and nothing noticed, because
+    they are in different languages in different files."""
+    js = (ROOT / "app/static/js/invoices.js").read_text(encoding="utf-8")
+    py = (ROOT / "app/routes/invoices/documents.py").read_text(encoding="utf-8")
+
+    body = re.search(r"API\.post\(`/invoices/\$\{id\}/email`,\s*\{(.+?)\}\)", js, re.S)
+    assert body, "could not find the dialog's email POST"
+    sent = set(re.findall(r"(\w+):", body.group(1)))
+
+    model = re.search(r"class _EmailInvoiceRequest\(StrictModel\):(.+?)\n\n", py, re.S)
+    assert model, "could not find _EmailInvoiceRequest"
+    accepted = set(re.findall(r"^\s{4}(\w+):", model.group(1), re.M))
+
+    assert sent <= accepted, (
+        f"the dialog posts {sorted(sent - accepted)} which the route rejects; "
+        f"_EmailInvoiceRequest is a StrictModel so this is a 422, not an ignore"
+    )
+
+
+def test_the_operators_message_reaches_the_email_body(
+    client, db_session, seed_accounts, invoice
+):
+    """The box says Message. It should be the message."""
+    from app.models.invoices import Invoice
+    from app.services.email_service import render_invoice_email
+    from app.services.settings_service import get_all_settings as get_settings
+
+    inv = db_session.query(Invoice).filter(Invoice.id == invoice["id"]).first()
+    body = render_invoice_email(
+        inv, get_settings(db_session), note="Ten days, as agreed."
+    )
+    assert "Ten days, as agreed." in body
+
+
+def test_an_operator_message_is_escaped(client, db_session, seed_accounts, invoice):
+    """It is operator-supplied text landing in an HTML email."""
+    from app.models.invoices import Invoice
+    from app.services.email_service import render_invoice_email
+    from app.services.settings_service import get_all_settings as get_settings
+
+    inv = db_session.query(Invoice).filter(Invoice.id == invoice["id"]).first()
+    body = render_invoice_email(
+        inv, get_settings(db_session), note="<script>x</script>"
+    )
+    assert "<script>x</script>" not in body
+    assert "&lt;script&gt;" in body

--- a/tests/test_email_invoice_dialog.py
+++ b/tests/test_email_invoice_dialog.py
@@ -43,9 +43,17 @@ def invoice(client):
 def test_the_payload_the_dialog_actually_sends_is_accepted(
     client, seed_accounts, invoice
 ):
-    """Not 422. SMTP is unconfigured in tests, so the honest outcome is a
-    502 from the send itself — which means validation passed and the request
-    reached the sending code."""
+    """The claim is only this: the request clears validation.
+
+    What happens *after* validation is host-dependent and is not what this
+    test is about — SMTP is unconfigured everywhere, so a machine with the
+    PDF stack answers 502 from the send, and one without it answers 500
+    because the attachment cannot be rendered. Asserting 502 made this pass
+    on Linux and fail on Windows CI, which is precisely the defect class
+    that job exists to catch (@ContractorKeith found the same shape in
+    2.10.2: a test that only passed where something was absent). Caught on
+    the 2.11.2 gate, by the job, before anyone ran it.
+    """
     r = client.post(
         f"/api/invoices/{invoice['id']}/email",
         json={
@@ -54,8 +62,11 @@ def test_the_payload_the_dialog_actually_sends_is_accepted(
             "message": f"Please find attached Invoice #{invoice['invoice_number']}.",
         },
     )
-    assert r.status_code != 422, r.text
-    assert r.status_code == 502, r.text
+    assert r.status_code != 422, (
+        "the dialog's own payload is rejected before reaching the send: " f"{r.text}"
+    )
+    # It got past the request model and into the handler.
+    assert r.status_code in (200, 500, 502), r.text
 
 
 def test_the_dialog_and_the_route_agree_on_their_fields():

--- a/tests/test_email_invoice_dialog.py
+++ b/tests/test_email_invoice_dialog.py
@@ -115,6 +115,13 @@ def test_the_dialog_and_the_route_agree_on_their_fields():
         f"the dialog posts {sorted(sent - accepted)} which the route rejects; "
         f"_EmailInvoiceRequest is a StrictModel so this is a 422, not an ignore"
     )
+    # The other direction, which @mdornich found by testing his own branch
+    # against this test: it removed the Message box entirely and still passed
+    # everything here. "The page stopped sending something the route
+    # supports" was outside the window, and it is the likelier mistake now
+    # that the field works. The box existing is part of the contract.
+    assert "message" in sent, "the Email Invoice dialog no longer sends a message"
+    assert "message" in accepted, "the route no longer accepts a message"
 
 
 def test_the_operators_message_reaches_the_email_body(
@@ -144,3 +151,142 @@ def test_an_operator_message_is_escaped(client, db_session, seed_accounts, invoi
     )
     assert "<script>x</script>" not in body
     assert "&lt;script&gt;" in body
+
+
+# ── The saved template, which was never loaded by anything (#140 part 1) ──
+
+
+def _save_invoice_template(client, subject, body):
+    # Defaults are created on demand, not at install — a fresh company has no
+    # invoice_email row at all, which is why the renderer has to fall through
+    # to the built-in body rather than assume one exists.
+    client.post("/api/email-templates/seed-defaults")
+    tpls = client.get("/api/email-templates").json()
+    tpl = [t for t in tpls if t["name"] == "invoice_email"]
+    assert tpl, "the invoice_email template should be seeded"
+    r = client.put(
+        f"/api/email-templates/{tpl[0]['id']}",
+        json={"subject_template": subject, "body_template": body},
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_the_saved_template_is_what_gets_sent(
+    client, db_session, seed_accounts, invoice
+):
+    """Editing `invoice_email` under Settings saved correctly and changed
+    nothing. `render_template_from_db` existed with exactly one caller — the
+    donor acknowledgment — and the invoice path went straight to the file
+    template."""
+    from app.models.invoices import Invoice
+    from app.services.email_service import render_invoice_email_parts
+    from app.services.settings_service import get_all_settings as get_settings
+
+    _save_invoice_template(
+        client,
+        "OBVIOUSLY CUSTOM {{ invoice.invoice_number }}",
+        "<p>A body nobody would write by accident.</p>",
+    )
+    inv = db_session.query(Invoice).filter(Invoice.id == invoice["id"]).first()
+    subject, body = render_invoice_email_parts(
+        inv, get_settings(db_session), db=db_session
+    )
+    assert subject.startswith("OBVIOUSLY CUSTOM")
+    assert "A body nobody would write by accident." in body
+    assert "Please find attached" not in body
+
+
+def test_without_a_database_the_built_in_body_is_used(
+    client, db_session, seed_accounts, invoice
+):
+    """The renderer must still work for callers that have no session."""
+    from app.models.invoices import Invoice
+    from app.services.email_service import render_invoice_email_parts
+    from app.services.settings_service import get_all_settings as get_settings
+
+    inv = db_session.query(Invoice).filter(Invoice.id == invoice["id"]).first()
+    _, body = render_invoice_email_parts(inv, get_settings(db_session))
+    assert "Please find attached" in body
+
+
+def test_a_broken_saved_template_does_not_stop_the_mail(
+    client, db_session, seed_accounts, invoice
+):
+    """A template is operator-authored text. A bad expression in it must not
+    be the reason an invoice never goes out."""
+    from app.models.invoices import Invoice
+    from app.services.email_service import render_invoice_email_parts
+    from app.services.settings_service import get_all_settings as get_settings
+
+    _save_invoice_template(client, "S", "{{ nope.does.not.exist | frobnicate }}")
+    inv = db_session.query(Invoice).filter(Invoice.id == invoice["id"]).first()
+    _, body = render_invoice_email_parts(inv, get_settings(db_session), db=db_session)
+    assert "Please find attached" in body, "should fall through to the built-in body"
+
+
+def test_the_note_survives_a_saved_template_that_never_mentions_it(
+    client, db_session, seed_accounts, invoice
+):
+    """The design decision, and @mdornich's call. If the note were a
+    `{{ note }}` context variable, a saved template that does not reference
+    it would drop the operator's message silently — the same failure class
+    #140 is about, moved rather than fixed. It is prepended, always."""
+    from app.models.invoices import Invoice
+    from app.services.email_service import render_invoice_email_parts
+    from app.services.settings_service import get_all_settings as get_settings
+
+    _save_invoice_template(client, "S", "<p>No mention of any note here.</p>")
+    inv = db_session.query(Invoice).filter(Invoice.id == invoice["id"]).first()
+    _, body = render_invoice_email_parts(
+        inv, get_settings(db_session), note="Ten days, as agreed.", db=db_session
+    )
+    assert "Ten days, as agreed." in body
+    assert body.index("Ten days") < body.index("No mention"), "the note goes above"
+
+
+def test_a_sales_receipt_still_uses_the_saved_invoice_template(
+    client, db_session, seed_accounts, invoice
+):
+    """#140 part three. `invoice_email_label()` answers 'Sales Receipt' for
+    that kind, so selecting a template by the document's face would skip the
+    saved template for every sales receipt — ordinary businesses, not just
+    nonprofit installs. The lookup is the fixed name `invoice_email`."""
+    from app.models.invoices import Invoice
+    from app.services.email_service import (
+        render_invoice_email_parts,
+        invoice_email_label,
+    )
+    from app.services.settings_service import get_all_settings as get_settings
+
+    _save_invoice_template(client, "S", "<p>CUSTOM BODY</p>")
+    inv = db_session.query(Invoice).filter(Invoice.id == invoice["id"]).first()
+    company = get_settings(db_session)
+
+    # Whatever the document is called, the same template is used.
+    label = invoice_email_label(inv, company)
+    _, body = render_invoice_email_parts(inv, company, db=db_session)
+    assert "CUSTOM BODY" in body, f"label was {label!r} and the template was skipped"
+
+
+def test_the_preview_returns_what_the_send_would_produce(
+    client, db_session, seed_accounts, invoice
+):
+    """A read-only endpoint that renders through the same code as the send.
+    It exists because an operator editing the template had no way to see the
+    result short of mailing a real customer."""
+    from app.models.email_log import EmailLog
+
+    _save_invoice_template(client, "SUBJ {{ invoice.invoice_number }}", "<p>BODY</p>")
+    before = db_session.query(EmailLog).count()
+
+    r = client.post(
+        f"/api/invoices/{invoice['id']}/email-preview",
+        json={"recipient": "a@b.com", "message": "Hello there."},
+    )
+    assert r.status_code == 200, r.text
+    out = r.json()
+    assert out["subject"] == f"SUBJ {invoice['invoice_number']}"
+    assert "BODY" in out["html_body"]
+    assert "Hello there." in out["html_body"]
+    # Read-only: nothing sent, nothing logged.
+    assert db_session.query(EmailLog).count() == before

--- a/tests/test_email_invoice_dialog.py
+++ b/tests/test_email_invoice_dialog.py
@@ -69,6 +69,34 @@ def test_the_payload_the_dialog_actually_sends_is_accepted(
     assert r.status_code in (200, 500, 502), r.text
 
 
+def test_an_unknown_field_is_still_refused():
+    """The control, and it is @macbase1's — their gate harness had it and my
+    test did not.
+
+    "The dialog's payload is accepted" is equally true of a fix that named
+    `message` and of one that simply deleted the model's strictness. Only
+    this tells them apart, and the second would be a far wider change than
+    #140 asked for: `_EmailInvoiceRequest` is a StrictModel on purpose, so
+    that a typo in the page is a loud 422 rather than a field silently
+    dropped on the floor.
+
+    It lives here as well as in the harness because CI runs this suite on
+    every push and does not run the harness.
+    """
+    from app.routes.invoices.documents import _EmailInvoiceRequest
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError) as e:
+        _EmailInvoiceRequest(
+            recipient="a@b.com", subject="s", message="m", nonsense="x"
+        )
+    assert "extra_forbidden" in str(e.value)
+
+    # And the four it does take still validate together.
+    ok = _EmailInvoiceRequest(recipient="a@b.com", subject="s", message="m")
+    assert ok.message == "m"
+
+
 def test_the_dialog_and_the_route_agree_on_their_fields():
     """The tripwire. These two drifted apart and nothing noticed, because
     they are in different languages in different files."""

--- a/tests/test_macos_harfbuzz_collision.py
+++ b/tests/test_macos_harfbuzz_collision.py
@@ -1,0 +1,68 @@
+"""The macOS bundle must contain exactly one HarfBuzz (issue #141).
+
+Reported by mdornich after a locally built `.app` crashed in native code on
+its first PDF render. PyInstaller collects two HarfBuzz builds:
+
+    Contents/Frameworks/PIL/.dylibs/libharfbuzz.0.dylib   Pillow's,   ~1.81 MB
+    Contents/Frameworks/libharfbuzz.dylib                 Homebrew's, ~1.32 MB
+    Contents/Frameworks/libharfbuzz-subset.0.dylib        Homebrew's, ~1.36 MB
+
+Both answer to `@rpath/libharfbuzz.0.dylib`, so whichever loads first wins
+for the whole process. The spec seeds Homebrew's under the versioned name,
+but PyInstaller's PIL hook wins the filename collision and replaces it with a
+symlink into `PIL/`. Pango then gets Pillow's HarfBuzz while
+`libharfbuzz-subset` is Homebrew's — and that symbol set exists only in the
+Homebrew build.
+
+These are source guards. The real check is a built bundle on an Apple
+Silicon Mac, which is the QA agent's job and is asked for in testing-repo
+issue #47. What is guarded here is that the spec keeps the properties the
+fix depends on, because those are what a later edit would quietly remove.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = (ROOT / "packaging/macos/SlowBooksPro-mac.spec").read_text(encoding="utf-8")
+
+
+def test_the_spec_drops_pillows_harfbuzz():
+    assert "_PIL_HARFBUZZ" in SPEC
+    assert "a.binaries.remove(entry)" in SPEC
+
+
+def test_the_spec_still_seeds_homebrews_versioned_harfbuzz():
+    """The half that makes dropping Pillow's copy safe rather than fatal.
+
+    Homebrew's library must end up AT `libharfbuzz.0.dylib`. If it only lands
+    under the unversioned name, `_imagingft`'s `@rpath/libharfbuzz.0.dylib`
+    goes from resolving the wrong library to resolving nothing — an import
+    failure instead of a render crash, which is worse and easier to ship."""
+    assert '_brew_library("harfbuzz", "libharfbuzz.0.dylib")' in SPEC
+    assert '_brew_library("harfbuzz", "libharfbuzz-subset.0.dylib")' in SPEC
+
+
+def test_the_build_fails_loudly_rather_than_shipping_a_collision():
+    """A bundle nobody looks inside is exactly how this shipped in the first
+    place. Zero copies and two copies are both build failures now."""
+    assert "expected exactly one libharfbuzz.0.dylib" in SPEC
+    assert SPEC.count("raise SystemExit") >= 2
+
+
+def test_nothing_in_the_app_draws_text_with_pillow():
+    """Why dropping Pillow's HarfBuzz is safe, asserted rather than assumed.
+
+    If someone later imports ImageDraw or ImageFont, complex-text shaping
+    becomes reachable and this decision needs revisiting — so the assumption
+    should fail out loud at that moment, not in a crash report."""
+    offenders = []
+    for path in (ROOT / "app").rglob("*.py"):
+        src = path.read_text(encoding="utf-8", errors="replace")
+        if re.search(r"\b(ImageDraw|ImageFont)\b", src):
+            offenders.append(str(path.relative_to(ROOT)))
+    assert not offenders, (
+        "app/ now draws text with Pillow: " + ", ".join(offenders) + ". "
+        "Pillow's HarfBuzz is dropped from the macOS bundle (#141) on the "
+        "grounds that nothing asks Pillow to shape text. Re-check that."
+    )

--- a/tests/test_macos_harfbuzz_collision.py
+++ b/tests/test_macos_harfbuzz_collision.py
@@ -14,6 +14,13 @@ symlink into `PIL/`. Pango then gets Pillow's HarfBuzz while
 `libharfbuzz-subset` is Homebrew's — and that symbol set exists only in the
 Homebrew build.
 
+An earlier version of this fix claimed the pinned Pillow wheel ships no raqm
+or fribidi, so shaping is off and its HarfBuzz is inert. @macbase1 measured
+pillow 12.3.0 from that same pin reporting `harfbuzz: True, raqm: True`. The
+conclusion is unchanged — nothing in `app/` draws text with Pillow — but it
+rests on that argument alone, which is what
+`test_nothing_in_the_app_draws_text_with_pillow` guards.
+
 These are source guards. The real check is a built bundle on an Apple
 Silicon Mac, which is the QA agent's job and is asked for in testing-repo
 issue #47. What is guarded here is that the spec keeps the properties the
@@ -27,9 +34,25 @@ ROOT = Path(__file__).resolve().parents[1]
 SPEC = (ROOT / "packaging/macos/SlowBooksPro-mac.spec").read_text(encoding="utf-8")
 
 
-def test_the_spec_drops_pillows_harfbuzz():
-    assert "_PIL_HARFBUZZ" in SPEC
-    assert "a.binaries.remove(entry)" in SPEC
+def test_the_spec_excludes_the_module_rather_than_dropping_the_library():
+    """@macbase1 measured both, on a box where they forced the collision.
+
+    Dropping Pillow's dylib from `a.binaries` after Analysis fails two ways:
+    alone it leaves ZERO versioned copies, because Homebrew's is already
+    sitting under the unversioned name — an affected builder cannot build at
+    all. And re-seeding the versioned name afterwards BUILDS and produces a
+    DANGLING SYMLINK into `PIL/`, because PyInstaller creates the cross-link
+    before the spec removes the file under it. That bundle signs, notarizes
+    and dies at the first PDF: the original symptom, reached by the repair.
+
+    Excluding the module is early enough — the library is never collected.
+    """
+    assert '"PIL._imagingft"' in SPEC
+    assert '"PIL.ImageFont"' in SPEC
+    assert "a.binaries.remove" not in SPEC, (
+        "dropping the library after collection is the approach that produces "
+        "a dangling symlink or a zero-copy build"
+    )
 
 
 def test_the_spec_still_seeds_homebrews_versioned_harfbuzz():
@@ -48,6 +71,9 @@ def test_the_build_fails_loudly_rather_than_shipping_a_collision():
     place. Zero copies and two copies are both build failures now."""
     assert "expected exactly one libharfbuzz.0.dylib" in SPEC
     assert SPEC.count("raise SystemExit") >= 2
+    # The assertion is the half that survives a future hook or collect_all
+    # reintroducing the collision, so it stays even though the excludes
+    # should mean it never fires.
 
 
 def test_nothing_in_the_app_draws_text_with_pillow():

--- a/tests/test_onclick_attributes_parse.py
+++ b/tests/test_onclick_attributes_parse.py
@@ -1,0 +1,115 @@
+"""No inline handler carries an interpolated string (found on the 2.12.0 gate).
+
+`app.js` rendered a Delete button as:
+
+    onclick="App.deleteAccount(${a.id}, ${JSON.stringify(a.name)})"
+
+`JSON.stringify` always emits double quotes and the attribute is
+double-quoted, so the JSON's own first quote **closed the attribute**. What
+reached the HTML parser was:
+
+    <button onclick="App.deleteAccount(5, " savings")"="">Delete</button>
+
+The handler is the fragment `App.deleteAccount(5, ` — clicking raises a
+SyntaxError, so no request is made, no toast appears and no dialog opens. On
+**every** row, because the break is in the quoting rather than in any
+particular name. Edit and Deactivate worked because they pass a number and a
+boolean, which survive the parser intact.
+
+Both QA agents found it at the GUI. @skytech read `launcher.log` and
+established that the application had never issued a single
+`DELETE /api/accounts/*` — the button was not being refused, it never asked.
+
+**Why nothing automated caught it.** The endpoint is correct and well
+covered, the suite passed, and every check in both gates passed. My own test
+asserted `"deleteAccount(" in js` — that the call exists in the source, not
+that the markup it produces parses. A test of a string is not a test of a
+document.
+
+So these tests do two things: parse a rendered instance of the row with a
+real HTML parser, and refuse the whole class rather than this instance.
+@macbase1's framing: *a `data-` attribute plus a delegated listener would
+make the class impossible rather than absent* — bigger than this release
+wants, and this is the guard that keeps the small fix honest.
+"""
+
+import re
+from html.parser import HTMLParser
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+JS_DIR = ROOT / "app/static/js"
+JS_FILES = sorted(p for p in JS_DIR.glob("*.js") if p.name != "chart.umd.js")
+
+# An onclick="..." whose body contains a JS template interpolation.
+_ONCLICK = re.compile(r'onclick="([^"]*)"')
+_INTERP = re.compile(r"\$\{([^}]*)\}")
+
+
+class _Attrs(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.tags = []
+
+    def handle_starttag(self, tag, attrs):
+        self.tags.append((tag, dict(attrs)))
+
+
+def test_the_delete_button_markup_parses_as_one_attribute():
+    """A rendered instance, through a real parser. This is the assertion that
+    was missing: the old markup produced three attributes and a truncated
+    handler, and no amount of reading the source made that obvious."""
+    import json
+
+    # json.dumps emits exactly what JSON.stringify does: DOUBLE quotes. That
+    # is the whole mechanism — single quotes here would have been safe, and
+    # reproducing the break with the wrong quote style would make the control
+    # pass for the wrong reason.
+    name = json.dumps("Savings")  # -> "Savings"
+    good = '<button class="btn" onclick="App.deleteAccount(5)">Delete</button>'
+    bad = f'<button class="btn" onclick="App.deleteAccount(5, {name})">Delete</button>'
+
+    p = _Attrs()
+    p.feed(good)
+    tag, attrs = p.tags[0]
+    assert set(attrs) == {"class", "onclick"}, attrs
+    assert attrs["onclick"] == "App.deleteAccount(5)"
+    assert attrs["onclick"].count("(") == attrs["onclick"].count(")")
+
+    # The control: the old shape really does break, so the assertion above is
+    # not passing for an unrelated reason.
+    p2 = _Attrs()
+    p2.feed(bad)
+    _, bad_attrs = p2.tags[0]
+    assert len(bad_attrs) > 2, "the control did not reproduce the break"
+    assert bad_attrs["onclick"] == "App.deleteAccount(5, ", bad_attrs
+
+
+# A broad scanner lived here and was deleted before it shipped.
+#
+# "Any interpolated expression inside an onclick" flagged nine files, and
+# every one was a false positive: `${sec.onClick(item)}` builds the whole
+# handler, `${!c.is_active}` is a boolean, `${id ? id : 'null'}` is a JS
+# literal, and `'${escapeHtml(u.username)}'` is the established safe pattern —
+# single quotes inside the double-quoted attribute, with the value escaped.
+#
+# I spent this week telling two agents that a sweep measuring everything is a
+# harder instrument than a check measuring one thing, and then wrote a sweep
+# that would have sent the next person after nine non-problems. @macbase1's
+# line, turned around: the sweep went, the named checks stayed.
+#
+# What is left is the mechanism that actually broke, and the assertion that
+# the markup parses.
+
+
+def test_json_stringify_never_reaches_an_inline_handler():
+    """The specific mechanism, named, because it looks safe. It is the correct
+    tool for embedding a value in a *script body* and the wrong one inside an
+    attribute that is already using the quotes it emits."""
+    for path in JS_FILES:
+        src = path.read_text(encoding="utf-8")
+        for handler in _ONCLICK.findall(src):
+            assert "JSON.stringify" not in handler, (
+                f"{path.name}: JSON.stringify inside an onclick emits double "
+                f"quotes into a double-quoted attribute"
+            )

--- a/tests/test_schema_repair.py
+++ b/tests/test_schema_repair.py
@@ -1,0 +1,202 @@
+"""Recovering a half-upgraded database (issue #132, second half).
+
+The guard added in this release refuses to start against a database behind
+head, which stops the damage happening again. It does nothing for a file it
+has already happened to — and @skytech pointed out the distinction while
+gating 2.12.0:
+
+    `alembic upgrade head` recovers an *ordinary* old file and can never
+    recover a *half-upgraded* one, because the tables the next revision
+    creates already exist.
+
+Measured before building this: a file at `e7f8a9b0c1d2` that a server touched
+gains three empty tables, keeps its revision, and then
+
+    alembic upgrade head
+    -> OperationalError: table vendor_credits already exists
+
+So the refusal was printing advice that fails for exactly the people who hit
+it — the same shape as #139's delete error saying "deactivate it instead"
+when nothing on the page could deactivate.
+"""
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _cfg(db):
+    from alembic.config import Config
+
+    cfg = Config(str(ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(ROOT / "migrations"))
+    cfg.attributes["database_url"] = "sqlite:///" + Path(db).as_posix()
+    return cfg
+
+
+def _head():
+    from alembic.script import ScriptDirectory
+
+    return ScriptDirectory.from_config(_cfg("/tmp/x.db")).get_current_head()
+
+
+def _half_upgraded(tmp_path, name="halfup.db", at="e7f8a9b0c1d2"):
+    """A file at an older revision that a server has started against — the
+    exact damage, produced the way it actually happens."""
+    from alembic import command
+
+    from app.database import Base
+    import app.models  # noqa: F401  — registers every table
+
+    db = tmp_path / name
+    command.upgrade(_cfg(db), at)
+    engine = create_engine(f"sqlite:///{db}")
+    before = set(inspect(engine).get_table_names())
+    Base.metadata.create_all(bind=engine)  # what a server start does
+    added = set(inspect(engine).get_table_names()) - before
+    engine.dispose()
+    assert added, "the fixture did not reproduce the damage"
+    return db, added
+
+
+def test_the_damage_really_blocks_an_ordinary_upgrade(tmp_path):
+    """The premise. If this ever stops being true the repair is unnecessary."""
+    from alembic import command
+
+    db, _ = _half_upgraded(tmp_path)
+    with pytest.raises(Exception) as e:
+        command.upgrade(_cfg(db), "head")
+    assert "already exists" in str(e.value)
+
+
+def test_repair_drops_the_empty_tables_and_reaches_head(tmp_path):
+    from app.services.schema_repair import repair
+
+    db, added = _half_upgraded(tmp_path)
+    result = repair(f"sqlite:///{db}")
+
+    assert result.ok, result.message
+    assert result.now_at == _head()
+    assert set(result.dropped) <= added
+    # And the file is genuinely usable afterwards, not merely stamped.
+    engine = create_engine(f"sqlite:///{db}")
+    tables = set(inspect(engine).get_table_names())
+    assert added <= tables, "the dropped tables were not recreated by the upgrade"
+    cols = {c["name"] for c in inspect(engine).get_columns("accounts")}
+    assert "bank_kind" in cols, "an ALTER that create_all could not do is still missing"
+    engine.dispose()
+
+
+def test_repair_refuses_to_drop_a_table_with_rows(tmp_path):
+    """The whole safety argument. `create_all()` only ever creates, so
+    anything it left behind is empty; a table with data in it was made by
+    something else and dropping it loses records."""
+    from app.services.schema_repair import repair
+
+    db, added = _half_upgraded(tmp_path)
+    # Pick the table the upgrade hits first and give it a row that satisfies
+    # its NOT NULL columns, so the refusal is about data rather than about a
+    # constraint.
+    victim = "vendor_credits"
+    assert victim in added
+    engine = create_engine(f"sqlite:///{db}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                'INSERT INTO "vendor_credits" '
+                "(credit_number, vendor_id, date) VALUES ('VC-X', 1, '2026-01-01')"
+            )
+        )
+    engine.dispose()
+
+    result = repair(f"sqlite:///{db}")
+    assert not result.ok
+    assert "row(s)" in result.message and victim in result.message
+    assert "needs a person" in result.message
+    # And it left the table alone.
+    engine = create_engine(f"sqlite:///{db}")
+    assert inspect(engine).has_table(victim)
+    engine.dispose()
+
+
+def test_repair_is_a_no_op_on_a_healthy_file(tmp_path):
+    from alembic import command
+
+    from app.services.schema_repair import repair
+
+    db = tmp_path / "healthy.db"
+    command.upgrade(_cfg(db), "head")
+    result = repair(f"sqlite:///{db}")
+    assert result.ok and result.dropped == []
+
+
+def test_repair_also_upgrades_an_ordinary_old_file(tmp_path):
+    """It replaces `alembic upgrade head` rather than sitting beside it, so an
+    operator does not have to work out which situation they are in."""
+    from alembic import command
+
+    from app.services.schema_repair import repair
+
+    db = tmp_path / "old.db"
+    command.upgrade(_cfg(db), "e7f8a9b0c1d2")
+    result = repair(f"sqlite:///{db}")
+    assert result.ok and result.now_at == _head() and result.dropped == []
+
+
+def test_dry_run_changes_nothing(tmp_path):
+    from app.services.schema_repair import repair
+
+    db, added = _half_upgraded(tmp_path)
+    before = _rev(db)
+    result = repair(f"sqlite:///{db}", dry_run=True)
+    assert "dry run" in result.message
+    assert _rev(db) == before
+    engine = create_engine(f"sqlite:///{db}")
+    assert added <= set(inspect(engine).get_table_names())
+    engine.dispose()
+
+
+def _rev(db):
+    engine = create_engine(f"sqlite:///{db}")
+    try:
+        with engine.connect() as conn:
+            return conn.execute(
+                text("SELECT version_num FROM alembic_version")
+            ).scalar()
+    finally:
+        engine.dispose()
+
+
+def test_the_startup_refusal_names_the_repair_for_a_half_upgraded_file(
+    tmp_path, monkeypatch
+):
+    """The message is the only way an operator finds out which situation they
+    are in, so it has to differ."""
+    import app.main as main
+
+    db, _ = _half_upgraded(tmp_path)
+    monkeypatch.setattr(main, "engine", create_engine(f"sqlite:///{db}"))
+    with pytest.raises(RuntimeError) as e:
+        main._refuse_a_database_behind_head()
+    assert "repair-schema.py" in str(e.value)
+    assert "will fail" in str(e.value)
+
+
+def test_the_startup_refusal_still_says_upgrade_for_an_ordinary_old_file(
+    tmp_path, monkeypatch
+):
+    from alembic import command
+
+    import app.main as main
+
+    db = tmp_path / "ordinary.db"
+    command.upgrade(_cfg(db), "e7f8a9b0c1d2")
+    monkeypatch.setattr(main, "engine", create_engine(f"sqlite:///{db}"))
+    with pytest.raises(RuntimeError) as e:
+        main._refuse_a_database_behind_head()
+    detail = str(e.value)
+    assert "alembic upgrade head" in detail
+    assert "repair-schema.py" not in detail

--- a/tests/test_startup_migration_guard.py
+++ b/tests/test_startup_migration_guard.py
@@ -1,0 +1,130 @@
+"""The app refuses to start against a database behind the migration head
+(issue #132).
+
+Found by the macOS QA agent while gating 2.11.0. `_create_missing_tables()`
+runs `create_all()` on every start. Point that at a database behind head and
+it half-upgrades it: tables the new revision ADDS are created, tables it
+ALTERS are untouched, and `alembic_version` does not move. Alembic can then
+never run on it again, because the upgrade tries to create tables that
+already exist.
+
+The agent's own company file ended up carrying three 2.11 tables, missing
+2.10's `accounts.bank_kind`, and still stamped at a 2.9-era revision. The
+app refused to start, and the start that failed was not the start that
+caused it.
+
+Neither shipped path reaches this — `desktop_launcher.py` migrates first and
+`docker-entrypoint.sh` runs `alembic upgrade head` at line 21 — but a
+self-managed deployment that sets DATABASE_URL and treats migrations as a
+separate operational step is on exactly that path.
+"""
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, text
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _cfg(db_path):
+    from alembic.config import Config
+
+    cfg = Config(str(ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(ROOT / "migrations"))
+    cfg.attributes["database_url"] = "sqlite:///" + Path(db_path).as_posix()
+    return cfg
+
+
+def _head():
+    from alembic.script import ScriptDirectory
+
+    return ScriptDirectory.from_config(_cfg("/tmp/unused.db")).get_current_head()
+
+
+def test_a_database_at_head_is_allowed(tmp_path, monkeypatch):
+    from alembic import command
+    import app.main as main
+
+    db = tmp_path / "at_head.db"
+    command.upgrade(_cfg(db), "head")
+
+    monkeypatch.setattr(main, "engine", create_engine(f"sqlite:///{db}"))
+    main._refuse_a_database_behind_head()  # must not raise
+
+
+def test_a_fresh_database_is_allowed(tmp_path, monkeypatch):
+    """No `alembic_version` at all means a NEW database — that is how a fresh
+    company file and a fresh Docker volume both start, and `create_all()` is
+    how they get built."""
+    import app.main as main
+
+    db = tmp_path / "fresh.db"
+    engine = create_engine(f"sqlite:///{db}")
+    with engine.connect() as conn:
+        conn.execute(text("SELECT 1"))
+
+    monkeypatch.setattr(main, "engine", engine)
+    main._refuse_a_database_behind_head()  # must not raise
+
+
+def test_a_database_behind_head_is_refused(tmp_path, monkeypatch):
+    """The case that matters. Before this, the app started and silently made
+    the database unmigratable."""
+    from alembic import command
+    import app.main as main
+
+    db = tmp_path / "behind.db"
+    command.upgrade(_cfg(db), "head")
+    # Wind the stamp back to something older without touching the schema —
+    # the same end state as a file that was created by an older build.
+    engine = create_engine(f"sqlite:///{db}")
+    with engine.begin() as conn:
+        conn.execute(text("UPDATE alembic_version SET version_num = 'd6e7f8a9b0c1'"))
+
+    monkeypatch.setattr(main, "engine", engine)
+    with pytest.raises(RuntimeError) as e:
+        main._refuse_a_database_behind_head()
+
+    detail = str(e.value)
+    assert "d6e7f8a9b0c1" in detail, "say which revision the database is at"
+    assert _head() in detail, "say which revision the build expects"
+    assert "alembic upgrade head" in detail, "say what to do about it"
+
+
+def test_an_unreadable_database_is_reported_not_silently_passed(
+    tmp_path, monkeypatch, caplog
+):
+    """The agent's own version of this guard had `except: return`, which let a
+    file through BY FAILING TO READ IT — it was mid-copy at the time. A guard
+    that cannot read the thing it guards must say so.
+
+    It still lets the start proceed: refusing here would turn a transient
+    database blip into a failure to boot, which is a worse trade than the
+    narrow window this guard covers.
+    """
+    import app.main as main
+
+    class _Exploding:
+        def connect(self, *a, **k):
+            raise OSError("disk went away")
+
+        dialect = None
+
+    monkeypatch.setattr(main, "engine", _Exploding())
+    with caplog.at_level("ERROR"):
+        main._refuse_a_database_behind_head()  # must not raise
+    assert any(
+        "alembic_version" in r.message for r in caplog.records
+    ), "the guard failed to read the database and said nothing"
+
+
+def test_the_shipped_entrypoints_migrate_before_serving():
+    """The reason this is a guard and not a fix: both shipped paths already
+    do the right thing, so the guard is for the deployment shapes we do not
+    control."""
+    launcher = (ROOT / "desktop_launcher.py").read_text(encoding="utf-8")
+    assert 'command.upgrade(cfg, "head")' in launcher
+
+    entry = (ROOT / "docker-entrypoint.sh").read_text(encoding="utf-8")
+    assert "alembic upgrade head" in entry

--- a/tests/test_template_secret_leak.py
+++ b/tests/test_template_secret_leak.py
@@ -1,0 +1,212 @@
+"""An editable email template cannot read a credential (GHSA-c3v4-f43f-4wqm).
+
+Reported privately under SECURITY.md. `get_all_settings()` decrypts on the
+way out, and the acknowledgment letter was rendered against the raw result —
+so a template containing `{{ company.smtp_password }}` rendered the live SMTP
+password, and `{{ company }}` dumped every credential at once, into an email
+addressed to whoever the sender chose.
+
+`GET /api/settings` redacts these keys for every role including admin, so the
+intent has always been that they do not leave the server. Jinja's
+`SandboxedEnvironment` is no help: `company` is a plain dict and reading a key
+from it is an ordinary permitted operation, not a sandbox escape.
+
+**It is privilege escalation.** A bookkeeper principal cannot write settings
+and gets the redacted read, but can edit a template and trigger a send — so a
+role specifically denied these values can mail them to an external address.
+
+**Widened by this release before it was caught.** Issue #140 made the
+`invoice_email` template actually render, having never been loaded by
+anything. That took the exposure from nonprofit installs sending
+acknowledgments to *every* install sending an invoice. These tests cover both
+paths, and the redaction is applied where each context is built rather than at
+the call sites.
+"""
+
+import pytest
+
+from app.models.email_templates import EmailTemplate
+from app.models.invoices import Invoice
+from app.services.settings_service import (
+    ENCRYPTED_SETTINGS_KEYS,
+    SECRET_PLACEHOLDER,
+    get_all_settings,
+    redact_secrets,
+    set_setting,
+)
+
+CANARIES = {
+    "smtp_password": "hunter2-CANARY",
+    "stripe_secret_key": "sk_live_CANARY",
+    "qbo_refresh_token": "qbo-CANARY",
+    "simplefin_access_url": "https://CANARY@simplefin.example/x",
+}
+
+
+@pytest.fixture
+def secrets(db_session):
+    for k, v in CANARIES.items():
+        set_setting(db_session, k, v)
+    db_session.commit()
+    return CANARIES
+
+
+def _set_template(db_session, name, body):
+    tpl = db_session.query(EmailTemplate).filter(EmailTemplate.name == name).first()
+    if tpl is None:
+        tpl = EmailTemplate(
+            name=name, template_type="invoice", subject_template="x", body_template=body
+        )
+        db_session.add(tpl)
+    else:
+        tpl.body_template = body
+    db_session.commit()
+
+
+def test_redact_secrets_covers_every_encrypted_key():
+    """The list is the one beside the encryption, so a credential added later
+    is redacted by the same act that encrypts it."""
+    raw = {k: "live-value" for k in ENCRYPTED_SETTINGS_KEYS}
+    raw["company_name"] = "Acme"
+    out = redact_secrets(raw)
+    for k in ENCRYPTED_SETTINGS_KEYS:
+        assert out[k] == SECRET_PLACEHOLDER, f"{k} was not redacted"
+    assert out["company_name"] == "Acme", "ordinary settings must survive"
+
+
+def test_an_empty_secret_stays_empty():
+    """The UI tells an unconfigured value from a set one by whether it is
+    blank; redacting an empty string would make everything look configured."""
+    assert redact_secrets({"smtp_password": ""})["smtp_password"] == ""
+
+
+def test_the_invoice_template_cannot_read_a_secret(
+    client, db_session, seed_accounts, secrets
+):
+    """The path this release created. Without the fix this renders the live
+    SMTP password into an email a customer receives."""
+    from app.services.email_service import render_invoice_email_parts
+
+    client.post("/api/email-templates/seed-defaults")
+    _set_template(
+        db_session,
+        "invoice_email",
+        "<p>{{ company.smtp_password }}|{{ company.stripe_secret_key }}</p>",
+    )
+
+    cust = client.post("/api/customers", json={"name": "P", "email": "a@b.com"}).json()
+    iid = client.post(
+        "/api/invoices",
+        json={
+            "customer_id": cust["id"],
+            "date": "2026-06-01",
+            "due_date": "2026-06-30",
+            "lines": [
+                {"description": "w", "quantity": 1, "rate": 100, "line_order": 0}
+            ],
+        },
+    ).json()["id"]
+    inv = db_session.query(Invoice).filter(Invoice.id == iid).first()
+
+    _, body = render_invoice_email_parts(
+        inv, get_all_settings(db_session), db=db_session
+    )
+    for value in secrets.values():
+        assert value not in body, f"{value!r} reached the email body"
+    assert SECRET_PLACEHOLDER in body
+
+
+def test_dumping_the_whole_settings_dict_leaks_nothing(
+    client, db_session, seed_accounts, secrets
+):
+    """`{{ company }}` was the worst case — every credential at once."""
+    from app.services.email_service import render_invoice_email_parts
+
+    client.post("/api/email-templates/seed-defaults")
+    _set_template(db_session, "invoice_email", "<p>{{ company }}</p>")
+
+    cust = client.post("/api/customers", json={"name": "P", "email": "a@b.com"}).json()
+    iid = client.post(
+        "/api/invoices",
+        json={
+            "customer_id": cust["id"],
+            "date": "2026-06-01",
+            "due_date": "2026-06-30",
+            "lines": [
+                {"description": "w", "quantity": 1, "rate": 100, "line_order": 0}
+            ],
+        },
+    ).json()["id"]
+    inv = db_session.query(Invoice).filter(Invoice.id == iid).first()
+
+    _, body = render_invoice_email_parts(
+        inv, get_all_settings(db_session), db=db_session
+    )
+    for value in secrets.values():
+        assert value not in body, f"{value!r} reached the email body"
+
+
+def test_the_redaction_matches_what_the_settings_api_shows(
+    client, db_session, seed_accounts, secrets
+):
+    """The control this worked around. Both sides read one list now — this
+    file used to carry a second frozenset identical to the first, which
+    happened to agree and would not have said so if it stopped."""
+    shown = client.get("/api/settings").json()
+    redacted = redact_secrets(get_all_settings(db_session))
+    for k in CANARIES:
+        assert shown.get(k) == SECRET_PLACEHOLDER
+        assert redacted[k] == SECRET_PLACEHOLDER
+
+
+def test_the_two_secret_lists_are_one_object():
+    """A credential added to one list and not the other would be encrypted at
+    rest and rendered in plaintext by a template."""
+    from app.routes import settings as settings_routes
+
+    assert settings_routes.SECRET_KEYS is ENCRYPTED_SETTINGS_KEYS
+
+
+def test_the_acknowledgment_template_cannot_read_a_secret(
+    client, db_session, seed_accounts, secrets
+):
+    """The vector as originally reported — the donor acknowledgment letter.
+
+    This one had been live since v2.9.0, on nonprofit installs. The invoice
+    path above is the same hole widened to every install; both are closed at
+    the point their context is built, which is why a third renderer added
+    later inherits the fix rather than repeating the bug.
+    """
+    from app.services.donor_documents import ACK_TEMPLATE_NAME, render_acknowledgment
+
+    _set_template(
+        db_session,
+        ACK_TEMPLATE_NAME,
+        "<p>{{ company.smtp_password }}|{{ company.qbo_refresh_token }}|{{ company }}</p>",
+    )
+    cust = client.post(
+        "/api/customers", json={"name": "Donor", "email": "d@e.com"}
+    ).json()
+    from app.models.contacts import Customer
+
+    customer = db_session.query(Customer).filter(Customer.id == cust["id"]).first()
+
+    from datetime import date as _date
+
+    gift = {
+        "id": 1,
+        "number": "G-1",
+        "date": _date(2026, 6, 1),
+        "amount": 100,
+        "description": "",
+        "fair_value_amount": None,
+        "fair_value_description": None,
+        "in_kind_lines": [],
+        "customer_id": customer.id,
+    }
+    subject, body = render_acknowledgment(
+        db_session, get_all_settings(db_session), customer, gift
+    )
+    for value in secrets.values():
+        assert value not in body, f"{value!r} reached the acknowledgment body"
+        assert value not in subject, f"{value!r} reached the acknowledgment subject"


### PR DESCRIPTION
Two reader-reported defects, one of which has been breaking a button on every install.

## #139 — a new company's 57 accounts could not be removed or hidden

@tresero, arriving from hledger with a chart of his own. He called it a showstopper and he is describing it accurately.

- **Delete** refused every seeded account. All 57 carry `is_system`, and the rule rejected anything with that flag — permanently, even on a company with no transactions in it.
- **Deactivate** was not on the page at all. The account form offers number, name, type, description. Nothing else. No control in the interface calls the delete endpoint either.
- Our own delete error says *"Deactivate it instead"*, which the interface could not do.

So the only thing an operator could do to our chart was rename it. And note that the CSV import he asked for would not have helped on its own: loading his twenty accounts into an existing company gives him seventy-seven, not twenty.

**This is the same wrong flag 2.10.2 found hiding the Edit button, in a second place.** The gate is `control_accounts` now: fifteen numbers the posting code resolves literally, where a document that cannot find one is #119. Those rename and deactivate, never delete. The other forty-two go when asked.

Deleting now **names what is in the way** — the count and the table — rather than "referenced by other records". That scan walks `Base.metadata` instead of a hand-kept list, because thirty-five columns across seventeen models reference `accounts.id` and vendor credits added one this week. A hand list would be wrong within a release, and the symptom of it being wrong is a foreign-key violation arriving as a 500.

The page gains Deactivate, Reactivate, Delete and a **show-inactive** toggle — hiding something with no way back to it is a trap. Delete is not rendered on a control account at all, rather than rendered and then refused.

## #140 — Email Invoice has never worked from the interface

@mdornich. Worse than the title suggests, and measured:

```
dialog payload    -> HTTP 422  extra_forbidden on 'message'
without 'message' -> HTTP 502  (reaches the send; SMTP unconfigured here)
```

The dialog posts `message`. The route is a `StrictModel` taking `recipient` and `subject`. **So every send from the interface failed validation before reaching any sending code.** The Message box did not merely get ignored — it broke the button it sat on.

Nothing caught it because every test called that endpoint with a payload the endpoint accepts, rather than the payload the page sends. That is the shape of 2.10.3's unreachable attachment route. There is now a tripwire that reads the fields out of `invoices.js` and out of `_EmailInvoiceRequest` and fails if they drift apart again.

The message is threaded through both bodies the renderer can produce, and escaped on each, since it is operator text landing in an HTML email.

**The rest of #140 is @mdornich's branch to open** — the saved template being ignored, and template selection keyed off a document label, which he correctly notes hits ordinary businesses through sales receipts and not just nonprofit installs. That is the better fix and it should carry his name. Invited on the issue.

## Also open, not here

**#141**, a macOS HarfBuzz collision on locally built bundles, also @mdornich. Testing-repo issue #47 asks our M1 agent whether it reaches the **signed CI artifact** or only local builds — that answer decides what it is. Whatever the fix, it goes in the spec file rather than a repair script, because we are not maintaining two build paths for macOS.

## State

- Suite **2108 passed / 0 failed**, 2 skipped (two control accounts created on demand, not seeded)
- `black` and `ruff` clean at CI scope
- **No schema change** — `f8a9b0c1d2e3` stays head, so an existing company opens with no upgrade step
- Version 2.11.2. Patch rather than minor on the 2.10.2 precedent: the same wrong-flag class shipped as a patch there

**Not merging until the three-platform gate passes and Trent says so.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DaDm82ccTQi7awPEQrrW3