### PR TITLE
Preview an email template edit before saving it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
+**You can see a template edit before you save it.** Editing `invoice_email`
+under Settings -> Email Templates still meant saving over a working template
+and mailing a real customer to find out what it looked like. The editor now
+renders what you have typed against an invoice you pick — no save, no send,
+no record written. It renders through the same sandboxed environment the send
+uses, so a preview cannot follow different rules than the mail it previews.
+
 ### v2.12.0 — Your chart, your templates, your clipboard
 
 Five reader-reported defects and one privately reported security issue,

--- a/app/routes/email_templates.py
+++ b/app/routes/email_templates.py
@@ -3,11 +3,12 @@
 # Phase 10: Quick Wins + Medium Effort Features
 # ============================================================================
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.models.email_templates import EmailTemplate
+from app.schemas.common import StrictModel
 from app.schemas.email_templates import (
     EmailTemplateCreate,
     EmailTemplateUpdate,
@@ -83,6 +84,60 @@ def get_template(template_id: int, db: Session = Depends(get_db)):
     if not template:
         raise HTTPException(status_code=404, detail="Template not found")
     return template
+
+
+class _TemplatePreviewRequest(StrictModel):
+    invoice_id: int
+    subject_template: str = ""
+    body_template: str = ""
+
+
+@router.post("/preview")
+def preview_template(
+    data: _TemplatePreviewRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    """Render candidate template text against a real invoice, without saving.
+
+    #140 gave the send dialog a preview of what it is about to send. This is
+    the other half: the operator editing `invoice_email` under Settings can
+    see an edit before committing it, rather than saving over a working
+    template to find out. Read-only — nothing is written, nothing is mailed.
+    """
+    from jinja2 import TemplateError
+
+    from app.models.invoices import Invoice
+    from app.services.email_service import invoice_email_context, template_env
+    from app.services.payments import enabled_providers
+    from app.services.settings_service import get_all_settings
+
+    inv = db.query(Invoice).filter(Invoice.id == data.invoice_id).first()
+    if not inv:
+        raise HTTPException(status_code=404, detail="Invoice not found")
+
+    company = get_all_settings(db)
+    pay_url = None
+    if inv.payment_token and enabled_providers(db):
+        pay_url = f"{str(request.base_url).rstrip('/')}/pay/{inv.payment_token}"
+
+    ctx = invoice_email_context(inv, company, pay_url=pay_url)
+    env = template_env()
+    try:
+        subject = env.from_string(data.subject_template).render(**ctx)
+        body = env.from_string(data.body_template).render(**ctx)
+    except (TemplateError, Exception) as exc:
+        # Everything here renders text the client supplied: a syntax error, a
+        # sandbox escape and "{{ 1/0 }}" are all bad input, so all are a 400.
+        # The message stays generic because the text came from the client.
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Template could not be rendered. Check the template "
+                "variables and syntax."
+            ),
+        ) from exc
+    return {"subject": subject, "html_body": body}
 
 
 @router.post("", response_model=EmailTemplateResponse, status_code=201)

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -137,23 +137,37 @@ def send_email(
 def render_template_from_db(db: Session, template_name: str, context: dict) -> tuple:
     """Load template from DB, render with Jinja2 SandboxedEnvironment, fall back to file."""
     from app.models.email_templates import EmailTemplate
-    from jinja2.sandbox import SandboxedEnvironment
 
     tpl = db.query(EmailTemplate).filter(EmailTemplate.name == template_name).first()
     if tpl:
-        # autoescape=True so customer-supplied names / addresses / memo
-        # text injected via {{ }} can't break out of HTML context. Same
-        # rule WC3D applied to the file-loader Environment in commit
-        # ca6182f — keep both paths consistent.
-        env = SandboxedEnvironment(autoescape=True)
-        from app.services.pdf_service import _format_currency, _format_date
-
-        env.filters["currency"] = _format_currency
-        env.filters["fdate"] = _format_date
+        env = template_env()
         subject = env.from_string(tpl.subject_template).render(**context)
         body = env.from_string(tpl.body_template).render(**context)
         return subject, body
     return None, None
+
+
+def template_env():
+    """The environment every operator-authored template is rendered in.
+
+    autoescape=True so customer-supplied names / addresses / memo text
+    injected via {{ }} can't break out of HTML context. Same rule WC3D
+    applied to the file-loader Environment in commit ca6182f — keep both
+    paths consistent. Sandboxed because the template text is operator-
+    editable and must not reach back into Python objects through attribute
+    access.
+
+    Shared by the send and by the template editor's preview, so a preview
+    cannot render under different rules than the mail it is previewing.
+    """
+    from jinja2.sandbox import SandboxedEnvironment
+
+    from app.services.pdf_service import _format_currency, _format_date
+
+    env = SandboxedEnvironment(autoescape=True)
+    env.filters["currency"] = _format_currency
+    env.filters["fdate"] = _format_date
+    return env
 
 
 def invoice_email_label(invoice, company_settings: dict) -> str:

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -751,9 +751,17 @@ const SettingsPage = {
     },
 
     async editTemplate(id) {
-        const t = await API.get(`/email-templates/${id}`);
+        let t, invoices = [];
+        try {
+            t = await API.get(`/email-templates/${id}`);
+            if (t.template_type === 'invoice') {
+                // Enough to pick one to preview against; the endpoint would
+                // otherwise return up to 500, each with its lines.
+                invoices = await API.get('/invoices?is_sales_receipt=false&limit=50');
+            }
+        } catch (err) { toast(err.message, 'error'); return; }
         openModal('Edit Email Template', `
-            <form onsubmit="SettingsPage.saveTemplate(event, ${id})">
+            <form id="email-template-editor" onsubmit="SettingsPage.saveTemplate(event, ${id})">
                 <div class="form-grid">
                     <div class="form-group"><label>Name</label>
                         <input name="name" value="${escapeHtml(t.name)}" readonly style="background:var(--gray-100);"></div>
@@ -768,11 +776,37 @@ const SettingsPage = {
                     Variables: {{ invoice.invoice_number }}, {{ invoice.total }}, {{ invoice.due_date }}, {{ customer_name }},
                     {{ company.company_name }}, {{ pay_url }}, {{ amount }}. Filters: | currency, | fdate
                 </div>
+                ${t.template_type === 'invoice' ? `<div style="margin-top:12px;">
+                    <label>Preview against ${T('invoice')}
+                        <select id="email-template-invoice">${invoices.map(inv => `<option value="${inv.id}">#${escapeHtml(inv.invoice_number)} — ${escapeHtml(inv.customer_name || '')}</option>`).join('')}</select></label>
+                    <button type="button" class="btn btn-secondary" onclick="SettingsPage.previewTemplate()" ${invoices.length ? '' : 'disabled'}>Preview</button>
+                    <p style="font-size:11px; color:var(--text-muted);">Renders what you have typed, without saving or sending.</p>
+                    <div id="email-template-preview"></div>
+                </div>` : ''}
                 <div class="form-actions">
                     <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
                     <button type="submit" class="btn btn-primary">Save Template</button>
                 </div>
             </form>`);
+    },
+
+    async previewTemplate() {
+        const form = document.getElementById('email-template-editor');
+        const picker = document.getElementById('email-template-invoice');
+        const out = document.getElementById('email-template-preview');
+        if (!form || !picker || !out) return;
+        out.innerHTML = '';
+        try {
+            const p = await API.post('/email-templates/preview', {
+                invoice_id: Number(picker.value),
+                subject_template: form.elements.subject_template.value,
+                body_template: form.elements.body_template.value,
+            });
+            out.innerHTML = `<p style="margin-top:8px;"><strong>Subject:</strong> ${escapeHtml(p.subject)}</p>
+                <iframe id="email-template-rendered" sandbox="" title="Template preview" style="width:100%;height:320px;border:1px solid var(--gray-300);background:white;"></iframe>`;
+            const frame = document.getElementById('email-template-rendered');
+            if (frame) frame.srcdoc = p.html_body;
+        } catch (err) { toast(err.message, 'error'); }
     },
 
     async saveTemplate(e, id) {

--- a/tests/test_email_template_preview.py
+++ b/tests/test_email_template_preview.py
@@ -1,0 +1,133 @@
+"""Previewing a template edit before saving it.
+
+#140 gave the send dialog a preview of the mail it is about to send. This is
+the other half: the operator editing `invoice_email` under Settings -> Email
+Templates could only see the result by saving over a working template and
+mailing a real customer. The preview renders what is currently typed, against
+a real invoice, without writing or sending anything.
+
+It deliberately renders through `email_service.template_env()` — the same
+environment the send uses — because a preview under different rules than the
+mail is how the template and the send drifted apart in the first place.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app.models.email_log import EmailLog
+from app.models.email_templates import EmailTemplate
+from app.models.invoices import Invoice, InvoiceStatus
+from app.models.transactions import Transaction
+
+
+@pytest.fixture
+def invoice(db_session, seed_customer):
+    seed_customer.email = "client@example.com"
+    inv = Invoice(
+        invoice_number="PREV-1",
+        customer_id=seed_customer.id,
+        date=date(2026, 9, 1),
+        due_date=date(2026, 9, 15),
+        subtotal=Decimal("125"),
+        total=Decimal("125"),
+        balance_due=Decimal("125"),
+        status=InvoiceStatus.SENT,
+    )
+    db_session.add(inv)
+    db_session.commit()
+    return inv
+
+
+def _preview(client, invoice_id, subject="S", body="<p>B</p>"):
+    return client.post(
+        "/api/email-templates/preview",
+        json={
+            "invoice_id": invoice_id,
+            "subject_template": subject,
+            "body_template": body,
+        },
+    )
+
+
+def test_preview_renders_unsaved_text_and_saves_nothing(client, db_session, invoice):
+    before = (
+        db_session.query(Transaction).count(),
+        db_session.query(EmailLog).count(),
+        db_session.query(EmailTemplate).count(),
+    )
+    r = _preview(
+        client,
+        invoice.id,
+        subject="Draft {{ invoice.invoice_number }}",
+        body="<p>{{ customer_name }} owes {{ invoice.total|currency }}</p>",
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["subject"] == "Draft PREV-1"
+    assert "$125.00" in r.json()["html_body"]
+    assert before == (
+        db_session.query(Transaction).count(),
+        db_session.query(EmailLog).count(),
+        db_session.query(EmailTemplate).count(),
+    )
+
+
+def test_preview_does_not_touch_the_saved_template(client, db_session, invoice):
+    db_session.add(
+        EmailTemplate(
+            name="invoice_email",
+            template_type="invoice",
+            subject_template="Saved subject",
+            body_template="<p>Saved body</p>",
+        )
+    )
+    db_session.commit()
+
+    assert (
+        _preview(client, invoice.id, subject="Unsaved").json()["subject"] == "Unsaved"
+    )
+    saved = db_session.query(EmailTemplate).filter_by(name="invoice_email").one()
+    assert saved.subject_template == "Saved subject"
+
+
+def test_preview_escapes_customer_supplied_text(client, db_session, invoice):
+    invoice.customer.name = "<img src=x onerror=alert(1)>"
+    db_session.commit()
+    body = _preview(client, invoice.id, body="<p>{{ customer_name }}</p>").json()[
+        "html_body"
+    ]
+    assert "<img" not in body
+    assert "&lt;img" in body
+
+
+def test_preview_cannot_read_settings_secrets(client, db_session, invoice):
+    """GHSA-c3v4-f43f-4wqm: the context is redacted at the point it is built,
+    and this endpoint must be no exception."""
+    from app.services.settings_service import set_setting
+
+    set_setting(db_session, "smtp_password", "hunter2-SECRET")
+    db_session.commit()
+
+    body = _preview(
+        client, invoice.id, body="<p>{{ company.smtp_password }}{{ company }}</p>"
+    ).json()["html_body"]
+    assert "hunter2-SECRET" not in body
+    assert "********" in body
+
+
+def test_preview_rejects_a_sandbox_escape(client, db_session, invoice):
+    r = _preview(client, invoice.id, body="{{ invoice.__class__.__mro__ }}")
+    assert r.status_code == 400
+
+
+def test_preview_rejects_bad_input_as_400_not_500(client, db_session, invoice):
+    """Syntax errors, unknown filters and arithmetic blowups are all just bad
+    text from the client."""
+    for bad in ("{% if %}", "{{ 1/0 }}", "{{ x | frobnicate }}"):
+        r = _preview(client, invoice.id, body=bad)
+        assert r.status_code == 400, f"{bad!r} gave {r.status_code}"
+
+
+def test_preview_404s_for_an_unknown_invoice(client, db_session):
+    assert _preview(client, 999999).status_code == 404


### PR DESCRIPTION
## Summary

v2.12.0 shipped the send-dialog preview. This is the other half of that idea:
the operator editing `invoice_email` under **Settings -> Email Templates** still
has no way to see an edit except by saving over a working template and mailing a
real customer.

`POST /api/email-templates/preview` renders the text currently in the editor
against an invoice you pick. Nothing saved, nothing sent.

## Changes

- New `POST /api/email-templates/preview` taking `invoice_id`,
  `subject_template`, `body_template`.
- `template_env()` extracted from `render_template_from_db()`, so the send and
  the preview share one environment. A preview rendering under different rules
  than the mail is the same class of problem as the template and the send
  disagreeing, which is what #140 was.
- The template editor gains a **Preview** button and an invoice picker
  (`is_sales_receipt=false&limit=50` — enough to pick one to render against).
  Output lands in a `sandbox=""` iframe.

## Test plan

- [x] `pytest tests/ -q` — **2115 passed**, 47 skipped
- [x] `black --check app/ tests/` passes
- [x] `ruff check app/ tests/` passes
- [x] Manually verified the user flow described above

Skips are this machine's missing WeasyPrint/tesseract native stack, not new.

`tests/test_email_template_preview.py` covers: unsaved text renders; the saved
row is untouched; customer text is escaped; secrets stay redacted; a sandbox
escape is refused; bad input is a 400 rather than a 500; unknown invoice is a
404. The read-only claim is asserted by counting `Transaction`, `EmailLog` and
`EmailTemplate` rows either side, rather than stated.

## Security implications

The preview builds its context with `invoice_email_context()`, so
GHSA-c3v4-f43f-4wqm's redaction covers this endpoint **by construction rather
than by remembering** — a template asking for `{{ company.smtp_password }}` here
gets `********`, and there's a test pinning it. Rendering is sandboxed via the
shared `template_env()`, and output renders in a `sandbox=""` iframe.

Bad template text returns a generic 400 — a syntax error, an unknown filter, a
sandbox escape and `{{ 1/0 }}` are all just bad input from the client, and the
message doesn't echo it back.

## Two deliberate omissions

**No save-time validation.** I had written it, and removed it after
`test_a_broken_saved_template_does_not_stop_the_mail` failed. That test is
right: `{{ nope | frobnicate }}` is valid syntax with an unknown filter, Jinja
rejects it at compile time, and refusing the save would mean a bad expression
can stop an invoice going out. Degrading to the built-in body is the better
behaviour, and the preview is where an operator should find out instead.

**Not folded into `/invoices/{id}/email-preview`.** That one previews a *send*
and takes `_EmailInvoiceRequest`. Adding template overrides to it would put
operator-authored template text into the model the send route also uses, which
seemed like the wrong direction to widen.

## Database changes

- [x] No schema changes

## Documentation

- [x] `CHANGELOG.md` updated under `[Unreleased]`

## Related

Follows #140 / #142 / v2.12.0. Supersedes my #146, which I've closed — v2.12.0
covered the rest of it, and your implementation of the label fix and the note
rule is the one I'd have wanted.
