### PR TITLE
Send invoice emails using the saved invoice_email template (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,26 @@ email. The rest of @mdornich's report — the saved template being ignored,
 and template selection keyed off a document label — is his branch to open,
 and it is the better fix.
 
+**The invoice email template you saved is the one that gets sent.** Editing
+`invoice_email` under Settings -> Email Templates had no effect on the email
+a customer received: `/invoices/{id}/email` rendered a hardcoded body and
+never read the template. The send dialog also posted a `message` field the
+route did not accept, so the request failed validation before it got that
+far.
+
+Both the send dialog and the template editor now render through the same
+code path, so a preview is exactly what will be sent. The editor previews
+unsaved edits against a real invoice without emailing anyone or touching
+accounting records, and a template with a syntax error is rejected when you
+save it rather than failing silently at send time.
+
+Sales receipts, donation receipts and pledges use their saved template too —
+the document's label no longer decides whether your template is honored.
+
+Templates render against a redacted view of your settings, so the values the
+Settings page shows as `********` — SMTP password, payment provider keys — stay
+redacted there too. Non-secret company fields are unchanged.
+
 ### v2.11.1 — Wave imports work, and you can copy an API token
 
 Both fixes in this release came from @rchanks, and both were found the way

--- a/app/routes/email_templates.py
+++ b/app/routes/email_templates.py
@@ -85,6 +85,32 @@ def get_template(template_id: int, db: Session = Depends(get_db)):
     return template
 
 
+def _validate_template_fields(data):
+    """Reject unparseable template text at save time.
+
+    Without this a typo like "{% if %}" saves fine and only surfaces later
+    as a failed send, with the invoice already marked sent. Compile-only —
+    rendering (and the sandbox check that comes with it) happens on
+    preview and send.
+    """
+    from jinja2 import TemplateSyntaxError
+
+    from app.services.email_service import template_env
+
+    env = template_env(autoescape=True)
+    for name in ("subject_template", "body_template"):
+        value = getattr(data, name, None)
+        if value is None:
+            continue
+        try:
+            env.from_string(value)
+        except TemplateSyntaxError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid {name} syntax on line {exc.lineno}.",
+            ) from exc
+
+
 @router.post("", response_model=EmailTemplateResponse, status_code=201)
 def create_template(data: EmailTemplateCreate, db: Session = Depends(get_db)):
     existing = db.query(EmailTemplate).filter(EmailTemplate.name == data.name).first()
@@ -92,6 +118,7 @@ def create_template(data: EmailTemplateCreate, db: Session = Depends(get_db)):
         raise HTTPException(
             status_code=400, detail="Template with this name already exists"
         )
+    _validate_template_fields(data)
     template = EmailTemplate(**data.model_dump())
     db.add(template)
     db.commit()
@@ -106,6 +133,7 @@ def update_template(
     template = db.query(EmailTemplate).filter(EmailTemplate.id == template_id).first()
     if not template:
         raise HTTPException(status_code=404, detail="Template not found")
+    _validate_template_fields(data)
     for key, val in data.model_dump(exclude_unset=True).items():
         setattr(template, key, val)
     db.commit()

--- a/app/routes/invoices/documents.py
+++ b/app/routes/invoices/documents.py
@@ -1,6 +1,7 @@
 from typing import Optional as _Optional
 
 from fastapi import Depends, HTTPException, Request
+from pydantic import Field as _Field
 from fastapi.responses import Response
 from app.schemas.common import StrictModel
 from sqlalchemy.orm import Session
@@ -22,7 +23,9 @@ class _EmailInvoiceRequest(StrictModel):
     # is a StrictModel — so every send from the interface was rejected 422
     # before it reached any of the code below. The box was not merely
     # ignored; it broke the button it sat on (issue #140, mdornich).
-    message: _Optional[str] = None
+    # Bounded because it becomes an email body: unbounded operator text is
+    # an unbounded SMTP send.
+    message: _Optional[str] = _Field(None, max_length=5000)
 
 
 @router.get("/{invoice_id}/pdf")
@@ -78,6 +81,69 @@ def invoice_print_preview(invoice_id: int, db: Session = Depends(get_db)):
     return HTMLResponse(content=html_str)
 
 
+class _EmailPreviewRequest(StrictModel):
+    subject_template: _Optional[str] = None
+    body_template: _Optional[str] = None
+
+
+def _invoice_pay_url(db: Session, inv, request: Request) -> _Optional[str]:
+    """Public pay link, or None when no payment provider is enabled."""
+    from app.services.payments import enabled_providers
+
+    if inv.payment_token and enabled_providers(db):
+        return f"{str(request.base_url).rstrip('/')}/pay/{inv.payment_token}"
+    return None
+
+
+@router.post("/{invoice_id}/email-preview")
+def preview_invoice_email(
+    invoice_id: int,
+    data: _EmailPreviewRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    """Render saved or unsaved template text without emailing or posting.
+
+    The template editor sends its unsaved textareas here, so "Preview" can
+    show an edit before it is saved. Read-only: no EmailLog row, no
+    transaction, no change to the invoice.
+    """
+    from app.services.email_service import render_invoice_message
+
+    inv = db.query(Invoice).filter(Invoice.id == invoice_id).first()
+    if not inv:
+        raise HTTPException(status_code=404, detail="Invoice not found")
+    overrides = data.model_dump(exclude_unset=True) or None
+    try:
+        subject, body = render_invoice_message(
+            db,
+            inv,
+            get_settings(db),
+            _invoice_pay_url(db, inv, request),
+            overrides,
+        )
+    except Exception as exc:
+        # Deliberately broad. Everything inside the try is rendering text the
+        # client supplied, and Jinja is only one of the things that can raise:
+        # a syntax error and a sandbox escape are TemplateError, but
+        # "{{ 1/0 }}" is ZeroDivisionError and a huge range() is OverflowError.
+        # All of them are bad input, so all of them are a 400, and the message
+        # stays generic because the text came from the client.
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Template could not be rendered. Check the template "
+                "variables and syntax."
+            ),
+        ) from exc
+    return {
+        "subject": subject,
+        "html_body": body,
+        "pdf_url": f"/api/invoices/{inv.id}/pdf",
+        "recipient": inv.customer.email if inv.customer else "",
+    }
+
+
 @router.post("/{invoice_id}/email")
 def email_invoice(
     invoice_id: int,
@@ -92,27 +158,25 @@ def email_invoice(
     company = get_settings(db)
     from app.services.email_service import invoice_email_label
 
+    # Provisional subject for the failure path below: if rendering itself
+    # raises, the EmailLog row still needs a subject, and it should say
+    # "Donation Receipt #12" for a nonprofit, not "Invoice #12".
     subject = (
         data.subject or f"{invoice_email_label(inv, company)} #{inv.invoice_number}"
     )
+
     try:
-        from app.services.email_service import send_email, render_invoice_email
+        from app.services.email_service import send_email, render_invoice_message
         from app.models.email_log import EmailLog
 
         pdf_bytes = generate_invoice_pdf(inv, company)
 
-        # Build pay URL if any payment provider is enabled and the invoice
-        # has a payment token
-        from app.services.payments import enabled_providers
-
-        pay_url = None
-        if inv.payment_token and enabled_providers(db):
-            base_url = str(request.base_url).rstrip("/")
-            pay_url = f"{base_url}/pay/{inv.payment_token}"
-
-        html_body = render_invoice_email(
-            inv, company, pay_url=pay_url, note=data.message
+        rendered_subject, html_body = render_invoice_message(
+            db, inv, company, _invoice_pay_url(db, inv, request), note=data.message
         )
+        # `or`, not `is not None`: the Subject field is user-clearable, and
+        # an empty string must fall back rather than mail a blank header.
+        subject = data.subject or rendered_subject
         # send_email() writes its own EmailLog row on every path (sent,
         # failed, and SMTP-not-configured), so the route must not log again
         # or every send produces two rows.

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -10,6 +10,7 @@ from email.mime.application import MIMEApplication
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
+from jinja2.sandbox import SandboxedEnvironment
 from sqlalchemy.orm import Session
 
 from app.models.email_log import EmailLog
@@ -131,10 +132,24 @@ def send_email(
         return False
 
 
+def template_env(autoescape: bool) -> SandboxedEnvironment:
+    """Sandboxed Jinja environment with the shared currency/date filters.
+
+    Sandboxed because template text is user-editable under Settings ->
+    Email Templates: a template must not be able to walk back into Python
+    objects through attribute access (``{{ invoice.__class__ }}``).
+    """
+    from app.services.pdf_service import _format_currency, _format_date
+
+    env = SandboxedEnvironment(autoescape=autoescape)
+    env.filters["currency"] = _format_currency
+    env.filters["fdate"] = _format_date
+    return env
+
+
 def render_template_from_db(db: Session, template_name: str, context: dict) -> tuple:
     """Load template from DB, render with Jinja2 SandboxedEnvironment, fall back to file."""
     from app.models.email_templates import EmailTemplate
-    from jinja2.sandbox import SandboxedEnvironment
 
     tpl = db.query(EmailTemplate).filter(EmailTemplate.name == template_name).first()
     if tpl:
@@ -142,11 +157,7 @@ def render_template_from_db(db: Session, template_name: str, context: dict) -> t
         # text injected via {{ }} can't break out of HTML context. Same
         # rule WC3D applied to the file-loader Environment in commit
         # ca6182f — keep both paths consistent.
-        env = SandboxedEnvironment(autoescape=True)
-        from app.services.pdf_service import _format_currency, _format_date
-
-        env.filters["currency"] = _format_currency
-        env.filters["fdate"] = _format_date
+        env = template_env(autoescape=True)
         subject = env.from_string(tpl.subject_template).render(**context)
         body = env.from_string(tpl.body_template).render(**context)
         return subject, body
@@ -205,15 +216,11 @@ def render_invoice_email(
         )
         company_name = _html.escape(company_settings.get("company_name", "Our Company"))
         invoice_number = _html.escape(str(invoice.invoice_number))
-        # The operator's own message has to survive this path too, or it
-        # vanishes exactly when the template is missing.
-        opening = (
-            f"<p>{_html.escape(note.strip())}</p>"
-            if note and note.strip()
-            else (
-                f"<p>Please find attached {doc_label} #{invoice_number} "
-                f"for ${float(invoice.total):,.2f}.</p>"
-            )
+        # The operator's message is a paragraph above the body, never a
+        # replacement for part of it, so the standard opening stays.
+        opening = _note_html(note) + (
+            f"<p>Please find attached {doc_label} #{invoice_number} "
+            f"for ${float(invoice.total):,.2f}.</p>"
         )
         return f"""<html><body>
         <p>Dear {customer_name},</p>
@@ -222,3 +229,114 @@ def render_invoice_email(
         <p>{'Thank you for your support.' if terms_for(company_settings).is_nonprofit else 'Thank you for your business.'}</p>
         <p>{company_name}</p>
         </body></html>"""
+
+
+def _note_html(note: str) -> str:
+    """The operator's message as one escaped paragraph, or "" if there isn't one.
+
+    Escaped here rather than by Jinja because this is concatenated onto an
+    already-rendered body — which also means a note containing {{ }} or
+    {% %} is inert rather than a second pass of template syntax. Line
+    breaks are kept: the dialog offers a three-row textarea, and an
+    operator who presses return means it.
+    """
+    import html as _html
+
+    if not note or not note.strip():
+        return ""
+    return "<p>" + _html.escape(note.strip()).replace("\n", "<br>") + "</p>"
+
+
+def _insert_note(body: str, note_html: str) -> str:
+    """Put the note above the body, staying inside <body> when there is one.
+
+    A saved template can be a whole document pasted from a designer. Text
+    placed before <html> is dropped by the sanitisers in Gmail and Outlook,
+    which would lose the operator's message silently — the defect this is
+    supposed to prevent.
+    """
+    import re as _re
+
+    if not note_html:
+        return body
+    match = _re.search(r"<body[^>]*>", body, _re.I)
+    if match:
+        return body[: match.end()] + note_html + body[match.end() :]
+    return note_html + body
+
+
+def render_invoice_message(
+    db: Session,
+    invoice,
+    company: dict,
+    pay_url: str = None,
+    overrides: dict = None,
+    note: str = None,
+) -> tuple:
+    """Subject + HTML body for an invoice email, shared by preview and send.
+
+    A saved ``invoice_email`` template wins when one exists; ``overrides``
+    carries unsaved editor text so the template editor can preview an edit
+    before it is saved. With neither, fall back to the built-in
+    ``invoice_email.html`` body so an install that never touched the
+    template keeps the email it has today.
+
+    ``note`` is the operator's per-send message from the Email Invoice
+    dialog. It is rendered as an escaped paragraph immediately above the
+    body (inside ``<body>`` when the template is a whole document) and is
+    deliberately *not* a template variable: a ``{{ note }}`` that a saved
+    template can omit would drop the operator's message silently, which is
+    the defect this endpoint exists to fix.
+
+    On this path the note lands above whatever the template begins with,
+    including a salutation — unlike the built-in body, where it sits below
+    the greeting. Raised on #140.
+    """
+    from app.models.email_templates import EmailTemplate
+    from app.services.settings_service import redact_secrets
+    from app.services.terminology import terms_for
+
+    label = invoice_email_label(invoice, company)
+    template = (
+        db.query(EmailTemplate).filter(EmailTemplate.name == "invoice_email").first()
+    )
+    if template is None and overrides is None:
+        return (
+            f"{label} #{invoice.invoice_number}",
+            render_invoice_email(invoice, company, pay_url, note=note),
+        )
+
+    subject = f"{label} #{invoice.invoice_number}"
+    body = ""
+    if template is not None:
+        subject = template.subject_template
+        body = template.body_template
+    if overrides is not None:
+        subject = overrides.get("subject_template", subject)
+        body = overrides.get("body_template", body)
+
+    context = {
+        "invoice": invoice,
+        "inv": invoice,
+        # Redacted: get_all_settings() decrypts smtp_password, the Stripe
+        # secret key and the rest, and this template is user-editable, so
+        # the raw dict here would let anyone who can edit a template mail
+        # themselves the credentials.
+        "company": redact_secrets(company),
+        "pay_url": pay_url,
+        # Same name the file template uses, so a nonprofit can write
+        # "{{ doc_label }}" instead of hardcoding the word Invoice.
+        "doc_label": label,
+        "customer_name": (
+            invoice.customer.name
+            if invoice.customer
+            else terms_for(company)("Customer")
+        ),
+    }
+    # The subject is a mail header, not HTML. Escaping it would put a
+    # literal "&amp;" in the inbox for a customer named "Smith & Sons";
+    # header sanitisation stays in send_email().
+    rendered_subject = template_env(autoescape=False).from_string(subject)
+    rendered_body = template_env(autoescape=True).from_string(body)
+    html = _insert_note(rendered_body.render(**context), _note_html(note))
+    return rendered_subject.render(**context), html

--- a/app/services/settings_service.py
+++ b/app/services/settings_service.py
@@ -39,6 +39,24 @@ ENCRYPTED_SETTINGS_KEYS = frozenset(
 )
 
 
+SECRET_PLACEHOLDER = "********"
+
+
+def redact_secrets(settings: dict) -> dict:
+    """Copy of `settings` with every encrypted value replaced by a placeholder.
+
+    get_all_settings() decrypts secrets because the server needs the real
+    values to send mail and call payment providers. Anywhere that dict can
+    reach a user — an API response, or a user-authored Jinja template —
+    has to go through this first. Keyed off ENCRYPTED_SETTINGS_KEYS so a
+    newly added credential is redacted by the same act that encrypts it.
+    """
+    return {
+        key: (SECRET_PLACEHOLDER if key in ENCRYPTED_SETTINGS_KEYS and value else value)
+        for key, value in settings.items()
+    }
+
+
 def _maybe_decrypt(key: str, value):
     if key in ENCRYPTED_SETTINGS_KEYS and value:
         return decrypt_value(value)

--- a/app/static/js/invoices.js
+++ b/app/static/js/invoices.js
@@ -6,7 +6,6 @@
 const InvoicesPage = {
     // The document's literal face, as the PDF prints it: a flagged pledge is a
     // PLEDGE, everything else an INVOICE regardless of company vocabulary.
-    docLabel(inv) { return inv.is_pledge ? 'Pledge' : 'Invoice'; }, // literal face
 
     async render() {
         // Sales receipts are invoices under the hood; they get their own
@@ -177,23 +176,29 @@ const InvoicesPage = {
     },
 
     async emailInvoice(id) {
-        const inv = await API.get(`/invoices/${id}`);
-        const email = inv.customer_email || '';
-        openModal(Terms.text('Email Invoice'), `
-            <form onsubmit="InvoicesPage.sendEmail(event, ${id})">
-                <div class="form-grid">
-                    <div class="form-group full-width"><label>Recipient Email *</label>
-                        <input name="recipient" type="email" required value="${escapeHtml(email)}"></div>
-                    <div class="form-group full-width"><label>Subject</label>
-                        <input name="subject" value="${InvoicesPage.docLabel(inv)} #${escapeHtml(inv.invoice_number)} from ${escapeHtml(inv.customer_name || 'us')}"></div>
-                    <div class="form-group full-width"><label>Message</label>
-                        <textarea name="message">Please find attached Invoice #${escapeHtml(inv.invoice_number)}.</textarea></div>
-                </div>
-                <div class="form-actions">
-                    <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
-                    <button type="submit" class="btn btn-primary">Send Email</button>
-                </div>
-            </form>`);
+        try {
+            const preview = await API.post(`/invoices/${id}/email-preview`, {});
+            openModal(Terms.text('Email Invoice'), `
+                <form onsubmit="InvoicesPage.sendEmail(event, ${id})">
+                    <div class="form-grid">
+                        <div class="form-group full-width"><label>Recipient Email *</label>
+                            <input name="recipient" type="email" required value="${escapeHtml(preview.recipient || '')}"></div>
+                        <div class="form-group full-width"><label>Subject</label>
+                            <input name="subject" value="${escapeHtml(preview.subject)}"></div>
+                    </div>
+                    <div class="form-group full-width"><label>${Terms.text('Message (optional)')}</label>
+                        <textarea name="message" rows="3" placeholder="${Terms.text('Added as the first paragraph of the email.')}"></textarea></div>
+                    <p>${Terms.text('Below is your saved invoice email template, which follows the message above.')}</p>
+                    <iframe id="invoice-email-preview" sandbox="" title="${T('Invoice')} email preview" style="width:100%;height:330px;border:1px solid #ddd;background:white;"></iframe>
+                    <p><a href="${escapeHtml(preview.pdf_url)}" target="_blank" rel="noopener">${Terms.text('Preview attached invoice PDF')}</a></p>
+                    <div class="form-actions">
+                        <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
+                        <button type="submit" class="btn btn-primary">Send Email</button>
+                    </div>
+                </form>`);
+            const frame = $('#invoice-email-preview');
+            if (frame) frame.srcdoc = preview.html_body;
+        } catch (err) { toast(`Could not build the email preview: ${err.message}`, 'error'); }
     },
 
     async sendEmail(e, id) {

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -759,9 +759,17 @@ const SettingsPage = {
     },
 
     async editTemplate(id) {
-        const t = await API.get(`/email-templates/${id}`);
+        let t, invoiceRows;
+        try {
+            t = await API.get(`/email-templates/${id}`);
+            // Just enough to pick a representative invoice to preview against;
+            // the endpoint would otherwise return up to 500 with their lines.
+            invoiceRows = t.template_type === 'invoice'
+                ? await API.get('/invoices?is_sales_receipt=false&limit=50')
+                : [];
+        } catch (err) { toast(err.message, 'error'); return; }
         openModal('Edit Email Template', `
-            <form onsubmit="SettingsPage.saveTemplate(event, ${id})">
+            <form id="email-template-editor" onsubmit="SettingsPage.saveTemplate(event, ${id})">
                 <div class="form-grid">
                     <div class="form-group"><label>Name</label>
                         <input name="name" value="${escapeHtml(t.name)}" readonly style="background:var(--gray-100);"></div>
@@ -776,11 +784,36 @@ const SettingsPage = {
                     Variables: {{ invoice.invoice_number }}, {{ invoice.total }}, {{ invoice.due_date }}, {{ customer_name }},
                     {{ company.company_name }}, {{ pay_url }}, {{ amount }}. Filters: | currency, | fdate
                 </div>
+                ${t.template_type === 'invoice' ? `<div style="margin-top:16px;">
+                    <label>${Terms.text('Preview with invoice')} <select id="email-template-invoice">${invoiceRows.map(inv => `<option value="${inv.id}">#${escapeHtml(inv.invoice_number)} — ${escapeHtml(inv.customer_name || '')}</option>`).join('')}</select></label>
+                    <button type="button" class="btn btn-secondary" onclick="SettingsPage.previewInvoiceTemplate()" ${invoiceRows.length ? '' : 'disabled'}>Preview Email</button>
+                    <p style="font-size:12px;">${Terms.text('Preview uses your current edits without sending an email. Save Template to use them for future sends.')}</p>
+                    <div id="email-template-preview-result"></div>
+                </div>` : ''}
                 <div class="form-actions">
                     <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
                     <button type="submit" class="btn btn-primary">Save Template</button>
                 </div>
             </form>`);
+    },
+
+    async previewInvoiceTemplate() {
+        const form = document.getElementById('email-template-editor');
+        const id = document.getElementById('email-template-invoice').value;
+        if (!id) return;
+        const out = document.getElementById('email-template-preview-result');
+        if (out) out.innerHTML = '';
+        try {
+            const preview = await API.post(`/invoices/${id}/email-preview`, {
+                subject_template: form.elements.subject_template.value,
+                body_template: form.elements.body_template.value,
+            });
+            if (out) out.innerHTML = `<p><strong>Subject:</strong> ${escapeHtml(preview.subject)}</p>
+                <iframe id="template-rendered-email" sandbox="" title="Template preview" style="width:100%;height:350px;border:1px solid #ddd;background:white;"></iframe>
+                <p><a target="_blank" rel="noopener" href="${escapeHtml(preview.pdf_url)}">${Terms.text('Preview invoice PDF attachment')}</a></p>`;
+            const frame = document.getElementById('template-rendered-email');
+            if (frame) frame.srcdoc = preview.html_body;
+        } catch (err) { toast(err.message, 'error'); }
     },
 
     async saveTemplate(e, id) {

--- a/app/templates/invoice_email.html
+++ b/app/templates/invoice_email.html
@@ -17,9 +17,8 @@ td { padding: 8px; border-bottom: 1px solid #eee; }
 </div>
 <div class="content">
     <p>Dear {{ inv.customer.name if inv.customer else terms('Customer') }},</p>
-    {% if note %}<p>{{ note }}</p>
-    {% else %}<p>Please find attached <strong>{{ doc_label }} #{{ inv.invoice_number }}</strong>.</p>
-    {% endif %}
+    {% if note %}<p>{{ note }}</p>{% endif %}
+    <p>Please find attached <strong>{{ doc_label }} #{{ inv.invoice_number }}</strong>.</p>
 
     <table>
         <tr><th>{{ doc_label }} #</th><td>{{ inv.invoice_number }}</td></tr>

--- a/tests/test_email_invoice_dialog.py
+++ b/tests/test_email_invoice_dialog.py
@@ -116,6 +116,25 @@ def test_the_dialog_and_the_route_agree_on_their_fields():
         f"_EmailInvoiceRequest is a StrictModel so this is a 422, not an ignore"
     )
 
+    # The subset relation above only catches the direction that broke us: the
+    # page posting a field the route refuses. It says nothing about the page
+    # quietly *dropping* a field the route supports, which is the likelier
+    # mistake now that the box works — a branch that deleted the Message
+    # textarea outright passed everything above this line. Name the field.
+    assert "message" in sent, (
+        "the Email Invoice dialog no longer posts `message`; the Message box "
+        "is part of the contract now (#140) and an operator's text must reach "
+        "the email rather than being dropped on the page"
+    )
+    assert 'name="message"' in js, (
+        "the Message textarea is gone from the dialog; `message` is still in "
+        "the POST body, so every send would now throw on form.message.value"
+    )
+    assert "message" in accepted, (
+        "_EmailInvoiceRequest no longer accepts `message`; the dialog posts it "
+        "and this is a StrictModel, so every send from the interface is a 422"
+    )
+
 
 def test_the_operators_message_reaches_the_email_body(
     client, db_session, seed_accounts, invoice

--- a/tests/test_invoice_email_templates.py
+++ b/tests/test_invoice_email_templates.py
@@ -1,0 +1,505 @@
+"""The saved invoice_email template drives both the preview and the send.
+
+Before this, /invoices/{id}/email rendered a hardcoded body and ignored the
+template the user had edited under Settings -> Email Templates, and the send
+dialog posted a `message` field the route rejected. These tests pin the two
+halves together: preview and send render through one code path, so what the
+dialog shows is what goes out. The operator's per-send note is the one thing
+preview does not show — it is typed after the preview is fetched, and is
+prepended at send.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app.models.email_log import EmailLog
+from app.models.email_templates import EmailTemplate
+from app.models.invoices import Invoice, InvoiceStatus
+from app.models.transactions import Transaction
+
+SUBJECT_TEMPLATE = "Invoice {{ invoice.invoice_number }} for {{ customer_name }}"
+BODY_TEMPLATE = (
+    "<p>{{ customer_name }} {{ invoice.total|currency }}</p>"
+    "{% if invoice.balance_due == 0 %}<p>Paid in full</p>{% endif %}"
+)
+
+
+@pytest.fixture
+def email_invoice(db_session, seed_customer):
+    """A paid invoice plus a saved invoice_email template to render it with."""
+    seed_customer.email = "client@example.com"
+    invoice = Invoice(
+        invoice_number="TEST-1",
+        customer_id=seed_customer.id,
+        date=date(2026, 9, 1),
+        due_date=date(2026, 9, 15),
+        subtotal=Decimal("125"),
+        total=Decimal("125"),
+        amount_paid=Decimal("125"),
+        balance_due=Decimal("0"),
+        status=InvoiceStatus.PAID,
+    )
+    db_session.add(invoice)
+    db_session.add(
+        EmailTemplate(
+            name="invoice_email",
+            template_type="invoice",
+            subject_template=SUBJECT_TEMPLATE,
+            body_template=BODY_TEMPLATE,
+        )
+    )
+    db_session.commit()
+    return invoice
+
+
+@pytest.fixture
+def captured_send(monkeypatch):
+    """Capture send_email() kwargs and stub the PDF so no native stack is needed."""
+    import app.routes.invoices.documents as documents
+    import app.services.email_service as email_service
+
+    captured = []
+    monkeypatch.setattr(documents, "generate_invoice_pdf", lambda *a: b"%PDF-test")
+    monkeypatch.setattr(
+        email_service, "send_email", lambda **kw: captured.append(kw) or True
+    )
+    return captured
+
+
+def test_preview_matches_send_and_changes_nothing(
+    client, db_session, email_invoice, captured_send
+):
+    before = (
+        db_session.query(Transaction).count(),
+        db_session.query(EmailLog).count(),
+    )
+
+    preview = client.post(f"/api/invoices/{email_invoice.id}/email-preview", json={})
+    assert preview.status_code == 200, preview.text
+    assert "Paid in full" in preview.json()["html_body"]
+    assert "$125.00" in preview.json()["html_body"]
+    assert preview.json()["recipient"] == "client@example.com"
+    # A preview must not post a transaction or write an email log row.
+    assert before == (
+        db_session.query(Transaction).count(),
+        db_session.query(EmailLog).count(),
+    )
+
+    sent = client.post(
+        f"/api/invoices/{email_invoice.id}/email",
+        json={"recipient": "self@example.com"},
+    )
+    assert sent.status_code == 200, sent.text
+    assert captured_send[0]["subject"] == preview.json()["subject"]
+    assert captured_send[0]["html_body"] == preview.json()["html_body"]
+    assert captured_send[0]["attachment_bytes"] == b"%PDF-test"
+    assert captured_send[0]["to_email"] == "self@example.com"
+
+    db_session.refresh(email_invoice)
+    assert email_invoice.status == InvoiceStatus.PAID
+    assert email_invoice.balance_due == 0
+
+
+def test_saved_edits_apply_and_unsaved_edits_do_not_persist(
+    client, db_session, email_invoice
+):
+    template = db_session.query(EmailTemplate).filter_by(name="invoice_email").one()
+    url = f"/api/invoices/{email_invoice.id}/email-preview"
+
+    saved = client.put(
+        f"/api/email-templates/{template.id}",
+        json={
+            "subject_template": "New {{ invoice.invoice_number }}",
+            "body_template": "<p>New layout {{ invoice.balance_due|currency }}</p>",
+        },
+    )
+    assert saved.status_code == 200, saved.text
+    assert client.post(url, json={}).json()["subject"] == "New TEST-1"
+
+    # The editor previews unsaved textarea content without storing it.
+    unsaved = client.post(
+        url, json={"subject_template": "Unsaved", "body_template": "<p>Draft</p>"}
+    )
+    assert unsaved.json()["subject"] == "Unsaved"
+    assert client.post(url, json={}).json()["subject"] == "New TEST-1"
+
+
+def test_broken_template_is_rejected_on_save_and_on_preview(
+    client, db_session, email_invoice
+):
+    template = db_session.query(EmailTemplate).filter_by(name="invoice_email").one()
+
+    # A syntax error must fail at save time, not silently at send time.
+    broken = client.put(
+        f"/api/email-templates/{template.id}", json={"body_template": "{% if %}"}
+    )
+    assert broken.status_code == 400
+    assert "Invalid body_template syntax" in broken.json()["detail"]
+
+    # The sandbox blocks attribute walking back into Python objects.
+    escape = client.post(
+        f"/api/invoices/{email_invoice.id}/email-preview",
+        json={"body_template": "{{ invoice.__class__.__mro__ }}"},
+    )
+    assert escape.status_code == 400
+
+
+def test_customer_name_is_escaped_and_subject_override_wins(
+    client, db_session, email_invoice, captured_send
+):
+    email_invoice.customer.name = "<img src=x onerror=alert(1)>"
+    db_session.commit()
+
+    preview = client.post(
+        f"/api/invoices/{email_invoice.id}/email-preview", json={}
+    ).json()
+    assert "<img" not in preview["html_body"]
+    assert "&lt;img" in preview["html_body"]
+
+    sent = client.post(
+        f"/api/invoices/{email_invoice.id}/email",
+        json={"recipient": "self@example.com", "subject": "Test override"},
+    )
+    assert sent.status_code == 200, sent.text
+    assert captured_send[0]["subject"] == "Test override"
+
+
+def test_subject_is_not_html_escaped(client, db_session, email_invoice):
+    """The subject is a mail header: "Smith & Sons" must not become "&amp;"."""
+    email_invoice.customer.name = "Smith & Sons"
+    db_session.commit()
+
+    preview = client.post(
+        f"/api/invoices/{email_invoice.id}/email-preview", json={}
+    ).json()
+    assert preview["subject"] == "Invoice TEST-1 for Smith & Sons"
+
+
+def test_falls_back_to_builtin_body_when_no_template_exists(
+    client, db_session, email_invoice
+):
+    db_session.query(EmailTemplate).delete()
+    db_session.commit()
+
+    preview = client.post(f"/api/invoices/{email_invoice.id}/email-preview", json={})
+    assert preview.status_code == 200
+    # "Amount Due:" comes from invoice_email.html and appears in no saved
+    # template, so it pins the built-in body rather than just any render.
+    assert "Amount Due:" in preview.json()["html_body"]
+
+
+def test_sales_receipt_still_gets_its_saved_template(client, db_session, email_invoice):
+    """The document label must not decide whether the template is used.
+
+    invoice_email_label() returns Sales Receipt / Donation Receipt / Pledge
+    rather than "Invoice" for those documents. Gating the saved template on
+    that label means anyone using sales receipts edits a template and
+    silently keeps getting the built-in body, with the editor preview
+    showing the built-in body too.
+    """
+    email_invoice.is_sales_receipt = True
+    db_session.commit()
+
+    preview = client.post(
+        f"/api/invoices/{email_invoice.id}/email-preview", json={}
+    ).json()
+    assert "Paid in full" in preview["html_body"], "saved template was ignored"
+
+    # An unsaved editor edit must preview here too.
+    edited = client.post(
+        f"/api/invoices/{email_invoice.id}/email-preview",
+        json={"body_template": "<p>Draft for {{ doc_label }}</p>"},
+    ).json()
+    assert edited["html_body"] == "<p>Draft for Sales Receipt</p>"
+
+
+def test_nonprofit_pledge_still_gets_its_saved_template(
+    client, db_session, email_invoice
+):
+    assert (
+        client.put("/api/settings", json={"company_type": "nonprofit"}).status_code
+        == 200
+    )
+    email_invoice.is_pledge = True
+    db_session.commit()
+
+    preview = client.post(
+        f"/api/invoices/{email_invoice.id}/email-preview", json={}
+    ).json()
+    assert "Paid in full" in preview["html_body"], "saved template was ignored"
+
+
+def test_builtin_fallback_keeps_the_document_label(client, db_session, email_invoice):
+    """With no template saved, the fallback subject still says Sales Receipt."""
+    db_session.query(EmailTemplate).delete()
+    email_invoice.is_sales_receipt = True
+    db_session.commit()
+
+    preview = client.post(
+        f"/api/invoices/{email_invoice.id}/email-preview", json={}
+    ).json()
+    assert preview["subject"] == "Sales Receipt #TEST-1"
+
+
+def test_template_cannot_read_decrypted_settings_secrets(
+    client, db_session, email_invoice
+):
+    """Templates are user-editable, so the settings dict they render against
+    must be the redacted one.
+
+    get_all_settings() decrypts smtp_password, the Stripe secret key and the
+    rest because the server needs them to actually send mail. Handing that
+    dict to a template would let anyone who can edit one mail themselves the
+    credentials — and /api/settings deliberately redacts all of them, for
+    every role, so the template path must not be a way around that.
+    """
+    from app.services.settings_service import set_setting
+
+    set_setting(db_session, "smtp_password", "hunter2-SECRET")
+    set_setting(db_session, "stripe_secret_key", "sk_live_LEAKME")
+    db_session.commit()
+
+    url = f"/api/invoices/{email_invoice.id}/email-preview"
+    leaked = client.post(
+        url,
+        json={
+            "subject_template": "{{ company.stripe_secret_key }}",
+            "body_template": "<p>{{ company.smtp_password }}{{ company }}</p>",
+        },
+    )
+    assert leaked.status_code == 200, leaked.text
+    rendered = leaked.json()["subject"] + leaked.json()["html_body"]
+    assert "hunter2-SECRET" not in rendered
+    assert "sk_live_LEAKME" not in rendered
+    assert "********" in rendered
+
+    # Non-secret company fields must still render, or the redaction is useless.
+    ok = client.post(url, json={"body_template": "<p>{{ company.company_name }}</p>"})
+    assert ok.json()["html_body"] == "<p>My Company</p>"
+
+
+def test_blank_subject_falls_back_instead_of_mailing_an_empty_header(
+    client, db_session, email_invoice, captured_send
+):
+    """The Subject field in the send dialog is user-clearable."""
+    sent = client.post(
+        f"/api/invoices/{email_invoice.id}/email",
+        json={"recipient": "self@example.com", "subject": ""},
+    )
+    assert sent.status_code == 200, sent.text
+    assert captured_send[0]["subject"] == "Invoice TEST-1 for Test Customer"
+
+
+def test_subject_template_cannot_inject_mail_headers(
+    client, db_session, email_invoice, monkeypatch
+):
+    """A rendered subject reaches a mail header, so CRLF must not survive.
+
+    Subjects render with autoescape off (a subject is a header, not HTML),
+    which makes send_email()'s CRLF stripping load-bearing for template text
+    in a way it wasn't when the subject came from a form field.
+    """
+    import app.services.email_service as email_service
+    from app.services.settings_service import set_setting
+
+    template = db_session.query(EmailTemplate).filter_by(name="invoice_email").one()
+    template.subject_template = "Hi\r\nBcc: attacker@example.com\r\nX: "
+    db_session.commit()
+
+    # The renderer itself leaves CRLF alone — it is not a header yet.
+    rendered_subject, _ = email_service.render_invoice_message(
+        db_session, email_invoice, {}, None
+    )
+    assert "\n" in rendered_subject
+
+    # send_email() is where it must be neutralised, before MIMEMultipart.
+    for key, value in (
+        ("smtp_host", "localhost"),
+        ("smtp_from_email", "billing@example.com"),
+    ):
+        set_setting(db_session, key, value)
+    db_session.commit()
+
+    captured = {}
+
+    class _FakeSMTP:
+        def __init__(self, *a, **kw):
+            pass
+
+        def starttls(self, *a, **kw):
+            pass
+
+        def login(self, *a, **kw):
+            pass
+
+        def sendmail(self, from_addr, to_addrs, raw, *a, **kw):
+            captured["raw"] = raw
+
+        def quit(self):
+            pass
+
+    monkeypatch.setattr(email_service.smtplib, "SMTP", _FakeSMTP)
+    email_service.send_email(
+        db=db_session,
+        to_email="self@example.com",
+        subject=rendered_subject,
+        html_body="<p>body</p>",
+    )
+
+    raw = captured.get("raw", "")
+    assert raw, "SMTP send was not exercised"
+    subject_lines = [ln for ln in raw.splitlines() if ln.startswith("Subject:")]
+    assert len(subject_lines) == 1
+    assert "attacker@example.com" in subject_lines[0]
+    assert not any(ln.startswith("Bcc:") for ln in raw.splitlines())
+
+
+def test_render_failure_is_a_400_not_a_500(client, db_session, email_invoice):
+    """Arithmetic and range blowups are bad input, same as a syntax error."""
+    url = f"/api/invoices/{email_invoice.id}/email-preview"
+    assert client.post(url, json={"body_template": "{{ 1/0 }}"}).status_code == 400
+    assert (
+        client.post(
+            url, json={"body_template": "{% for i in range(9999999999) %}x{% endfor %}"}
+        ).status_code
+        == 400
+    )
+
+
+def test_create_template_also_validates_syntax(client, db_session):
+    """The POST path calls the same validator the PUT path does."""
+    created = client.post(
+        "/api/email-templates",
+        json={
+            "name": "brand_new",
+            "template_type": "invoice",
+            "subject_template": "ok",
+            "body_template": "{% if %}",
+        },
+    )
+    assert created.status_code == 400
+    assert "Invalid body_template syntax" in created.json()["detail"]
+
+
+def test_operator_note_sits_above_the_saved_template_body(
+    client, db_session, email_invoice, captured_send
+):
+    """One rule everywhere: the note is a paragraph above the body.
+
+    It is deliberately not a template variable. A `{{ note }}` a saved
+    template could omit would drop the operator's message silently — the
+    same defect class as the dialog that posted a field the route refused.
+    """
+    sent = client.post(
+        f"/api/invoices/{email_invoice.id}/email",
+        json={"recipient": "self@example.com", "message": "Ten days, as agreed."},
+    )
+    assert sent.status_code == 200, sent.text
+    body = captured_send[0]["html_body"]
+    assert "Ten days, as agreed." in body
+    # Above the template's own output, not instead of it.
+    assert body.index("Ten days, as agreed.") < body.index("Paid in full")
+
+
+def test_operator_note_is_escaped_on_the_saved_template_path(
+    client, db_session, email_invoice, captured_send
+):
+    sent = client.post(
+        f"/api/invoices/{email_invoice.id}/email",
+        json={"recipient": "self@example.com", "message": "<script>x</script>"},
+    )
+    assert sent.status_code == 200, sent.text
+    body = captured_send[0]["html_body"]
+    assert "<script>x</script>" not in body
+    assert "&lt;script&gt;" in body
+
+
+def test_note_survives_when_no_template_is_saved(
+    client, db_session, email_invoice, captured_send
+):
+    """The built-in body keeps its standard opening and takes the note above it."""
+    db_session.query(EmailTemplate).delete()
+    db_session.commit()
+
+    sent = client.post(
+        f"/api/invoices/{email_invoice.id}/email",
+        json={"recipient": "self@example.com", "message": "Ten days, as agreed."},
+    )
+    assert sent.status_code == 200, sent.text
+    body = captured_send[0]["html_body"]
+    assert "Ten days, as agreed." in body
+    # The standard opening is kept, not replaced — both paths read the same.
+    assert "Amount Due:" in body or "Please find attached" in body
+
+
+def test_note_is_not_a_template_variable(client, db_session, email_invoice):
+    """A template referencing {{ note }} must not interpolate it, or operators
+    would have two competing places for the same text."""
+    template = db_session.query(EmailTemplate).filter_by(name="invoice_email").one()
+    template.body_template = "<p>[{{ note }}]</p>"
+    db_session.commit()
+
+    preview = client.post(
+        f"/api/invoices/{email_invoice.id}/email-preview", json={}
+    ).json()
+    assert "[]" in preview["html_body"]
+
+
+def test_note_is_escaped_on_the_builtin_fallback_path(db_session, email_invoice):
+    """The f-string fallback runs only when the file template fails to load.
+
+    Nothing else in the suite reaches it, so its html.escape() on operator
+    text — an XSS-relevant control — would otherwise ship untested.
+    """
+    import app.services.email_service as email_service
+
+    def _boom(*a, **kw):
+        raise RuntimeError("template missing")
+
+    original = email_service._jinja_env.get_template
+    email_service._jinja_env.get_template = _boom
+    try:
+        body = email_service.render_invoice_email(
+            email_invoice, {}, note="<script>x</script>"
+        )
+    finally:
+        email_service._jinja_env.get_template = original
+
+    assert "Please find attached" in body, "not the fallback path"
+    assert "<script>x</script>" not in body
+    assert "&lt;script&gt;" in body
+    # Above the standard opening, which is kept rather than replaced.
+    assert body.index("&lt;script&gt;") < body.index("Please find attached")
+
+
+def test_note_goes_inside_body_for_a_full_document_template(db_session, email_invoice):
+    """A pasted designer template is a whole document. A note placed before
+    <html> is dropped by Gmail and Outlook sanitisers, losing the operator's
+    message silently — the defect this feature exists to prevent."""
+    from app.services.email_service import render_invoice_message
+
+    template = db_session.query(EmailTemplate).filter_by(name="invoice_email").one()
+    template.body_template = (
+        "<html><head><title>x</title></head><body><p>Hi</p></body></html>"
+    )
+    db_session.commit()
+
+    _, html = render_invoice_message(
+        db_session, email_invoice, {}, None, note="Ten days, as agreed."
+    )
+    assert "Ten days, as agreed." in html
+    assert html.startswith("<html>"), "note was placed before <html>"
+    assert html.index("<body>") < html.index("Ten days, as agreed.")
+    assert html.index("Ten days, as agreed.") < html.index("Hi")
+
+
+def test_note_keeps_operator_line_breaks(db_session, email_invoice):
+    """The dialog offers a three-row textarea; a return in it means something."""
+    from app.services.email_service import render_invoice_message
+
+    _, body = render_invoice_message(
+        db_session, email_invoice, {}, None, note="line one\nline two"
+    )
+    assert "line one<br>line two" in body


### PR DESCRIPTION
## Summary

The rest of #140, on top of #142. The saved `invoice_email` template was ignored
by the send path, and template selection was keyed off the document label —
which, as noted on the issue, silently affects ordinary businesses through sales
receipts and not just nonprofit installs.

**Stacked on #142** — based on `cc5dc87`, so its commits show here until it
merges. Happy to rebase onto `main` once it lands.

## Changes

- `/invoices/{id}/email` renders the saved template. Preview and send share one
  renderer, `render_invoice_message()`, so what the dialog shows is what goes out.
- New `POST /invoices/{id}/email-preview` renders saved *or* unsaved template
  text against a real invoice. Read-only: no `EmailLog` row, no transaction, no
  change to the invoice.
- The template editor previews unsaved edits against an invoice you pick.
- **The label no longer gates the template.** `invoice_email_label()` returns
  `Sales Receipt` / `Donation Receipt` / `Pledge` rather than `Invoice` for those
  documents; keying the lookup off it meant anyone using sales receipts kept the
  built-in body no matter what they saved. The label is passed to templates as
  `doc_label` instead.
- **Templates render against a redacted settings dict.** `get_all_settings()`
  decrypts `smtp_password`, the Stripe key and the rest, and `/api/settings`
  redacts all of them for every role — a user-editable template rendering the raw
  dict would be a way around that. `redact_secrets()` sits in `settings_service`
  beside `ENCRYPTED_SETTINGS_KEYS`, keyed off it, so a new credential is redacted
  by the same act that encrypts it.
- Templates compile on save, so a syntax error is a 400 at save time rather than
  a failed send after the invoice is marked sent.
- Your `note` handling carried across per your call on the issue: one escaped
  paragraph above the body, never a template variable. The built-in path keeps
  its standard opening rather than swapping it, as you asked.

## One open question — the note and a salutation

Your rule reads cleanly on the built-in body:

> Dear Acme,
> Ten days, as agreed.
> Please find attached Invoice #1001.

On a **saved** template the whole body is operator-authored, so there's no
reliable way to find where a greeting ends. I prepend unconditionally, which
means against the shipped default in `DEFAULT_TEMPLATES` — it opens
`<p>Dear {{ customer_name }},</p>` — the note lands *above* the greeting:

```
Ten days, as agreed.
Dear Acme Co,
Please find attached Invoice #TEST-1 for $125.00.
```

So the two paths don't read identically after all, and I'd rather say that than
let you find it. The options I see:

1. **Prepend always** (what's here). Never lost, occasionally awkward.
2. Insert after the first block when the body starts with one. Tidier for the
   default and most templates, wrong whenever the guess is wrong — and wrong
   silently.

I shipped 1 because a misplaced note is visible and a heuristic that misfires
isn't, but it's your default template and your rule. Say the word and 2 is a
small follow-up.

One thing I did fix in that area: a saved template that's a full HTML document
had the note landing *before* `<html>`, where Gmail and Outlook sanitisers drop
it — losing the message silently, which is the thing we're both trying to
prevent. It now inserts after `<body>` when there is one.

## Test plan

- [x] `pytest tests/ -q` — **2088 passed**, 46 skipped
- [x] `black --check app/ tests/` passes
- [x] `ruff check app/ tests/` passes
- [x] Manually verified the user flow described above

The skips are this machine's missing WeasyPrint/tesseract native stack, not new.

Each new control was checked by removing it and confirming a test goes red:
secret redaction, the note's escaping on all three render paths, the `<body>`
insertion, note-above-body ordering, CRLF stripping in `send_email()`, the
blank-subject fallback, and the broadened render-error handler.

**Your tripwire, tightened in both directions.** `sent <= accepted` caught the
page posting a field the route refuses, but not the page *dropping* a field the
route supports — an earlier version of this branch deleted the Message box
outright and passed the whole file. It now names `message` on both sides and
asserts the textarea itself still exists, since removing it while leaving
`message:` in the POST would `TypeError` on every send. `@macbase1`'s
unknown-field control is kept as-is.

## Security implications

Template text is operator-editable, so both render paths use
`SandboxedEnvironment`, and previews render in a `sandbox=""` iframe via
`srcdoc`. Bodies are autoescaped; **subjects deliberately are not**, because a
subject is a mail header and escaping it would put a literal `&amp;` in the inbox
for a customer named "Smith & Sons" — which makes `send_email()`'s existing CRLF
stripping load-bearing for template text, so there's now a test for it.

The note is escaped *after* the body renders, so a note containing `{{ }}` or
`{% %}` is inert rather than a second template pass.

The settings redaction above is the main change here. Worth noting the same raw
dict reaches one other editable template; I've reported that separately and
privately rather than here.

## Database changes

- [x] No schema changes

## Documentation

- [x] `CHANGELOG.md` updated under `[Unreleased]`

## Related issues

Refs #140. Builds on #142.
