### PR TITLE
docs: park the design notes on main and retire their branches

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,17 @@
+# Design notes
+
+Thinking that has not been built, kept where it can be found.
+
+**Nothing in this directory is committed product behaviour.** Each file says
+its own status at the top. They are here rather than on long-lived branches
+because a branch holding one markdown file is a bad container for an idea: it
+falls behind, nobody browses it, and the only way to read it is to know it
+exists.
+
+| File | Status |
+|---|---|
+| [accountant-sharing.md](accountant-sharing.md) | DESIGN — two candidate architectures, neither chosen (2026-08-13) |
+| [canada.md](canada.md) | PARKED — scoped, sized, deliberately not started (2026-09-03) |
+
+A parked design is not a backlog item. If one of these gets built it will be
+because someone asked for it, not because it was written down.

--- a/docs/design/accountant-sharing.md
+++ b/docs/design/accountant-sharing.md
@@ -1,0 +1,29 @@
+# Accountant File Sharing — design notes (brainstorm, 2026-08-13)
+
+Status: DESIGN. Two candidate architectures, not yet chosen.
+
+## Option A — gated single-use drop-box
+
+Client-side Fernet-encrypted export; outbound-only POST to a Cloudflare
+Worker (same self-hosted pattern as the AI gateway) holding the
+encrypted blob with a TTL; PIN delivered out-of-band; the worker never
+sees plaintext. Self-destructing link closes the standing-exposure
+problem entirely.
+
+## Option B — scheduled email (the simple pivot)
+
+Clone `run_recurring.py`'s scheduling pattern exactly; use
+`email_service.send_email()` (already supports attachments) with the
+existing IIF/PDF export functions. Pure wiring, no new infrastructure.
+
+Tradeoff (flagged, unresolved): an email attachment is a standing
+exposure — it lives in two inboxes indefinitely — vs. Option A's TTL'd
+self-destructing link. A password-protected zip + out-of-band PIN
+closes most of the gap cheaply if Option B wins.
+
+## Prerequisite — ALREADY SHIPPED
+
+The smtp_password at-rest encryption gap identified during this
+brainstorm was fixed independently and released in v2.5.2
+(ENCRYPTED_SETTINGS_KEYS in settings_service). The pipe that would
+carry monthly financial statements is already sealed.

--- a/docs/design/canada.md
+++ b/docs/design/canada.md
@@ -1,0 +1,66 @@
+# Canadian support — design notes (PARKED)
+
+Status: PARKED 2026-09-03. Trent asked for the full set (sales tax, payroll,
+filings, conversion), heard the sizing, and parked it so the v2.8 stage stays
+shippable. Nothing here is committed product behavior.
+
+## The requirement
+
+Seamless: a Canadian company must feel exactly like a US one does today. One
+codebase, no forks, no per-dollar branching. Country is chosen once, at company
+creation, and locked.
+
+## Where Canada actually differs (the four seams)
+
+1. **Tax on a line.** Today a document carries one tax rate and one payable
+   account. Canada needs a **tax code with components** — GST + PST, HST alone,
+   GST + QST — each to its own account, and tax paid on purchases is
+   **recoverable** (input tax credits), so the return nets collected against
+   paid. This ripples through every tax-bearing form and PDF (invoice, bill,
+   expense, sales receipt, credit memo, PO). It is also a straight improvement
+   for US users (state + county + city rates), so **build it first as a general
+   feature** and lap it on US books before Canada leans on it.
+2. **Payroll calculation.** CPP (basic exemption, YMPE, second ceiling / CPP2),
+   EI (employee rate, employer × 1.4), federal + provincial withholding via the
+   CRA T4127 formulas. A second engine beside the US one, selected by country;
+   same pay-run flow. Testable against the CRA's PDOC calculator. Largest single
+   piece — on the order of the whole US payroll module — and a standing
+   January/July table-update commitment.
+3. **Filings.** GST/HST return (GST34 lines), PD7A remittance, T4 slips + T4
+   Summary (CRA XML), Record of Employment (ROE Web XML is fussy — its own
+   medium piece).
+4. **Words and seeds.** Province/state, postal code/ZIP, BN/EIN, SIN/SSN, CAD as
+   home currency, a Canadian chart of accounts seeded at creation. A label
+   dictionary and a second seed file.
+
+## The switch
+
+`company.country` (US | CA), set at company creation, immutable. It picks the
+chart seed, the tax-code set, the payroll engine, the filing set and the label
+dictionary. Nothing else asks. US companies see exactly what they see today.
+
+## Sizing (against work already shipped)
+
+| Piece | Size |
+|---|---|
+| Tax codes w/ recoverable components + GST return | ≈ jobs M1 + M2 together |
+| Canadian payroll engine | ≈ the US payroll module (biggest piece) |
+| T4 / T4 Summary / PD7A | ≈ jobs M3 |
+| ROE | medium, fussy XML |
+| QuickBooks Canada conversion (tax-code mapping) | small |
+
+Whole thing ≈ two v2.7-sized stages; payroll is more than half.
+
+## Conditions before unparking
+
+- The general tax-code engine has shipped and been lapped on US books.
+- A Canadian bookkeeper is lined up to lap payroll against a real remittance
+  (the CRA calculator proves the math, not the workflow).
+- Someone owns the twice-yearly table updates.
+
+## Open questions
+
+- Home currency: is CAD-as-home a settings flip today, or does multi-currency
+  assume USD home? Check `settings` / `exchange_rate` handling before scoping.
+- Quebec: QPP instead of CPP, QPIP, RL-1 slips — decide whether Quebec is in
+  the first cut or explicitly not.


### PR DESCRIPTION
`feat/accountant-sharing` and `feat/canada` each held **exactly one markdown file** and were **246** and **127** commits behind `main`.

A branch holding a single document is a bad container for an idea. It falls behind, nobody browses it, and reading it requires already knowing it exists — which is the opposite of what writing something down is for.

Both documents already state their own status at the top: accountant sharing is DESIGN with two candidate architectures and neither chosen; Canada is PARKED, with the sizing that led to parking it. `docs/design/README.md` says plainly that nothing in the directory is committed product behaviour, so moving them onto `main` cannot be misread as a decision to build either.

No code, no behaviour change.

**The two branches are deleted with this.** `parked/bofa-detail-csv` stays — it carries a contributor's commit and is waiting on a real bank export, which is an active state rather than an abandoned one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DaDm82ccTQi7awPEQrrW3