### PR TITLE
v2.12.1 — bundle the repair script (#144), with @mdornich's template preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,20 @@ to close it checked that the named file existed, which is exactly the check
 that passes while the instruction still fails. It now takes the command out
 of the message and runs it.
 
+**A template preview says what came out blank.** Some things an operator
+might type — `{{ config }}`, `{{ request }}`, anything the template sandbox
+refuses — are simply not available to an email template, so they render as
+nothing. The preview showed a working template with a hole in it and no
+reason for the hole, which is the one outcome that tells the author nothing
+at all.
+
+The preview now lists what resolved to nothing, beside the rendered output.
+The output itself is unchanged and still byte-identical to what would be
+sent, because a preview that renders under different rules is not a preview.
+Raised by the macOS QA agent, who noticed it while running a battery of
+deliberately hostile template input and pointed out that silently-empty
+deserved a decision rather than being inherited.
+
 **Repairing a damaged file no longer gets slower the more tables are
 involved.** Each attempt restarted the whole upgrade, so the work doubled
 with every table in the way: three tables took seven passes, and five would

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,20 @@ Raised by the macOS QA agent, who noticed it while running a battery of
 deliberately hostile template input and pointed out that silently-empty
 deserved a decision rather than being inherited.
 
+**And a repair that cannot finish no longer starts.** The repair used to
+clear the tables in its way and only then discover whether it could run the
+upgrade at all — so on an installed application, where it could not, the file
+was left with nothing to clear and the same problem, and the next attempt
+offered a different instruction that also could not work. A loop entered by
+following the instructions. It now loads what it needs first and, if that
+cannot work, says so while the file is still untouched.
+
+The reason it could not work on an installed application was that the repair
+ran before the application had worked out which company file it was talking
+about, so it fell back to looking for a database server that is not there.
+Found by the Windows QA agent, who first reported a different cause, tested
+it, and withdrew that half of their own report.
+
 **Repairing a damaged file no longer gets slower the more tables are
 involved.** Each attempt restarted the whole upgrade, so the work doubled
 with every table in the way: three tables took seven passes, and five would

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,13 +34,31 @@ an operator should find out instead. And this is its own endpoint rather than
 an option on the send preview, because widening a request model that a
 sending route shares is how a surface grows a capability nobody audited.
 
-**The refusal to open an older company file now names a script that exists.**
+**The refusal to open an older company file now names a command that runs.**
 Found by inspecting the published 2.12.0 artifact rather than the source: the
 message named `scripts/repair-schema.py`, and that file was not in the
 installed application. Files are bundled selectively, and the repair script
 was not among them — so the operator most likely to read that message was the
-one least likely to have the file. It ships now, on both platforms, and the
-message resolves the path that exists on the machine it is printed on.
+one least likely to have the file. It ships now on both platforms — and,
+more to the point, an installed application is told to use its own
+`--_repair-schema` option rather than a separate Python command it has no way
+to run. Both QA agents found the first attempt at this: the file was in the
+bundle and nothing on the machine could execute it, because the program code
+lives inside the executable rather than beside it.
+
+That was the fourth time one mistake has appeared in this product — an error
+telling somebody to do something they cannot do. The test that was supposed
+to close it checked that the named file existed, which is exactly the check
+that passes while the instruction still fails. It now takes the command out
+of the message and runs it.
+
+**Repairing a damaged file no longer gets slower the more tables are
+involved.** Each attempt restarted the whole upgrade, so the work doubled
+with every table in the way: three tables took seven passes, and five would
+have exceeded the limit and given up. Everything blocking is now cleared in
+one pass, so the cost is one step per table. Measured by the Windows QA
+agent, who noticed the comment in the code claimed one pass per table and the
+behaviour did not.
 
 **You can see a template edit before you save it.** Editing `invoice_email`
 under Settings -> Email Templates still meant saving over a working template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@ to close it checked that the named file existed, which is exactly the check
 that passes while the instruction still fails. It now takes the command out
 of the message and runs it.
 
+**A template preview says what came out blank, and the editor's own list of
+what you can use is now accurate.** The hint under the editor offered
+`{{ amount }}`, which does not exist and rendered as nothing, and offered
+`{{ pay_url }}` without saying it is only set when a payment provider is
+enabled — where a template using it bare would put the word "None" into a
+customer's email. It no longer can: that name is simply absent when there is
+no link, so it renders as nothing and is reported like anything else. The
+list also now mentions the one variable that makes a single template read
+correctly as both an invoice and a sales receipt, which it never advertised.
+
 **A template preview says what came out blank.** Some things an operator
 might type — `{{ config }}`, `{{ request }}`, anything the template sandbox
 refuses — are simply not available to an email template, so they render as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,15 @@ to close it checked that the named file existed, which is exactly the check
 that passes while the instruction still fails. It now takes the command out
 of the message and runs it.
 
+**And it tells the two kinds of blank apart.** Something no email template
+can ever use is reported differently from something that is available and
+simply not set for this invoice. The first version called both "not available
+to an email template" — which was wrong about the payment link, and
+contradicted the list of usable variables printed two inches above it. Raised
+by the Windows QA agent as a suggestion rather than a finding; taken because
+one message disagreeing with another message on the same screen is the defect
+this release spent its whole review closing.
+
 **A template preview says what came out blank, and the editor's own list of
 what you can use is now accurate.** The hint under the editor offered
 `{{ amount }}`, which does not exist and rendered as nothing, and offered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
+### v2.12.1 — See an email template before you save it
+
+**Preview an email template edit against a real invoice, before saving it.**
+Contributed by @mdornich. v2.12.0 added a preview to the Email Invoice
+dialog; this is the other half of the same idea. An operator editing the
+invoice email under Settings still had no way to see an edit except by
+saving over a working template and mailing a real customer to find out.
+
+`POST /api/email-templates/preview` renders the text currently in the editor
+against an invoice you pick. Nothing saved, nothing sent — asserted by
+counting rows either side rather than claimed. The preview and the mail share
+one template environment, because a preview rendering under different rules
+than the mail is the same class of problem as the template and the send
+disagreeing, which is what the previous release was about.
+
+Credentials stay redacted in the preview by construction rather than by
+remembering: it builds its context through the same helper the send does, so
+the protection added in 2.12.0 covers this endpoint without anyone having to
+notice it needed to.
+
+Two things he deliberately left out, both correctly. Validating a template at
+save time would mean a bad expression can stop an invoice going out, and
+degrading to the built-in body is the better behaviour — the preview is where
+an operator should find out instead. And this is its own endpoint rather than
+an option on the send preview, because widening a request model that a
+sending route shares is how a surface grows a capability nobody audited.
+
+**The refusal to open an older company file now names a script that exists.**
+Found by inspecting the published 2.12.0 artifact rather than the source: the
+message named `scripts/repair-schema.py`, and that file was not in the
+installed application. Files are bundled selectively, and the repair script
+was not among them — so the operator most likely to read that message was the
+one least likely to have the file. It ships now, on both platforms, and the
+message resolves the path that exists on the machine it is printed on.
+
 **You can see a template edit before you save it.** Editing `invoice_email`
 under Settings -> Email Templates still meant saving over a working template
 and mailing a real customer to find out what it looked like. The editor now

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 # Single source of truth for the application version: app/main.py reports
 # it on the FastAPI app and /health, /api/system serves it to the frontend
 # footer, and the Windows release workflow parses it for the installer.
-__version__ = "2.12.0"
+__version__ = "2.12.1"

--- a/app/main.py
+++ b/app/main.py
@@ -281,11 +281,17 @@ def _refuse_a_database_behind_head() -> None:
         from app.services.schema_repair import looks_half_upgraded
 
         if looks_half_upgraded(engine):
+            # Name the path that exists on THIS install. Frozen bundles put
+            # it under _internal/scripts; a checkout has it at scripts/.
+            # Printing the repo path at a Server Edition operator who only
+            # has the bundle is the defect #144 was about.
+            from app.services.schema_repair import repair_script_path
+
             remedy = (
                 "A server has already been started against this database "
                 "while it was behind, so `alembic upgrade head` will fail on "
                 "a table that already exists. Repair it with:\n"
-                "    python3 scripts/repair-schema.py --database-url <url>\n"
+                f"    python3 {repair_script_path()} --database-url <url>\n"
                 "which drops only the empty tables left behind and then "
                 "upgrades. Take a copy first."
             )

--- a/app/main.py
+++ b/app/main.py
@@ -285,13 +285,13 @@ def _refuse_a_database_behind_head() -> None:
             # it under _internal/scripts; a checkout has it at scripts/.
             # Printing the repo path at a Server Edition operator who only
             # has the bundle is the defect #144 was about.
-            from app.services.schema_repair import repair_script_path
+            from app.services.schema_repair import repair_command
 
             remedy = (
                 "A server has already been started against this database "
                 "while it was behind, so `alembic upgrade head` will fail on "
                 "a table that already exists. Repair it with:\n"
-                f"    python3 {repair_script_path()} --database-url <url>\n"
+                f"    {repair_command()} --database-url <url>\n"
                 "which drops only the empty tables left behind and then "
                 "upgrades. Take a copy first."
             )

--- a/app/routes/email_templates.py
+++ b/app/routes/email_templates.py
@@ -109,6 +109,7 @@ def preview_template(
 
     from app.models.invoices import Invoice
     from app.services.email_service import (
+        classify_blanks,
         invoice_email_context,
         recording_template_env,
     )
@@ -146,10 +147,14 @@ def preview_template(
     # working template with a hole in it. The body is byte-identical to what
     # would be sent — the preview would not be a preview otherwise — and the
     # names that resolved to nothing are reported beside it.
+    # Two kinds of blank, and calling them both "not available" contradicted
+    # the editor's own variable list for `pay_url` (@skytech, 2.12.1 gate).
+    blanks = list(resolved_to_nothing)
     return {
         "subject": subject,
         "html_body": body,
-        "resolved_to_nothing": list(resolved_to_nothing),
+        "resolved_to_nothing": blanks,
+        **classify_blanks(blanks),
     }
 
 

--- a/app/routes/email_templates.py
+++ b/app/routes/email_templates.py
@@ -108,7 +108,10 @@ def preview_template(
     from jinja2 import TemplateError
 
     from app.models.invoices import Invoice
-    from app.services.email_service import invoice_email_context, template_env
+    from app.services.email_service import (
+        invoice_email_context,
+        recording_template_env,
+    )
     from app.services.payments import enabled_providers
     from app.services.settings_service import get_all_settings
 
@@ -122,7 +125,7 @@ def preview_template(
         pay_url = f"{str(request.base_url).rstrip('/')}/pay/{inv.payment_token}"
 
     ctx = invoice_email_context(inv, company, pay_url=pay_url)
-    env = template_env()
+    env, resolved_to_nothing = recording_template_env()
     try:
         subject = env.from_string(data.subject_template).render(**ctx)
         body = env.from_string(data.body_template).render(**ctx)
@@ -137,7 +140,17 @@ def preview_template(
                 "variables and syntax."
             ),
         ) from exc
-    return {"subject": subject, "html_body": body}
+    # A blank where the author expected content is the one outcome that
+    # explains nothing. `{{ config }}`, `{{ request }}` and anything the
+    # sandbox refuses all render as empty, so the preview looks like a
+    # working template with a hole in it. The body is byte-identical to what
+    # would be sent — the preview would not be a preview otherwise — and the
+    # names that resolved to nothing are reported beside it.
+    return {
+        "subject": subject,
+        "html_body": body,
+        "resolved_to_nothing": list(resolved_to_nothing),
+    }
 
 
 @router.post("", response_model=EmailTemplateResponse, status_code=201)

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -10,6 +10,8 @@ from email.mime.text import MIMEText
 from email.mime.application import MIMEApplication
 from pathlib import Path
 
+from contextvars import ContextVar
+
 from jinja2 import Environment, FileSystemLoader, Undefined
 from sqlalchemy.orm import Session
 
@@ -170,6 +172,11 @@ def template_env():
     return env
 
 
+_recorded_blanks: "ContextVar[list | None]" = ContextVar(
+    "recorded_blanks", default=None
+)
+
+
 class RecordingUndefined(Undefined):
     """Renders as nothing, like the default, and remembers that it did.
 
@@ -177,21 +184,33 @@ class RecordingUndefined(Undefined):
     nothing at all. `{{ config }}`, `{{ request }}` and a name the sandbox
     refuses all resolve to undefined and render as empty — so the operator
     sees a working template with a hole in it and no reason for the hole.
-    That is the same class as an error naming a command nobody can run, which
-    this product has now shipped four times.
 
     The fix is NOT to make the preview strict. The preview must render under
     the same rules as the mail, or it is not a preview — so this behaves
-    exactly like `Undefined` and simply records what it was asked for. The
-    preview reports the list alongside the body; the send never sees it.
+    exactly like `Undefined` and only records.
+
+    **The list lives in a ContextVar, not on the class.** The first version
+    appended to a class attribute, which @skytech reproduced as cross-request
+    contamination: `preview_template` is a sync `def`, so FastAPI runs it in a
+    threadpool, and with sixteen concurrent previews three returned another
+    request's variable names and two returned none of their own. Invisible on
+    a desktop; Server Edition serves a LAN, and two bookkeepers previewing at
+    once got each other's. anyio copies the context per task, so a ContextVar
+    is isolated per request.
+
+    **Only a RENDER is recorded.** `{% if pay_url %}` asks whether something
+    is there; that is a guard doing its job, not a hole. Reporting it would
+    flag the shipped default template on every preview, which is a false
+    alarm and the fastest way to teach an operator to ignore the line.
     """
 
-    _seen: list = []
-
     def _record(self):
+        seen = _recorded_blanks.get()
+        if seen is None:
+            return
         name = self._undefined_name or "a value"
-        if name not in RecordingUndefined._seen:
-            RecordingUndefined._seen.append(name)
+        if name not in seen:
+            seen.append(name)
 
     def __str__(self):  # noqa: D105 — Jinja renders through this
         self._record()
@@ -201,25 +220,19 @@ class RecordingUndefined(Undefined):
         self._record()
         return ""
 
-    def __iter__(self):
-        self._record()
-        return iter(())
-
-    def __bool__(self):
-        self._record()
-        return False
-
 
 def recording_template_env():
-    """`template_env()` plus a note of everything that resolved to nothing.
+    """`template_env()` plus a per-request note of what rendered as nothing.
 
-    Returns (env, seen) where `seen` is filled during render. Used only by the
-    preview — the send path must not pay for this or behave differently.
+    Returns (env, seen). `seen` fills during render and belongs to this
+    request only — the send path must not pay for this, and neither must
+    another request.
     """
     env = template_env()
-    RecordingUndefined._seen = []
+    seen: list[str] = []
+    _recorded_blanks.set(seen)
     env.undefined = RecordingUndefined
-    return env, RecordingUndefined._seen
+    return env, seen
 
 
 def invoice_email_label(invoice, company_settings: dict) -> str:
@@ -258,7 +271,14 @@ def invoice_email_context(invoice, company_settings: dict, pay_url: str = None) 
         "customer_name": (
             invoice.customer.name if invoice.customer else terms("Customer")
         ),
-        "pay_url": pay_url,
+        # Omitted rather than None when no provider is enabled. `{{ pay_url }}`
+        # used to render the literal text "None" into a customer's email, and
+        # `resolved_to_nothing` could not flag it because None is a real
+        # value. Undefined renders as empty, is reported, and `{% if pay_url %}`
+        # — which the shipped default uses — is still correctly falsy.
+        # @skytech, 2.12.1 gate: the one gap the feature is shaped to catch
+        # and structurally could not.
+        **({"pay_url": pay_url} if pay_url else {}),
         "doc_label": invoice_email_label(invoice, company_settings),
         "terms": terms,
     }

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -10,7 +10,7 @@ from email.mime.text import MIMEText
 from email.mime.application import MIMEApplication
 from pathlib import Path
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, Undefined
 from sqlalchemy.orm import Session
 
 from app.models.email_log import EmailLog
@@ -168,6 +168,58 @@ def template_env():
     env.filters["currency"] = _format_currency
     env.filters["fdate"] = _format_date
     return env
+
+
+class RecordingUndefined(Undefined):
+    """Renders as nothing, like the default, and remembers that it did.
+
+    A preview that renders a blank is the one outcome that tells its author
+    nothing at all. `{{ config }}`, `{{ request }}` and a name the sandbox
+    refuses all resolve to undefined and render as empty — so the operator
+    sees a working template with a hole in it and no reason for the hole.
+    That is the same class as an error naming a command nobody can run, which
+    this product has now shipped four times.
+
+    The fix is NOT to make the preview strict. The preview must render under
+    the same rules as the mail, or it is not a preview — so this behaves
+    exactly like `Undefined` and simply records what it was asked for. The
+    preview reports the list alongside the body; the send never sees it.
+    """
+
+    _seen: list = []
+
+    def _record(self):
+        name = self._undefined_name or "a value"
+        if name not in RecordingUndefined._seen:
+            RecordingUndefined._seen.append(name)
+
+    def __str__(self):  # noqa: D105 — Jinja renders through this
+        self._record()
+        return ""
+
+    def __html__(self):
+        self._record()
+        return ""
+
+    def __iter__(self):
+        self._record()
+        return iter(())
+
+    def __bool__(self):
+        self._record()
+        return False
+
+
+def recording_template_env():
+    """`template_env()` plus a note of everything that resolved to nothing.
+
+    Returns (env, seen) where `seen` is filled during render. Used only by the
+    preview — the send path must not pay for this or behave differently.
+    """
+    env = template_env()
+    RecordingUndefined._seen = []
+    env.undefined = RecordingUndefined
+    return env, RecordingUndefined._seen
 
 
 def invoice_email_label(invoice, company_settings: dict) -> str:

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -221,6 +221,42 @@ class RecordingUndefined(Undefined):
         return ""
 
 
+# Names a template MAY use that are simply absent for this particular
+# invoice, as opposed to names no email template can ever use.
+#
+# @skytech, 2.12.1 gate: the preview banner said `pay_url` was "not available
+# to an email template" while the hint line two inches above said it IS
+# available, conditional on a payment provider. Two messages about one
+# variable, disagreeing — which is the class this whole gate has been about,
+# in the smallest possible form.
+CONDITIONAL_TEMPLATE_NAMES = {
+    "pay_url": (
+        "only set when a payment provider is enabled — guard it with "
+        "{% if pay_url %}"
+    ),
+}
+
+
+def classify_blanks(names) -> dict:
+    """Split recorded blanks into the two kinds an author needs told apart.
+
+    `{{ config }}` can never work. `{{ pay_url }}` works and is not set for
+    this invoice. Telling an operator the second is "not available" is wrong,
+    and it contradicts the editor's own variable list.
+    """
+    unavailable, conditional = [], []
+    for name in names:
+        (conditional if name in CONDITIONAL_TEMPLATE_NAMES else unavailable).append(
+            name
+        )
+    return {
+        "unavailable": unavailable,
+        "conditional": [
+            {"name": n, "why": CONDITIONAL_TEMPLATE_NAMES[n]} for n in conditional
+        ],
+    }
+
+
 def recording_template_env():
     """`template_env()` plus a per-request note of what rendered as nothing.
 

--- a/app/services/schema_repair.py
+++ b/app/services/schema_repair.py
@@ -112,6 +112,34 @@ def repair(url: str, dry_run: bool = False) -> RepairResult:
         started = _current_revision(engine)
         result = RepairResult(ok=False, started_at=started, now_at=started)
 
+        # Prove the upgrade CAN run before destroying anything.
+        #
+        # @skytech, 2.12.1 gate: on a frozen build the migration import died
+        # on psycopg2 — and the drop phase had already completed. So the file
+        # was left worse than it started: nothing to drop any more, so the
+        # next start reports it as an ordinary old database and offers
+        # `alembic upgrade head`, which still cannot run. A loop, entered by
+        # following the instructions.
+        #
+        # A repair whose first act is irreversible and whose second act may
+        # fail for an unrelated reason is not a repair. Load the machinery
+        # first; if that cannot work, say so while the file is still intact.
+        if not dry_run:
+            try:
+                from alembic.script import ScriptDirectory
+
+                ScriptDirectory.from_config(_alembic_cfg(url)).get_current_head()
+                import app.database  # noqa: F401 — the import that failed
+            except Exception as exc:  # noqa: BLE001 — reported, not raised
+                result.message = (
+                    f"cannot run migrations here, so nothing was changed: "
+                    f"{type(exc).__name__}: {exc}. The database is exactly as "
+                    f"it was. If this is an installed build, run the repair "
+                    f"through the application itself rather than a separate "
+                    f"interpreter."
+                )
+                return result
+
         # Clear everything in the way in ONE pass, before running anything.
         #
         # @skytech measured the retry loop and it is 2**N - 1 drops, not N:

--- a/app/services/schema_repair.py
+++ b/app/services/schema_repair.py
@@ -40,8 +40,10 @@ _ALREADY_EXISTS = re.compile(
     r'(?:table|relation)\s+"?([A-Za-z_][A-Za-z0-9_]*)"?\s+already exists', re.I
 )
 
-# One drop per pending revision is already generous; this only bounds a
-# pathological loop, it is not an expected number.
+# A net, not the mechanism. `repair()` clears the known blockers in one pass
+# first, so this loop should normally run once. It used to BE the mechanism,
+# and cost 2**N - 1 rounds because each retry re-ran the migration from the
+# start and SQLite recreated what the previous round had dropped.
 MAX_ROUNDS = 25
 
 
@@ -54,28 +56,25 @@ class RepairResult:
     message: str = ""
 
 
-def repair_script_path() -> str:
-    """Where `repair-schema.py` actually is on this install.
+def repair_command() -> str:
+    """The command that actually works on THIS install.
 
-    A frozen bundle puts data files under `sys._MEIPASS`, so the script lives
-    at `_internal/scripts/repair-schema.py` rather than at `scripts/` — and
-    the startup refusal that names it is read mostly by Server Edition
-    operators, who may only have the bundle (#144). Falls back to the
-    repo-relative path, which is right for a checkout and is also the least
-    misleading thing to print if the file is missing entirely.
+    Frozen, there is no interpreter to run a bundled script with and
+    `app.services` is not importable from disk — so the remedy is the
+    launcher's own hidden flag, which runs inside the frozen runtime. From a
+    checkout, the script is the plain thing to say.
+
+    2.12.1 named a bundled script and both QA agents found nothing on the
+    machine could execute it. Naming a path that EXISTS is not the same as
+    naming an instruction that RUNS, and the test asserts the second now.
     """
     import sys
 
-    base = getattr(sys, "_MEIPASS", None)
-    if base:
-        bundled = Path(base) / "scripts" / "repair-schema.py"
-        if bundled.exists():
-            return str(bundled)
-    return str(
-        (ROOT / "scripts" / "repair-schema.py").resolve()
-        if (ROOT / "scripts" / "repair-schema.py").exists()
-        else "scripts/repair-schema.py"
-    )
+    if getattr(sys, "frozen", False):
+        exe = Path(sys.executable).name
+        return f"{exe} --_repair-schema"
+    script = ROOT / "scripts" / "repair-schema.py"
+    return f"python3 {script if script.exists() else 'scripts/repair-schema.py'}"
 
 
 def _alembic_cfg(url: str):
@@ -112,6 +111,43 @@ def repair(url: str, dry_run: bool = False) -> RepairResult:
     try:
         started = _current_revision(engine)
         result = RepairResult(ok=False, started_at=started, now_at=started)
+
+        # Clear everything in the way in ONE pass, before running anything.
+        #
+        # @skytech measured the retry loop and it is 2**N - 1 drops, not N:
+        # each round re-runs the migration from the start and SQLite DDL is
+        # not transactional, so the tables dropped in earlier rounds are
+        # recreated before the next failure. Today's three-table revision
+        # burns seven rounds of twenty-five; a five-table revision needs
+        # thirty-one and the tool gives up — after dropping tables, and
+        # re-running will not converge because it restarts the same doubling.
+        #
+        # The pending revisions already tell us which tables they will create.
+        # Drop the ones that are present and empty, once, and the upgrade then
+        # runs straight through. The loop below stays as a net for anything
+        # this pass does not foresee.
+        if started and not dry_run:
+            try:
+                pending = tables_pending_revisions_would_create(url, started)
+                present = set(inspect(engine).get_table_names())
+                for table in sorted(pending & present):
+                    rows = _row_count(engine, table)
+                    if rows:
+                        result.message = (
+                            f"refusing to repair: '{table}' is in the way of "
+                            f"the upgrade but holds {rows} row(s), so it was "
+                            f"not left behind by create_all. This needs a "
+                            f"person."
+                        )
+                        return result
+                    logger.warning("schema repair: dropping empty table %s", table)
+                    with engine.begin() as conn:
+                        conn.execute(text(f'DROP TABLE "{table}"'))
+                    result.dropped.append(table)
+            except Exception:
+                # The retry loop can still get there; do not fail the repair
+                # because the shortcut could not read the migration scripts.
+                logger.exception("could not pre-clear blocking tables")
 
         for _ in range(MAX_ROUNDS):
             try:

--- a/app/services/schema_repair.py
+++ b/app/services/schema_repair.py
@@ -54,6 +54,30 @@ class RepairResult:
     message: str = ""
 
 
+def repair_script_path() -> str:
+    """Where `repair-schema.py` actually is on this install.
+
+    A frozen bundle puts data files under `sys._MEIPASS`, so the script lives
+    at `_internal/scripts/repair-schema.py` rather than at `scripts/` — and
+    the startup refusal that names it is read mostly by Server Edition
+    operators, who may only have the bundle (#144). Falls back to the
+    repo-relative path, which is right for a checkout and is also the least
+    misleading thing to print if the file is missing entirely.
+    """
+    import sys
+
+    base = getattr(sys, "_MEIPASS", None)
+    if base:
+        bundled = Path(base) / "scripts" / "repair-schema.py"
+        if bundled.exists():
+            return str(bundled)
+    return str(
+        (ROOT / "scripts" / "repair-schema.py").resolve()
+        if (ROOT / "scripts" / "repair-schema.py").exists()
+        else "scripts/repair-schema.py"
+    )
+
+
 def _alembic_cfg(url: str):
     from alembic.config import Config
 

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -774,7 +774,9 @@ const SettingsPage = {
                 </div>
                 <div style="font-size:10px; color:var(--text-muted); margin:8px 0;">
                     Variables: {{ invoice.invoice_number }}, {{ invoice.total }}, {{ invoice.due_date }}, {{ customer_name }},
-                    {{ company.company_name }}, {{ pay_url }}, {{ amount }}. Filters: | currency, | fdate
+                    {{ company.company_name }}, {{ doc_label }}, {{ pay_url }}. Filters: | currency, | fdate
+                    <br><span style="opacity:.8;">{{ doc_label }} reads &ldquo;Invoice&rdquo; or &ldquo;Sales Receipt&rdquo; to match the document.
+                    {{ pay_url }} is only set when a payment provider is enabled &mdash; guard it with {% if pay_url %}.</span>
                 </div>
                 ${t.template_type === 'invoice' ? `<div style="margin-top:12px;">
                     <label>Preview against ${T('invoice')}

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -808,12 +808,24 @@ const SettingsPage = {
             // that explains nothing. The server reports what resolved to
             // nothing; say so next to the preview rather than leaving them
             // looking at a hole.
-            const missing = p.resolved_to_nothing || [];
-            const note = missing.length
+            // Two kinds of blank. Telling an operator that pay_url is "not
+            // available" contradicted the variable list two inches above,
+            // which says it is available and conditional.
+            const unavailable = p.unavailable || [];
+            const conditional = p.conditional || [];
+            const lines = [];
+            if (unavailable.length) {
+                lines.push(`<strong>Not available to an email template:</strong>
+                    ${unavailable.map(escapeHtml).join(', ')} — these came out blank and
+                    the email would send with the same gaps.`);
+            }
+            for (const c of conditional) {
+                lines.push(`<strong>${escapeHtml(c.name)} is not set for this ${T('Invoice').toLowerCase()}:</strong>
+                    ${escapeHtml(c.why)}.`);
+            }
+            const note = lines.length
                 ? `<p class="form-hint" style="margin-top:8px;color:var(--text-warning,#92400e);">
-                       <strong>Rendered as nothing:</strong> ${missing.map(escapeHtml).join(', ')}.
-                       These are not available to an email template, so they came out blank —
-                       the email would send with the same gaps.</p>`
+                       ${lines.join('<br>')}</p>`
                 : '';
             out.innerHTML = `<p style="margin-top:8px;"><strong>Subject:</strong> ${escapeHtml(p.subject)}</p>
                 ${note}

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -802,7 +802,19 @@ const SettingsPage = {
                 subject_template: form.elements.subject_template.value,
                 body_template: form.elements.body_template.value,
             });
+            // A blank where the author expected content is the one outcome
+            // that explains nothing. The server reports what resolved to
+            // nothing; say so next to the preview rather than leaving them
+            // looking at a hole.
+            const missing = p.resolved_to_nothing || [];
+            const note = missing.length
+                ? `<p class="form-hint" style="margin-top:8px;color:var(--text-warning,#92400e);">
+                       <strong>Rendered as nothing:</strong> ${missing.map(escapeHtml).join(', ')}.
+                       These are not available to an email template, so they came out blank —
+                       the email would send with the same gaps.</p>`
+                : '';
             out.innerHTML = `<p style="margin-top:8px;"><strong>Subject:</strong> ${escapeHtml(p.subject)}</p>
+                ${note}
                 <iframe id="email-template-rendered" sandbox="" title="Template preview" style="width:100%;height:320px;border:1px solid var(--gray-300);background:white;"></iframe>`;
             const frame = document.getElementById('email-template-rendered');
             if (frame) frame.srcdoc = p.html_body;

--- a/app/static/whats-new.json
+++ b/app/static/whats-new.json
@@ -1,4 +1,11 @@
 {
+  "2.12.1": {
+    "title": "See an email template before you save it",
+    "items": [
+      "Preview an email template edit against a real invoice before saving it. Editing the invoice email used to mean saving over a working template and mailing a customer to find out what it looked like — contributed by mdornich",
+      "The message shown when the app refuses to open a company file older than itself now names a repair script that is actually there. It named a path that was not included in the installed app"
+    ]
+  },
   "2.12.0": {
     "title": "Your chart, your templates, your clipboard",
     "items": [

--- a/desktop_launcher.py
+++ b/desktop_launcher.py
@@ -1388,8 +1388,6 @@ def _repair_schema(argv) -> int:
     Runs the repair in-process so it works from a frozen bundle, where a
     separate interpreter is neither present nor able to import `app`.
     """
-    from app.services.schema_repair import repair
-
     url = None
     for i, a in enumerate(argv):
         if a == "--database-url" and i + 1 < len(argv):
@@ -1402,6 +1400,23 @@ def _repair_schema(argv) -> int:
             file=sys.stderr,
         )
         return 2
+
+    # BEFORE importing anything that touches app.config, and that is the
+    # whole fix. `app/config.py` reads BASE_DIR/.env — inside the bundle when
+    # frozen, not the user's data dir — so DATABASE_URL is unset, falls back
+    # to the PostgreSQL default, and `app/database.py` creates its engine AT
+    # MODULE SCOPE. `migrations/env.py` imports that module, so the import
+    # died on psycopg2 before the migration ever looked at the URL we passed.
+    #
+    # The normal startup path already points DATABASE_URL at the chosen
+    # company file before serving; this entry point ran before that step and
+    # inherited none of it. @skytech traced it on the 2.12.1 gate, and it was
+    # the FIFTH appearance of one class: an instruction the reader cannot
+    # carry out. Their own first diagnosis was a cross-database hazard, which
+    # they tested and withdrew — the real cause is smaller and this is it.
+    os.environ["DATABASE_URL"] = url
+
+    from app.services.schema_repair import repair
 
     result = repair(url, dry_run="--dry-run" in argv)
     print(f"revision before : {result.started_at}")

--- a/desktop_launcher.py
+++ b/desktop_launcher.py
@@ -1382,6 +1382,36 @@ def run_smoke_test(port: int = 3999) -> int:
     return 0
 
 
+def _repair_schema(argv) -> int:
+    """`SlowBooksPro --_repair-schema --database-url <url> [--dry-run]`.
+
+    Runs the repair in-process so it works from a frozen bundle, where a
+    separate interpreter is neither present nor able to import `app`.
+    """
+    from app.services.schema_repair import repair
+
+    url = None
+    for i, a in enumerate(argv):
+        if a == "--database-url" and i + 1 < len(argv):
+            url = argv[i + 1]
+        elif a.startswith("--database-url="):
+            url = a.split("=", 1)[1]
+    if not url:
+        print(
+            "usage: SlowBooksPro --_repair-schema --database-url <url> [--dry-run]",
+            file=sys.stderr,
+        )
+        return 2
+
+    result = repair(url, dry_run="--dry-run" in argv)
+    print(f"revision before : {result.started_at}")
+    print(f"revision now    : {result.now_at}")
+    if result.dropped:
+        print(f"dropped (empty) : {', '.join(result.dropped)}")
+    print(f"result          : {'OK' if result.ok else 'FAILED'} - {result.message}")
+    return 0 if result.ok else 1
+
+
 def main() -> int:
     # Make every stdio write total BEFORE argparse can print anything.
     # A frozen console=False build launched with redirected stdio (any
@@ -1410,6 +1440,22 @@ def main() -> int:
     # argparse must never meet, so handle it before parsing.
     if "--_serve" in sys.argv:
         return _serve()
+
+    # Same reason, same shape: the repair has to run INSIDE the frozen
+    # runtime, because that is the only place `app.services` is importable.
+    #
+    # 2.12.1 shipped scripts/repair-schema.py in the bundle and the startup
+    # refusal named it — and both QA agents found that nothing on the machine
+    # can execute it. `_internal/app/` holds only static and templates; the
+    # Python modules live inside the executable. On Windows the printed
+    # `python3` is the Microsoft Store alias stub, zero bytes.
+    #
+    # That was the FOURTH appearance of one class: an error telling the
+    # reader to do something they cannot do. The test I added asserted the
+    # named path EXISTS, which is exactly the assertion that passes while the
+    # instruction still fails. It executes it now.
+    if "--_repair-schema" in sys.argv:
+        return _repair_schema(sys.argv)
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(

--- a/packaging/macos/SlowBooksPro-mac.spec
+++ b/packaging/macos/SlowBooksPro-mac.spec
@@ -61,6 +61,10 @@ datas += _tree("app/templates", "app/templates")
 # they must exist on disk in the bundle, not just inside the PYZ.
 datas += _tree("migrations", "migrations")
 
+# Named by app.main's startup refusal for a half-upgraded database (#132).
+# See #144: the message has to point somewhere the reader can actually go.
+datas += [(os.path.join(ROOT, "scripts", "repair-schema.py"), "scripts")]
+
 # PyInstaller's WeasyPrint hook uses ctypes.util.find_library(), which does
 # not find Homebrew libraries on Apple Silicon. Seed the six libraries that
 # WeasyPrint dlopens; PyInstaller follows and rewrites their dependency

--- a/packaging/windows/SlowBooksPro.spec
+++ b/packaging/windows/SlowBooksPro.spec
@@ -59,6 +59,13 @@ datas += _tree("migrations", "migrations")
 # portable copy can register the startup task without downloading anything:
 #   _internal\scripts\windows\serveredition-install.ps1
 datas += _tree("scripts/windows", "scripts/windows")
+# repair-schema.py is named by app.main's startup refusal when it meets a
+# half-upgraded database (#132). Server Edition is precisely the deployment
+# shape that refusal exists for, and its install scripts ship in this bundle
+# — so the operator most likely to read the message was the one least likely
+# to have the file (#144). An error naming a path the reader cannot reach is
+# the same defect as "deactivate it instead" with no deactivate control.
+datas += [(os.path.join(ROOT, "scripts", "repair-schema.py"), "scripts")]
 
 # The WeasyPrint DLL set staged by CI (empty when building without it, so a
 # local `pyinstaller SlowBooksPro.spec` still produces a testable bundle).

--- a/tests/test_email_template_preview.py
+++ b/tests/test_email_template_preview.py
@@ -183,3 +183,90 @@ def test_the_editor_shows_it(client):
     )
     assert "resolved_to_nothing" in js
     assert "Rendered as nothing" in js
+
+
+def test_two_renders_at_once_do_not_see_each_others_blanks():
+    """@skytech reproduced cross-request contamination in the first version:
+    the recorder appended to a **class attribute**, and `preview_template` is
+    a sync `def`, so FastAPI runs it in a threadpool. With sixteen concurrent
+    previews, three returned another request's variable names and two
+    returned none of their own. Invisible on a desktop; **Server Edition
+    serves a LAN**, and two bookkeepers previewing at once got each other's.
+
+    Driven at the renderer rather than through the test client on purpose.
+    The client fixture shares one in-memory SQLite connection via StaticPool,
+    so eight threads through it break inside SQLAlchemy's result handling —
+    a failure about the harness, not the product. An earlier version of this
+    test did exactly that: it passed alone and failed in the full suite,
+    which is a flaky test, which is worse than no test.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    from app.services.email_service import recording_template_env
+
+    def render(tag):
+        env, seen = recording_template_env()
+        names = [f"zz_{tag}_{i}" for i in range(40)]
+        body = "".join("{{ %s }}" % n for n in names)
+        env.from_string(body).render()
+        return tag, list(seen)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(render, range(16)))
+
+    for tag, seen in results:
+        assert seen, f"render {tag} reported nothing of its own"
+        foreign = [n for n in seen if not n.startswith(f"zz_{tag}_")]
+        assert not foreign, f"render {tag} saw another's names: {foreign[:3]}"
+        assert len(seen) == 40, f"render {tag} reported {len(seen)} of its 40"
+
+
+def test_a_guard_is_not_reported_as_a_hole(client, db_session, invoice):
+    """`{% if pay_url %}` asks whether something is there. That is a guard
+    doing its job, not a blank an author needs explaining — and the shipped
+    default template uses exactly that, so reporting it would raise a false
+    alarm on every preview and teach operators to ignore the line."""
+    r = _preview(client, invoice.id, body="{% if pay_url %}<p>Pay</p>{% endif %}")
+    assert r.status_code == 200, r.text
+    assert r.json()["resolved_to_nothing"] == []
+
+
+def test_pay_url_does_not_render_the_word_None(client, db_session, invoice):
+    """It used to be passed as `None` when no provider is enabled, so a bare
+    `{{ pay_url }}` mailed customers the literal text "None" — and
+    `resolved_to_nothing` could not flag it, because None is a real value.
+    Omitted from the context now: renders empty, and is reported."""
+    r = _preview(client, invoice.id, body="<p>Pay: {{ pay_url }}</p>")
+    assert r.status_code == 200, r.text
+    out = r.json()
+    assert "None" not in out["html_body"], out["html_body"]
+    assert "pay_url" in out["resolved_to_nothing"]
+
+
+def test_the_editor_hint_only_advertises_variables_that_exist(
+    client, db_session, invoice
+):
+    """@skytech found `{{ amount }}` in the editor's own hint line and not in
+    the context, so an operator following the product's hint was told by the
+    product that the hint was wrong. Every name the hint offers is rendered
+    here and must not come back as a blank."""
+    import re
+    from pathlib import Path
+
+    js = (Path(__file__).resolve().parents[1] / "app/static/js/settings.js").read_text(
+        encoding="utf-8"
+    )
+    hint = js[js.index("Variables:") : js.index("Filters:")]
+    names = re.findall(r"\{\{\s*([A-Za-z_][\w.]*)", hint)
+    assert names, "could not read the hint line"
+
+    body = "".join("<p>%s = {{ %s }}</p>" % (n, n) for n in names)
+    r = _preview(client, invoice.id, body=body)
+    assert r.status_code == 200, r.text
+    blank = [n for n in r.json()["resolved_to_nothing"]]
+    # pay_url is legitimately absent without a payment provider, and the hint
+    # now says so in the same breath.
+    unexpected = [n for n in blank if n != "pay_url"]
+    assert (
+        not unexpected
+    ), f"the editor advertises {unexpected}, which render as nothing"

--- a/tests/test_email_template_preview.py
+++ b/tests/test_email_template_preview.py
@@ -131,3 +131,55 @@ def test_preview_rejects_bad_input_as_400_not_500(client, db_session, invoice):
 
 def test_preview_404s_for_an_unknown_invoice(client, db_session):
     assert _preview(client, 999999).status_code == 404
+
+
+# ── A blank is the one outcome that explains nothing ─────────────────────
+
+
+def test_the_preview_names_what_rendered_as_nothing(client, db_session, invoice):
+    """Raised by @macbase1 on the 2.12.1 gate.
+
+    `{{ config }}`, `{{ request }}` and anything the sandbox refuses all
+    resolve to undefined and render as **empty**, with a 200. The author sees
+    a working template with a hole in it and no reason for the hole — which
+    is the same class as an error naming a command nobody can run, a mistake
+    this product has now shipped four times.
+
+    The body stays byte-identical to what would be sent; it would not be a
+    preview otherwise. What changes is that the names are reported beside it.
+    """
+    r = _preview(client, invoice.id, body="<p>{{ config }}{{ request }}</p>")
+    assert r.status_code == 200, r.text
+    out = r.json()
+    assert set(out["resolved_to_nothing"]) >= {"config", "request"}
+
+
+def test_a_template_that_renders_reports_nothing_missing(client, db_session, invoice):
+    """The control. Without it, a list that is always full passes the test
+    above for the wrong reason."""
+    r = _preview(
+        client,
+        invoice.id,
+        body="<p>{{ invoice.invoice_number }} {{ customer_name }}</p>",
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["resolved_to_nothing"] == []
+
+
+def test_the_body_is_unchanged_by_the_reporting(client, db_session, invoice):
+    """The preview must render under the same rules as the mail. Recording
+    what vanished must not make it render differently."""
+    r = _preview(client, invoice.id, body="<p>before{{ config }}after</p>")
+    assert r.status_code == 200
+    assert "<p>beforeafter</p>" in r.json()["html_body"]
+
+
+def test_the_editor_shows_it(client):
+    """Server-side only would leave the author looking at the same hole."""
+    from pathlib import Path
+
+    js = (Path(__file__).resolve().parents[1] / "app/static/js/settings.js").read_text(
+        encoding="utf-8"
+    )
+    assert "resolved_to_nothing" in js
+    assert "Rendered as nothing" in js

--- a/tests/test_email_template_preview.py
+++ b/tests/test_email_template_preview.py
@@ -181,8 +181,12 @@ def test_the_editor_shows_it(client):
     js = (Path(__file__).resolve().parents[1] / "app/static/js/settings.js").read_text(
         encoding="utf-8"
     )
-    assert "resolved_to_nothing" in js
-    assert "Rendered as nothing" in js
+    # The classified fields, since the banner now tells the two kinds of
+    # blank apart rather than calling both "not available".
+    assert "p.unavailable" in js
+    assert "p.conditional" in js
+    assert "Not available to an email template" in js
+    assert "is not set for this" in js
 
 
 def test_two_renders_at_once_do_not_see_each_others_blanks():
@@ -241,6 +245,12 @@ def test_pay_url_does_not_render_the_word_None(client, db_session, invoice):
     out = r.json()
     assert "None" not in out["html_body"], out["html_body"]
     assert "pay_url" in out["resolved_to_nothing"]
+    # And it is reported as CONDITIONAL, not as unavailable — the editor's
+    # own variable list says pay_url is available, so calling it unavailable
+    # would have the product contradicting itself two inches apart.
+    assert [c["name"] for c in out["conditional"]] == ["pay_url"]
+    assert "pay_url" not in out["unavailable"]
+    assert "payment provider" in out["conditional"][0]["why"]
 
 
 def test_the_editor_hint_only_advertises_variables_that_exist(
@@ -270,3 +280,46 @@ def test_the_editor_hint_only_advertises_variables_that_exist(
     assert (
         not unexpected
     ), f"the editor advertises {unexpected}, which render as nothing"
+
+
+def test_a_name_no_template_can_use_is_reported_as_unavailable(
+    client, db_session, invoice
+):
+    """The other side of the split. `config` genuinely cannot work, and
+    saying so is correct — the defect was applying that sentence to a
+    variable the editor advertises."""
+    r = _preview(client, invoice.id, body="<p>{{ config }}</p>")
+    assert r.status_code == 200, r.text
+    out = r.json()
+    assert out["unavailable"] == ["config"]
+    assert out["conditional"] == []
+
+
+def test_the_banner_does_not_contradict_the_editors_variable_list(
+    client, db_session, invoice
+):
+    """@skytech, 2.12.1 gate. Every name the editor advertises must be
+    reported as conditional or not reported at all — never as "not available
+    to an email template", which is what the banner used to say about
+    `pay_url` while the hint line above called it available.
+
+    Read out of the editor rather than hardcoded, so correcting one and not
+    the other fails here instead of shipping."""
+    import re
+    from pathlib import Path
+
+    js = (Path(__file__).resolve().parents[1] / "app/static/js/settings.js").read_text(
+        encoding="utf-8"
+    )
+    hint = js[js.index("Variables:") : js.index("Filters:")]
+    advertised = {
+        n.split(".")[0] for n in re.findall(r"\{\{\s*([A-Za-z_][\w.]*)", hint)
+    }
+
+    body = "".join("<p>{{ %s }}</p>" % n for n in sorted(advertised))
+    out = _preview(client, invoice.id, body=body).json()
+    wrongly_unavailable = [n for n in out["unavailable"] if n in advertised]
+    assert not wrongly_unavailable, (
+        f"the editor advertises {wrongly_unavailable} and the preview calls "
+        f"them unavailable; the product is contradicting itself"
+    )

--- a/tests/test_schema_repair.py
+++ b/tests/test_schema_repair.py
@@ -205,24 +205,121 @@ def test_the_startup_refusal_still_says_upgrade_for_an_ordinary_old_file(
 # ── #144: the message must name a path that exists ───────────────────────
 
 
-def test_the_refusal_names_a_path_that_exists():
-    """Found during check 0 on the published v2.12.0 artifact.
+def test_the_refusal_names_a_command_that_actually_runs(tmp_path, monkeypatch):
+    """Take the command OUT of the refusal message and execute it.
 
-    The guard printed `scripts/repair-schema.py`, and that file was **not in
-    the bundle** — `scripts/` ships selectively and the zip carried only the
-    three Server Edition PowerShell files. Server Edition is precisely the
-    deployment shape the half-upgraded branch exists for, so the operator
-    most likely to read the message was the one least likely to have the
-    file. An error naming a path the reader cannot reach is the same defect
-    as #139's "deactivate it instead" with no deactivate control.
+    @macbase1's framing, and it is the reason this is written this way:
+
+        it does not ask "is repair-schema.py in the bundle". It takes the
+        path out of the refusal message, stats it, and then executes it — so
+        any future message naming any path is measured the same way.
+
+    2.12.1 shipped the script and named it, and both agents found nothing on
+    the machine could run it: `_internal/app/` holds only static and
+    templates, and on Windows the printed `python3` is the Store alias stub.
+    My test asserted the named path **existed** — which is exactly the
+    assertion that passes while the instruction still fails. Fourth
+    appearance of that class, inside the fix meant to close it.
     """
-    from pathlib import Path
+    import re
+    import subprocess
+    import sys
 
-    from app.services.schema_repair import repair_script_path
+    import app.main as main
 
-    assert Path(
-        repair_script_path()
-    ).exists(), "the startup refusal names a script that is not there"
+    db, _ = _half_upgraded(tmp_path, name="from_message.db")
+    monkeypatch.setattr(main, "engine", create_engine(f"sqlite:///{db}"))
+    with pytest.raises(RuntimeError) as e:
+        main._refuse_a_database_behind_head()
+    message = str(e.value)
+
+    # The line the operator is told to type.
+    line = [ln.strip() for ln in message.splitlines() if "--database-url" in ln]
+    assert line, f"the refusal names no command:\n{message}"
+    command = line[0]
+
+    m = re.match(r"python3?\s+(\S.*?)\s+--database-url", command)
+    assert m, f"not a runnable python invocation on a checkout: {command!r}"
+    script = Path(m.group(1))
+    assert script.exists(), f"the refusal names {script}, which is not there"
+
+    # And it works when run exactly as instructed.
+    out = subprocess.run(
+        [sys.executable, str(script), "--database-url", f"sqlite:///{db}"],
+        capture_output=True,
+        text=True,
+        cwd=str(ROOT),
+    )
+    assert out.returncode == 0, out.stdout + out.stderr
+    assert _rev(db) == _head(), "the command ran and did not repair the file"
+
+
+def test_a_frozen_build_is_told_to_use_the_launcher(monkeypatch):
+    """There is no interpreter inside a bundle and `app` is not importable
+    from disk, so a frozen install is given the launcher's own flag instead of
+    a python invocation that cannot work."""
+    import sys
+
+    from app.services import schema_repair
+
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", "/Apps/SlowBooksPro.exe", raising=False)
+    cmd = schema_repair.repair_command()
+    assert cmd == "SlowBooksPro.exe --_repair-schema"
+    assert "python" not in cmd
+
+
+def test_the_launcher_exposes_that_flag():
+    """The other half: the flag has to exist, and be handled before argparse
+    like `--_serve`, or the message names something the binary rejects."""
+    src = (ROOT / "desktop_launcher.py").read_text(encoding="utf-8")
+    assert '"--_repair-schema" in sys.argv' in src
+    assert "def _repair_schema(" in src
+    # Before argparse, same as --_serve.
+    assert src.index('"--_repair-schema" in sys.argv') < src.index(
+        "parser = argparse.ArgumentParser"
+    )
+
+
+def test_the_repair_is_linear_in_blocking_tables(tmp_path):
+    """@skytech measured the old loop at 2**N - 1 drops, not N: every retry
+    re-ran the migration from the start and SQLite, whose DDL is not
+    transactional, recreated what the last round dropped. Three tables cost
+    seven rounds of twenty-five; five would need thirty-one and give up.
+
+    The blockers are cleared in one pass now, so N tables cost N drops."""
+    from sqlalchemy import inspect as _inspect
+
+    from app.database import Base
+    from app.services.schema_repair import (
+        repair,
+        tables_pending_revisions_would_create,
+    )
+
+    pending = sorted(
+        tables_pending_revisions_would_create(
+            "sqlite:///" + str(tmp_path / "probe.db"), "e7f8a9b0c1d2"
+        )
+    )
+    assert len(pending) >= 2, "need a multi-table revision to measure this"
+
+    from alembic import command
+
+    for n in range(1, len(pending) + 1):
+        db = tmp_path / f"linear{n}.db"
+        command.upgrade(_cfg(db), "e7f8a9b0c1d2")
+        engine = create_engine(f"sqlite:///{db}")
+        for name in pending[:n]:
+            Base.metadata.tables[name].create(bind=engine)
+        assert len(set(_inspect(engine).get_table_names()) & set(pending)) == n
+        engine.dispose()
+
+        result = repair(f"sqlite:///{db}")
+        assert result.ok, result.message
+        assert len(result.dropped) == n, (
+            f"{n} blocking tables cost {len(result.dropped)} drops; the "
+            f"one-pass clearing has regressed to the retry loop"
+        )
 
 
 def test_both_specs_ship_the_repair_script():
@@ -238,19 +335,3 @@ def test_both_specs_ship_the_repair_script():
     ):
         src = (root / spec).read_text(encoding="utf-8")
         assert "repair-schema.py" in src, f"{spec} does not ship the repair script"
-
-
-def test_the_frozen_path_is_preferred_when_it_exists(tmp_path, monkeypatch):
-    """A bundle resolves to its own copy, not to a repo path that will not be
-    there on an installed machine."""
-    import sys
-
-    from app.services import schema_repair
-
-    fake = tmp_path / "scripts"
-    fake.mkdir()
-    (fake / "repair-schema.py").write_text("# bundled copy\n")
-    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
-
-    got = schema_repair.repair_script_path()
-    assert got == str(fake / "repair-schema.py")

--- a/tests/test_schema_repair.py
+++ b/tests/test_schema_repair.py
@@ -200,3 +200,57 @@ def test_the_startup_refusal_still_says_upgrade_for_an_ordinary_old_file(
     detail = str(e.value)
     assert "alembic upgrade head" in detail
     assert "repair-schema.py" not in detail
+
+
+# ── #144: the message must name a path that exists ───────────────────────
+
+
+def test_the_refusal_names_a_path_that_exists():
+    """Found during check 0 on the published v2.12.0 artifact.
+
+    The guard printed `scripts/repair-schema.py`, and that file was **not in
+    the bundle** — `scripts/` ships selectively and the zip carried only the
+    three Server Edition PowerShell files. Server Edition is precisely the
+    deployment shape the half-upgraded branch exists for, so the operator
+    most likely to read the message was the one least likely to have the
+    file. An error naming a path the reader cannot reach is the same defect
+    as #139's "deactivate it instead" with no deactivate control.
+    """
+    from pathlib import Path
+
+    from app.services.schema_repair import repair_script_path
+
+    assert Path(
+        repair_script_path()
+    ).exists(), "the startup refusal names a script that is not there"
+
+
+def test_both_specs_ship_the_repair_script():
+    """The other half: it has to be IN the bundle for the resolved path to
+    find it. Guarded in the spec rather than trusted, because the only way
+    to notice it was missing was to unzip a released artifact."""
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    for spec in (
+        "packaging/windows/SlowBooksPro.spec",
+        "packaging/macos/SlowBooksPro-mac.spec",
+    ):
+        src = (root / spec).read_text(encoding="utf-8")
+        assert "repair-schema.py" in src, f"{spec} does not ship the repair script"
+
+
+def test_the_frozen_path_is_preferred_when_it_exists(tmp_path, monkeypatch):
+    """A bundle resolves to its own copy, not to a repo path that will not be
+    there on an installed machine."""
+    import sys
+
+    from app.services import schema_repair
+
+    fake = tmp_path / "scripts"
+    fake.mkdir()
+    (fake / "repair-schema.py").write_text("# bundled copy\n")
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+
+    got = schema_repair.repair_script_path()
+    assert got == str(fake / "repair-schema.py")

--- a/tests/test_schema_repair.py
+++ b/tests/test_schema_repair.py
@@ -335,3 +335,67 @@ def test_both_specs_ship_the_repair_script():
     ):
         src = (root / spec).read_text(encoding="utf-8")
         assert "repair-schema.py" in src, f"{spec} does not ship the repair script"
+
+
+def test_nothing_is_dropped_when_the_migration_cannot_run(tmp_path, monkeypatch):
+    """@skytech, 2.12.1 gate: on a frozen build the migration import died on
+    psycopg2 **after the drop phase had completed**, leaving the file worse
+    than it started — nothing left to drop, so the next start reported it as
+    an ordinary old database and offered a command that still could not run.
+    A loop, entered by following the instructions.
+
+    A repair whose first act is irreversible and whose second act may fail
+    for an unrelated reason is not a repair.
+    """
+    from sqlalchemy import inspect as _inspect
+
+    from app.services import schema_repair
+
+    db, added = _half_upgraded(tmp_path, name="cannot_run.db")
+    before = set(_inspect(create_engine(f"sqlite:///{db}")).get_table_names())
+
+    # Stand in for the import that failed on the frozen bundle.
+    real = schema_repair._alembic_cfg
+
+    def boom(url):
+        raise ModuleNotFoundError("No module named 'psycopg2'")
+
+    monkeypatch.setattr(schema_repair, "_alembic_cfg", boom)
+    result = schema_repair.repair(f"sqlite:///{db}")
+    monkeypatch.setattr(schema_repair, "_alembic_cfg", real)
+
+    assert not result.ok
+    assert result.dropped == [], "it dropped tables it could not then replace"
+    assert "nothing was changed" in result.message
+    assert "psycopg2" in result.message, "say what actually stopped it"
+
+    after = set(_inspect(create_engine(f"sqlite:///{db}")).get_table_names())
+    assert after == before, "the file was modified by a repair that failed"
+    assert _rev(db) != _head()
+
+
+def test_the_repair_entry_point_sets_the_database_url_first():
+    """The cause, guarded at the source.
+
+    `app/config.py` reads `BASE_DIR/.env`, which is inside the bundle when
+    frozen rather than in the user's data directory, so `DATABASE_URL` was
+    unset and fell back to the PostgreSQL default — and `app/database.py`
+    builds its engine at module scope, which `migrations/env.py` imports. The
+    import died before the migration looked at the URL we passed.
+
+    So the assignment has to come before the import, and a later edit that
+    reorders them would reintroduce a defect no test on this machine can
+    reach, because a checkout always has a working `DATABASE_URL`.
+    """
+    from pathlib import Path
+
+    src = (Path(__file__).resolve().parents[1] / "desktop_launcher.py").read_text(
+        encoding="utf-8"
+    )
+    body = src[src.index("def _repair_schema(") :]
+    body = body[: body.index("\ndef ")]
+
+    assert 'os.environ["DATABASE_URL"] = url' in body
+    assert body.index('os.environ["DATABASE_URL"] = url') < body.index(
+        "from app.services.schema_repair import repair"
+    ), "the import happens before the URL is set; that is the original defect"


### PR DESCRIPTION
Small release. One defect found by inspecting the published 2.12.0 artifact, plus the contributor PR already merged to `main`.

## VonHoltenCodes/SlowBooks-Pro-2026#144 — the refusal named a path that is not in the bundle

Found during check 0 on the released artifact rather than in the source. `app.main`'s startup refusal for a half-upgraded database prints:

> Repair it with: `python3 scripts/repair-schema.py --database-url <url>`

That file is **not in the shipped bundle.** `scripts/` is included selectively and the zip carries only the three Server Edition PowerShell files.

**Server Edition is precisely the deployment shape that branch exists for** — the desktop launcher and the Docker entrypoint both migrate first, so neither can reach it. So the operator most likely to read the message was the one least likely to have the file.

This is the **third** appearance of one class: an error telling the reader to do something they cannot do. VonHoltenCodes/SlowBooks-Pro-2026#139's delete error said "deactivate it instead" when nothing on the page could deactivate; the first version of this very guard said `alembic upgrade head`, which fails for the case it detects. The test now asserts **the named path exists**, which closes the class rather than the instance.

Both specs ship the script, and `repair_script_path()` resolves the bundled copy under `sys._MEIPASS` when frozen and the repo path otherwise.

## Also here: @mdornich's VonHoltenCodes/SlowBooks-Pro-2026#147, already merged to `main`

A preview for the template editor — the other half of the send-dialog preview 2.12.0 added. Its context is built through the shared helper, so **GHSA-c3v4-f43f-4wqm's redaction covers it by construction rather than by remembering.** Verified independently here rather than taken on trust:

```
named secret      -> 200  leaked=False
whole company dict-> 200  leaked=False
sandbox probe     -> 400  leaked=False
divide by zero    -> 400  leaked=False
```

He also removed his own save-time template validation after one of our tests showed it would let a bad expression stop an invoice going out. That reversed a position I had held earlier the same day, and his reasoning is better than mine was: a template that cannot be saved is a nuisance, an invoice that cannot be sent is a problem.

## VonHoltenCodes/SlowBooks-Pro-Testing#52 is deliberately not in this

The session-scoped engine touches every one of 2,162 tests, and its failure mode is **a test that passes while leaking state into the next one** — which is worse than the memory it saves. It wants its own run and its own review, not a tail-end change to a release branch. Trent's call.

## State

- Suite **2162 passed / 0 failed**, `black` and `ruff` clean at CI scope
- **No schema change** — an existing company file opens with no upgrade step
- Version 2.12.1

**Not merging until the three-platform gate passes and Trent says so.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DaDm82ccTQi7awPEQrrW3