### PR TITLE
v2.13.0 — Bank of America, in a file the bank produced

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,6 @@
 # Ensure shell scripts always have LF line endings (fixes Docker on all platforms)
 *.sh text eol=lf
 docker-entrypoint.sh text eol=lf
+
+# Preserve the byte shape of the real Bank of America export fixture.
+tests/fixtures/bofa_detail_real_shape.csv -text whitespace=cr-at-eol

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
+**Bank of America detail CSV import.** Checking and savings detail exports
+with the bank's statement-summary preamble now import into the review queue.
+The statement's beginning-balance metadata is skipped because opening balances
+are posted separately through the linked ledger account.
+
 ### v2.12.1 — See an email template before you save it
 
 **Preview an email template edit against a real invoice, before saving it.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,68 @@ on what the software does, not on what sprint shipped what.
 
 ## [Unreleased]
 
+### v2.13.0 — Bank of America, in a file the bank produced
+
 **Bank of America detail CSV import.** Checking and savings detail exports
 with the bank's statement-summary preamble now import into the review queue.
 The statement's beginning-balance metadata is skipped because opening balances
-are posted separately through the linked ledger account.
+are posted separately through the linked ledger account. Contributed by
+@Lazyjimpressions, and parked for a day for one reason: no file a bank had
+produced. He opened two real exports, reported what they contain, and then
+committed a fixture derived from them with its byte shape pinned — CRLF, the
+six-row preamble, minus-sign debits, a blank amount on the balance row, a
+quoted comma in a description, a thousands separator. Every unknown the park
+recorded is answered by that file. The one gap left, a check-number column
+neither export has, is carried as a missing field rather than a wrong number.
+
+**Only a sentence written for the user leaves the process.** Four code-scanning
+alerts, open since August on the CSV, IIF and QuickBooks Online import routes,
+all said the same thing: a caught exception's text reaches a response. The
+sites already answered through the shared helper, and the scanner was still
+right — for a ValueError it returned the exception's own text, and nothing
+told "Missing customer NAME" apart from "invalid literal for int() with base
+10: 'abc'". "In our own words" meant "is a ValueError", a convention nobody
+could check. The marker is explicit now: a data problem carries the sentence
+it was raised with, the helper passes that on and nothing else, and Python's
+own wording is logged with its value and answered generically. A missing
+control account, which an import used to swallow into "unexpected error",
+tells the operator which account to restore. The query run locally against
+this tree reports no such sinks; the previous tree reported five.
+
+**A Windows machine without the WebView2 runtime is told what it can do.** The
+portable zip carries no runtime installer (the installer does), and the
+launcher's check for the runtime already existed. What was wrong was what it
+said: the installed application was told to run a Python command it has no
+way to run — no Python, no such file — the sixth appearance this month of an
+error telling somebody to do something they cannot do. The installed build is
+now told the two things it can do, and on Windows is offered the one path that
+works without the runtime: the app in the system browser, held open by a box
+the user closes to stop it. The tests execute that path against stubs and read
+the installer's name out of the packaging script rather than from memory. Not
+covered anywhere: the end-to-end on a machine with the runtime genuinely
+absent, which needs a scratch machine. Recorded as such rather than claimed.
+
+**On Windows, the server no longer waits a scheduler tick per request.** About
+half of all requests waited exactly 15.625 ms — a trivial health check cost
+the same as a full invoice write. The server process now asks for a 1 ms timer
+while it serves, and first tells Windows 11 not to ignore that request from a
+process with no window, which the server is. It logs the timer resolution
+before and after so the change can be confirmed on real hardware rather than
+assumed. Measured on the Windows lane of the release gate, not here.
+
+**The test suite builds its database once.** Every test used to build its own
+engine and schema; now the schema exists once and each test runs in a
+transaction that is rolled back. Peak memory 795 → 606 MB and wall time 6:43
+→ 4:00 on the same machine, with 2,199 tests passing in shuffled order. A
+sentinel asserts five tables empty at the start of every test, so a test that
+ever commits outside its transaction fails the next test by name. Found on
+the way: the async library's per-run registry kept every closed event loop
+alive through its own root task, one per request the test client made; those
+are released after each test now. Memory still climbs across a run, about
+170 KB per test from a source not yet named, so the issue stays open with
+the measurement rather than closing on the improvement.
+
+No schema change. An existing company file opens with no upgrade step.
 
 ### v2.12.1 — See an email template before you save it
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,13 +48,27 @@ the installer's name out of the packaging script rather than from memory. Not
 covered anywhere: the end-to-end on a machine with the runtime genuinely
 absent, which needs a scratch machine. Recorded as such rather than claimed.
 
-**On Windows, the server no longer waits a scheduler tick per request.** About
-half of all requests waited exactly 15.625 ms — a trivial health check cost
-the same as a full invoice write. The server process now asks for a 1 ms timer
-while it serves, and first tells Windows 11 not to ignore that request from a
-process with no window, which the server is. It logs the timer resolution
-before and after so the change can be confirmed on real hardware rather than
-assumed. Measured on the Windows lane of the release gate, not here.
+**A 1 ms timer for the Windows server, available and off.** Issue #107 measured
+about half of all requests waiting exactly one 15.625 ms scheduler tick on
+2.9.3. The server can now ask Windows for a 1 ms timer while it serves — and
+first tell Windows 11 not to ignore that request from a process with no
+window, which the server is — logging the resolution before and after. It is
+**off unless `SLOWBOOKS_TIMER_RESOLUTION_MS` is set**, because the gate put a
+Windows 11 box back at the true default and measured the unfixed build: a
+median under 2 ms and not one sample in the tick band. The symptom does not
+reproduce there, and a permanent 1 ms timer in a background process costs
+power, so it is not imposed on every install for a benefit nobody has
+measured. The switch and the log line are the instrument for anyone who does
+see the tick.
+
+**The bank-import dialog says it is working, and names Bank of America.** The
+preview pane stayed empty for the whole round trip and the button stayed live,
+so a second click put a second parse in flight; found by the owner on a
+382-byte file. It shows *Reading the file…* first and takes the button away
+until the answer is back, and the import button does the same. The file
+picker's own label listed Chase and PayPal and not Bank of America — the one
+place a user is actually choosing a file described a different product than
+the one shipped.
 
 **The test suite builds its database once.** Every test used to build its own
 engine and schema; now the schema exists once and each test runs in a

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Full catalog (300+ entries) in **[docs/features.md](docs/features.md)**. Highlig
 - **Double-entry core** — auto + manual journals, closing-date
   enforcement, automatic audit log, 50-account contractor chart
 - **Banking** — the register is the ledger (entries post, feeds are a review queue, reconciliation over ledger lines), transfers, deposits, check printing,
-  OFX/QFX + Chase/PayPal CSV import with dedup, SimpleFIN bank feeds,
+  OFX/QFX + Bank of America/Chase/PayPal CSV import with dedup, SimpleFIN bank feeds,
   shared auto-categorization rules
 - **Reports & tax** — P&L (plain & by Class), Balance Sheet, Trial
   Balance, agings, GL, Cash Flow, Sales Tax with pay-to-government flow,

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 # Single source of truth for the application version: app/main.py reports
 # it on the FastAPI app and /health, /api/system serves it to the frontend
 # footer, and the Windows release workflow parses it for the installer.
-__version__ = "2.12.1"
+__version__ = "2.13.0"

--- a/app/routes/bank_import.py
+++ b/app/routes/bank_import.py
@@ -108,7 +108,7 @@ async def import_csv(
 ):
     """Import CSV bank transactions into a bank account.
 
-    Auto-detects format (Chase checking, Chase credit, PayPal).
+    Auto-detects format (Bank of America detail, Chase checking/credit, PayPal).
     Deduplicates by content-derived import_id (re-imports and overlapping
     exports skip; legitimate same-day duplicates still import).
     Auto-applies bank rules after import.

--- a/app/routes/time_entries.py
+++ b/app/routes/time_entries.py
@@ -20,6 +20,7 @@ from app.schemas.time_entries import (
     TimeEntryApprove,
 )
 from app.services.overtime import classify_period
+from app.services.safe_errors import safe_message
 
 router = APIRouter(prefix="/api/time-entries", tags=["time-entries"])
 
@@ -66,7 +67,13 @@ def post_entries_to_job(data: PostToJobRequest, db: Session = Depends(get_db)):
             )
         except ValueError as exc:
             db.rollback()
-            results.append({"id": entry_id, "ok": False, "error": str(exc)})
+            results.append(
+                {
+                    "id": entry_id,
+                    "ok": False,
+                    "error": safe_message(exc, "post time entry to job"),
+                }
+            )
     return {"results": results, "posted": sum(1 for r in results if r["ok"])}
 
 
@@ -182,7 +189,9 @@ def post_entry_to_job(entry_id: int, db: Session = Depends(get_db)):
     try:
         jc = post_time_entry_to_job(db, entry)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(
+            status_code=400, detail=safe_message(exc, "post time entry to job")
+        )
     db.commit()
     return {
         "id": entry.id,
@@ -210,7 +219,9 @@ def reject_time_entry(entry_id: int, db: Session = Depends(get_db)):
             try:
                 void_job_cost(db, jc)
             except ValueError as exc:
-                raise HTTPException(status_code=400, detail=str(exc))
+                raise HTTPException(
+                    status_code=400, detail=safe_message(exc, "void job cost")
+                )
         entry.job_cost_id = None
     entry.status = TimeEntryStatus.REJECTED
     db.commit()

--- a/app/services/accounting.py
+++ b/app/services/accounting.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from app.models.transactions import Transaction, TransactionLine
 from app.models.accounts import Account, AccountType
 from app.services import control_accounts
+from app.services.safe_errors import DataProblem
 
 CENT = Decimal("0.01")
 
@@ -167,15 +168,15 @@ def create_journal_entry(
         debit = Decimal(str(line.get("debit", 0)))
         credit = Decimal(str(line.get("credit", 0)))
         if debit < 0 or credit < 0:
-            raise ValueError(f"Line {i+1}: debit and credit must be non-negative")
+            raise DataProblem(f"Line {i+1}: debit and credit must be non-negative")
         if debit > 0 and credit > 0:
-            raise ValueError(f"Line {i+1}: a line cannot have both debit and credit")
+            raise DataProblem(f"Line {i+1}: a line cannot have both debit and credit")
 
     total_debit = sum(Decimal(str(line.get("debit", 0))) for line in lines)
     total_credit = sum(Decimal(str(line.get("credit", 0))) for line in lines)
 
     if total_debit != total_credit:
-        raise ValueError(
+        raise DataProblem(
             f"Journal entry not balanced: debits={total_debit}, credits={total_credit}"
         )
 

--- a/app/services/bank_csv_import.py
+++ b/app/services/bank_csv_import.py
@@ -55,6 +55,11 @@ PAYPAL_NEW_SIG = {
 }
 BOFA_DETAIL_SIG = {"Date", "Description", "Amount", "Running Bal."}
 
+# How far into a file parse_csv will look for the header row. Bank of
+# America puts a statement summary of roughly eight lines above it;
+# every other supported export puts the header on row 1.
+PREAMBLE_SCAN_LINES = 25
+
 
 def detect_format(headers: set[str]) -> str:
     """Detect CSV format by header column signature (not filename)."""
@@ -280,6 +285,11 @@ def parse_paypal_new(reader: csv.DictReader) -> list[dict]:
     return transactions
 
 
+# Description prefixes Bank of America uses for statement metadata rows that
+# sit inside the transaction table. These are balances, not transactions.
+_BOFA_STATEMENT_METADATA = ("beginning balance", "ending balance")
+
+
 def _parse_bofa_amount(val: str) -> Decimal:
     """Parse Bank of America amounts such as ``1,234.56`` or ``($25.00)``."""
     normalized = val.strip().replace(",", "").replace("$", "")
@@ -292,9 +302,17 @@ def parse_bofa_detail(reader: csv.DictReader) -> list[dict]:
     """Parse Bank of America's detailed checking/savings CSV export.
 
     The export starts with a statement-summary block before the real header.
-    ``parse_csv`` positions the reader at that header. A beginning-balance row
-    is statement metadata, not a transaction, so it stays out of the review
-    queue; opening balances are posted separately through the linked account.
+    ``parse_csv`` positions the reader at that header.
+
+    A beginning-balance row is statement metadata, not a transaction, so it
+    stays out of the review queue; opening balances are posted separately
+    through the linked ledger account (see ``bank_posting.post_opening_balance``).
+    Bank of America normally emits that row with an empty Amount, which the
+    blank-amount guard below already drops — but it is dropped **by
+    description as well**, because relying on the blank was relying on a
+    detail of one export layout to enforce a rule about what a transaction
+    is. If the row ever carries an amount it would otherwise import as a
+    deposit and overstate the account by the opening balance.
     """
     transactions = []
     for row in reader:
@@ -303,6 +321,8 @@ def parse_bofa_detail(reader: csv.DictReader) -> list[dict]:
         amount_str = (row.get("Amount") or "").strip()
 
         if not date_str or not amount_str:
+            continue
+        if description.lower().startswith(_BOFA_STATEMENT_METADATA):
             continue
 
         try:
@@ -349,12 +369,21 @@ def parse_csv(csv_text: str) -> dict:
         }
 
     # Some exports (notably Bank of America detail CSVs) put a statement
-    # summary before the transaction table. Locate the first recognized
-    # header instead of assuming it is physical row 1.
+    # summary before the transaction table, so the header is not physical
+    # row 1. Scan for it — but only across the first PREAMBLE_SCAN_LINES.
+    #
+    # The bound matters. A signature match is a *set subset* test, so a data
+    # row whose values happen to spell a signature's column names would be
+    # taken for a header; the further into the file we look, the more rows
+    # get that chance, and the one we would pick is the one that truncates
+    # the import. Real preambles are short (BofA's is about eight lines), so
+    # a small window buys the feature without buying that risk. It also
+    # keeps an unrecognized 100k-row export from being parsed twice before
+    # we can say "unknown format".
     reader = None
     fmt = "unknown"
     headers: set[str] = set()
-    for index, line in enumerate(lines):
+    for index, line in enumerate(lines[:PREAMBLE_SCAN_LINES]):
         candidate = next(csv.reader([line]), [])
         candidate_headers = {h.strip().strip('"').strip("'") for h in candidate if h}
         candidate_format = detect_format(candidate_headers)

--- a/app/services/bank_csv_import.py
+++ b/app/services/bank_csv_import.py
@@ -1,5 +1,5 @@
 # ============================================================================
-# CSV Bank Transaction Import — Chase checking, Chase credit card, PayPal
+# CSV Bank Transaction Import — Bank of America, Chase, and PayPal
 # Extends Feature 18 (bank feed import) to support CSV bank statement exports.
 #
 # Column mapping & pitfalls documented in the skill. Key rules:
@@ -53,6 +53,7 @@ PAYPAL_NEW_SIG = {
     "From Email Address",
     "Name",
 }
+BOFA_DETAIL_SIG = {"Date", "Description", "Amount", "Running Bal."}
 
 
 def detect_format(headers: set[str]) -> str:
@@ -65,6 +66,8 @@ def detect_format(headers: set[str]) -> str:
         return "paypal"
     if PAYPAL_NEW_SIG.issubset(headers):
         return "paypal_new"
+    if BOFA_DETAIL_SIG.issubset(headers):
+        return "bofa_detail"
     return "unknown"
 
 
@@ -277,6 +280,50 @@ def parse_paypal_new(reader: csv.DictReader) -> list[dict]:
     return transactions
 
 
+def _parse_bofa_amount(val: str) -> Decimal:
+    """Parse Bank of America amounts such as ``1,234.56`` or ``($25.00)``."""
+    normalized = val.strip().replace(",", "").replace("$", "")
+    if normalized.startswith("(") and normalized.endswith(")"):
+        normalized = f"-{normalized[1:-1]}"
+    return Decimal(normalized)
+
+
+def parse_bofa_detail(reader: csv.DictReader) -> list[dict]:
+    """Parse Bank of America's detailed checking/savings CSV export.
+
+    The export starts with a statement-summary block before the real header.
+    ``parse_csv`` positions the reader at that header. A beginning-balance row
+    is statement metadata, not a transaction, so it stays out of the review
+    queue; opening balances are posted separately through the linked account.
+    """
+    transactions = []
+    for row in reader:
+        date_str = (row.get("Date") or "").strip()
+        description = (row.get("Description") or "").strip()
+        amount_str = (row.get("Amount") or "").strip()
+
+        if not date_str or not amount_str:
+            continue
+
+        try:
+            txn_date = parse_date(date_str)
+            amount = _parse_bofa_amount(amount_str)
+        except (ValueError, InvalidOperation) as e:
+            logger.warning("Skipping Bank of America row: %s", e)
+            continue
+
+        transactions.append(
+            {
+                "date": txn_date,
+                "amount": amount,
+                "payee": description,
+                "description": description,
+                "check_number": None,
+            }
+        )
+    return transactions
+
+
 # ── Dispatch ─────────────────────────────────────────────────────────────
 
 
@@ -293,23 +340,40 @@ def parse_csv(csv_text: str) -> dict:
     if csv_text.startswith("\ufeff"):
         csv_text = csv_text[1:]
 
-    reader = csv.DictReader(io.StringIO(csv_text))
-    if not reader.fieldnames:
+    lines = csv_text.splitlines()
+    if not lines:
         return {
             "format": "unknown",
             "transactions": [],
             "error": "Empty CSV or no headers",
         }
 
-    # Normalize headers: strip whitespace, quotes, and BOM residue
-    headers = {h.strip().strip('"').strip("'") for h in reader.fieldnames if h}
-    fmt = detect_format(headers)
+    # Some exports (notably Bank of America detail CSVs) put a statement
+    # summary before the transaction table. Locate the first recognized
+    # header instead of assuming it is physical row 1.
+    reader = None
+    fmt = "unknown"
+    headers: set[str] = set()
+    for index, line in enumerate(lines):
+        candidate = next(csv.reader([line]), [])
+        candidate_headers = {h.strip().strip('"').strip("'") for h in candidate if h}
+        candidate_format = detect_format(candidate_headers)
+        if candidate_format != "unknown":
+            headers = candidate_headers
+            fmt = candidate_format
+            reader = csv.DictReader(io.StringIO("\n".join(lines[index:])))
+            break
+
+    if reader is None:
+        first_row = next(csv.reader([lines[0]]), [])
+        headers = {h.strip().strip('"').strip("'") for h in first_row if h}
 
     parsers = {
         "chase_checking": parse_chase_checking,
         "chase_credit": parse_chase_credit,
         "paypal": parse_paypal,
         "paypal_new": parse_paypal_new,
+        "bofa_detail": parse_bofa_detail,
     }
 
     parser = parsers.get(fmt)
@@ -332,6 +396,7 @@ _IMPORT_ID_PREFIX = {
     "chase_credit": "cc",
     "paypal": "pp",
     "paypal_new": "pp",
+    "bofa_detail": "bofa",
 }
 
 

--- a/app/services/bank_csv_import.py
+++ b/app/services/bank_csv_import.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Session
 
 from app.models.banking import BankTransaction
 from app.services.bank_rules_engine import apply_bank_rules
+from app.services.safe_errors import DataProblem
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +91,7 @@ def parse_date(val: str) -> date:
         return dateparser.parse(val).date()
     except ImportError:
         pass
-    raise ValueError(f"Cannot parse date: {val}")
+    raise DataProblem(f"Cannot parse date: {val}")
 
 
 # ── Format-specific parsers ──────────────────────────────────────────────

--- a/app/services/control_accounts.py
+++ b/app/services/control_accounts.py
@@ -62,6 +62,9 @@ class MissingControlAccount(LookupError):
             "Account), then try again. Nothing was posted."
         )
         super().__init__(detail)
+        # This sentence is for the operator: safe_message passes it on
+        # rather than answering "unexpected error" for a LookupError.
+        self.user_text = detail
 
 
 # number -> (name as seeded, what the posting code uses it for)

--- a/app/services/iif_import.py
+++ b/app/services/iif_import.py
@@ -35,7 +35,7 @@ from app.services.accounting import (
     get_ar_account_id,
     get_default_income_account_id,
 )
-from app.services.safe_errors import safe_message
+from app.services.safe_errors import DataProblem, safe_message
 
 logger = logging.getLogger(__name__)
 
@@ -789,14 +789,14 @@ def _resolve_block_class(db: Session, trns_type: str, doc_ref: str, spls: list):
     if not names:
         return None
     if len(names) > 1:
-        raise ValueError(
+        raise DataProblem(
             f"{trns_type} {doc_ref}: multiple CLASS values {sorted(names)} in one "
             f"block — classes apply per document; split the block or unify the CLASS"
         )
     name = names.pop()
     class_id = resolve_class_id(db, name)
     if class_id is None:
-        raise ValueError(
+        raise DataProblem(
             f"{trns_type} {doc_ref}: class '{name}' not found. Import your "
             f"QuickBooks class list (File > Utilities > Export > Lists > Class "
             f"List) or create it under Settings → Classes first, or correct "
@@ -817,7 +817,7 @@ def _validate_block_balance(trns_type: str, trns: dict, spls: list) -> Decimal:
     spl_total = sum((_parse_decimal(s.get("AMOUNT", "")) for s in spls), Decimal("0"))
     residual = trns_amt + spl_total
     if abs(residual) > Decimal("0.01"):
-        raise ValueError(
+        raise DataProblem(
             f"{trns_type} block does not sum to zero "
             f"(TRNS={trns_amt}, SPL total={spl_total}, residual={residual}). "
             f"Standard QB convention: TRNS and SPL amounts carry opposite signs."
@@ -845,27 +845,29 @@ def _import_bill(db: Session, trns: dict, spls: list) -> Bill:
 
     vendor_name = trns.get("NAME", "").strip()
     if not vendor_name:
-        raise ValueError("BILL: missing vendor NAME on TRNS line")
+        raise DataProblem("BILL: missing vendor NAME on TRNS line")
     vendor = db.query(Vendor).filter(Vendor.name == vendor_name).first()
     if not vendor:
-        raise ValueError(
+        raise DataProblem(
             f"BILL: vendor '{vendor_name}' not found. Add the vendor in "
             f"Vendors first, or correct the NAME in the IIF file."
         )
 
     ap_acct_name = trns.get("ACCNT", "").strip()
     if not ap_acct_name:
-        raise ValueError(f"BILL ({vendor_name}): missing AP account ACCNT on TRNS line")
+        raise DataProblem(
+            f"BILL ({vendor_name}): missing AP account ACCNT on TRNS line"
+        )
     ap_account = _find_account(db, ap_acct_name)
     if not ap_account:
-        raise ValueError(
+        raise DataProblem(
             f"BILL ({vendor_name}): AP account '{ap_acct_name}' not found. "
             f"Add the account in the chart of accounts first."
         )
 
     doc_num = trns.get("DOCNUM", "").strip()
     if not doc_num:
-        raise ValueError(
+        raise DataProblem(
             f"BILL ({vendor_name}): missing DOCNUM (bill_number is required)"
         )
 
@@ -886,10 +888,10 @@ def _import_bill(db: Session, trns: dict, spls: list) -> Bill:
     for spl in spls:
         spl_acct_name = spl.get("ACCNT", "").strip()
         if not spl_acct_name:
-            raise ValueError(f"BILL {doc_num}: SPL line missing ACCNT")
+            raise DataProblem(f"BILL {doc_num}: SPL line missing ACCNT")
         spl_acct = _find_account(db, spl_acct_name)
         if not spl_acct:
-            raise ValueError(
+            raise DataProblem(
                 f"BILL {doc_num}: expense account '{spl_acct_name}' not found"
             )
         spl_amount = _parse_decimal(spl.get("AMOUNT", ""))
@@ -984,10 +986,10 @@ def _import_deposit(db: Session, trns: dict, spls: list) -> Transaction:
 
     bank_acct_name = trns.get("ACCNT", "").strip()
     if not bank_acct_name:
-        raise ValueError("DEPOSIT: missing bank account ACCNT on TRNS line")
+        raise DataProblem("DEPOSIT: missing bank account ACCNT on TRNS line")
     bank_acct = _find_account(db, bank_acct_name)
     if not bank_acct:
-        raise ValueError(
+        raise DataProblem(
             f"DEPOSIT: bank account '{bank_acct_name}' not found. "
             f"Add the account in the chart of accounts first."
         )
@@ -1017,12 +1019,12 @@ def _import_deposit(db: Session, trns: dict, spls: list) -> Transaction:
     for spl in spls:
         spl_acct_name = spl.get("ACCNT", "").strip()
         if not spl_acct_name:
-            raise ValueError(
+            raise DataProblem(
                 f"DEPOSIT {doc_num or bank_acct_name}: SPL line missing ACCNT"
             )
         spl_acct = _find_account(db, spl_acct_name)
         if not spl_acct:
-            raise ValueError(
+            raise DataProblem(
                 f"DEPOSIT {doc_num or bank_acct_name}: source account "
                 f"'{spl_acct_name}' not found"
             )

--- a/app/services/job_costing.py
+++ b/app/services/job_costing.py
@@ -45,6 +45,7 @@ from app.models.time_entries import TimeEntry, TimeEntryStatus
 from app.models.transactions import Transaction, TransactionLine
 from app.services.accounting import create_journal_entry
 from app.services.jobs_service import job_attribution
+from app.services.safe_errors import DataProblem
 
 TWO = Decimal("0.01")
 
@@ -237,7 +238,7 @@ def resolve_line_accounts(
     if not debit and ctype:
         debit = ctype.default_account_id
     if not debit:
-        raise ValueError(
+        raise DataProblem(
             "No cost account for this line — pick one, or set a default account on "
             f"the '{ctype.name if ctype else cost_type}' cost type or the cost code in Settings"
         )
@@ -251,7 +252,7 @@ def resolve_line_accounts(
             else ctype.offset_account_id
         )
     if not credit:
-        raise ValueError(
+        raise DataProblem(
             "No offset account for this line — pick one, or set the offset account on "
             f"the '{ctype.name if ctype else cost_type}' cost type in Settings "
             "(Settings → Cost Types → Create default offset accounts)"
@@ -297,7 +298,7 @@ def post_job_cost(db: Session, jc: JobCost) -> Transaction:
             }
         )
     if not lines:
-        raise ValueError("A job cost entry needs at least one line with an amount")
+        raise DataProblem("A job cost entry needs at least one line with an amount")
     label = job.full_name if job else "allocation"
     txn = create_journal_entry(
         db,
@@ -315,7 +316,7 @@ def post_job_cost(db: Session, jc: JobCost) -> Transaction:
 
 def void_job_cost(db: Session, jc: JobCost) -> None:
     if jc.status == "void":
-        raise ValueError("Job cost entry is already void")
+        raise DataProblem("Job cost entry is already void")
     txn = jc.transaction
     if txn is not None:
         reverse = [
@@ -385,18 +386,18 @@ def labor_cost_for_entry(
 
 def post_time_entry_to_job(db: Session, entry: TimeEntry) -> JobCost:
     if entry.job_cost_id:
-        raise ValueError("Time entry is already posted to its job")
+        raise DataProblem("Time entry is already posted to its job")
     if not entry.job_id:
-        raise ValueError("Time entry has no job")
+        raise DataProblem("Time entry has no job")
     if entry.status not in (TimeEntryStatus.APPROVED, TimeEntryStatus.SUBMITTED):
-        raise ValueError("Only submitted or approved time entries post to a job")
+        raise DataProblem("Only submitted or approved time entries post to a job")
     emp = entry.employee or db.get(Employee, entry.employee_id)
     types = cost_type_map(db)
     labor = types.get("labor")
     code = db.get(CostCode, entry.cost_code_id) if entry.cost_code_id else None
     hours, rate, base = labor_cost_for_entry(emp, entry)
     if base <= 0:
-        raise ValueError("Time entry has no hours, or the employee has no cost rate")
+        raise DataProblem("Time entry has no hours, or the employee has no cost rate")
     debit, credit = resolve_line_accounts(db, types, code, "labor", None, None)
 
     jc = JobCost(
@@ -519,7 +520,7 @@ def distribute_payroll_burden(db: Session, run) -> Optional[JobCost]:
         or tax_expense
     )
     if tax_expense is None:
-        raise ValueError(
+        raise DataProblem(
             "No payroll tax expense account (6120) to distribute burden from"
         )
 
@@ -678,10 +679,12 @@ def allocate_cost(
 ) -> JobCost:
     amount = _q(amount)
     if amount <= 0:
-        raise ValueError("Allocation amount must be positive")
+        raise DataProblem("Allocation amount must be positive")
     weights = allocation_weights(db, method, job_ids, start_date, end_date, explicit)
     if not weights:
-        raise ValueError("Nothing to allocate on: no jobs carry weight for that method")
+        raise DataProblem(
+            "Nothing to allocate on: no jobs carry weight for that method"
+        )
     total_w = sum(weights.values())
     types = cost_type_map(db)
     code = db.get(CostCode, cost_code_id) if cost_code_id else None

--- a/app/services/migration_common.py
+++ b/app/services/migration_common.py
@@ -26,6 +26,7 @@ from sqlalchemy.orm import Session
 
 from app.models.accounts import Account
 from app.services.accounting import _q, create_journal_entry
+from app.services.safe_errors import DataProblem
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +55,7 @@ def parse_amount(raw: str) -> Decimal:
     try:
         value = Decimal(raw)
     except InvalidOperation:
-        raise ValueError(f"unparseable amount: {raw!r}")
+        raise DataProblem(f"unparseable amount: {raw!r}")
     return -value if negative else value
 
 
@@ -65,7 +66,7 @@ def parse_date(raw: str, formats: tuple[str, ...]):
             return datetime.strptime(raw, fmt).date()
         except ValueError:
             continue
-    raise ValueError(f"unparseable date: {raw!r}")
+    raise DataProblem(f"unparseable date: {raw!r}")
 
 
 def sniff_reader(csv_text: str) -> csv.DictReader:

--- a/app/services/qb_report_import.py
+++ b/app/services/qb_report_import.py
@@ -39,6 +39,7 @@ from app.services.accounting import (
     get_undeposited_funds_id,
 )
 from app.services.iif_import import _find_account
+from app.services.safe_errors import DataProblem, safe_message
 
 logger = logging.getLogger(__name__)
 
@@ -408,16 +409,13 @@ def import_sales_receipt_report(db: Session, csv_text: str) -> dict:
 
             sp.commit()
             result["imported"] += 1
-        except (ValueError, LookupError, InvalidOperation) as e:
-            # data problems carry our own wording — keep it for the user
+        except Exception as e:
+            # A DataProblem carries its own sentence; Python's own errors
+            # are bugs — logged with the traceback, answered generically.
             sp.rollback()
-            result["errors"].append(f"Receipt {rec.get('num') or rec['row']}: {e}")
-        except Exception:
-            sp.rollback()
-            logger.exception("QB report import row failed")
             result["errors"].append(
-                f"Receipt {rec.get('num') or rec['row']}"
-                + ": unexpected error — the server log has the details"
+                f"Receipt {rec.get('num') or rec['row']}: "
+                + safe_message(e, "QB report import")
             )
 
     db.commit()
@@ -487,14 +485,14 @@ def import_deposit_report(db: Session, csv_text: str) -> dict:
             hdr = block["header"]
             dep_date = _parse_date(_cell(hdr, cols, "Date"))
             if dep_date is None:
-                raise ValueError("deposit row has no parseable date")
+                raise DataProblem("deposit row has no parseable date")
             bank_name = _cell(hdr, cols, "Account")
             bank = _find_account(db, bank_name)
             if not bank:
-                raise ValueError(f"bank account '{bank_name}' not found")
+                raise DataProblem(f"bank account '{bank_name}' not found")
             total = _q(_amount(_cell(hdr, cols, "Amount")))
             if total <= 0:
-                raise ValueError(f"deposit total {total} is not positive")
+                raise DataProblem(f"deposit total {total} is not positive")
 
             # Sum-to-zero: header total + detail amounts must cancel.
             detail = []
@@ -503,14 +501,14 @@ def import_deposit_report(db: Session, csv_text: str) -> dict:
                 acct_name = _cell(drow, cols, "Account")
                 acct = _find_account(db, acct_name)
                 if not acct:
-                    raise ValueError(
+                    raise DataProblem(
                         f"source account '{acct_name}' not found - import "
                         "your chart of accounts (IIF lists) first"
                     )
                 detail.append((acct, amt, _cell(drow, cols, "Name")))
             residual = total + sum(a for _, a, _ in detail)
             if abs(residual) > Decimal("0.01"):
-                raise ValueError(
+                raise DataProblem(
                     f"block does not balance (residual {residual}); "
                     "export the report with all its rows"
                 )
@@ -561,16 +559,13 @@ def import_deposit_report(db: Session, csv_text: str) -> dict:
             )
             sp.commit()
             result["deposits"] += 1
-        except (ValueError, LookupError, InvalidOperation) as e:
-            # data problems carry our own wording — keep it for the user
+        except Exception as e:
+            # A DataProblem carries its own sentence; Python's own errors
+            # are bugs — logged with the traceback, answered generically.
             sp.rollback()
-            result["errors"].append(f"Deposit block at row {block['row']}: {e}")
-        except Exception:
-            sp.rollback()
-            logger.exception("QB report import row failed")
             result["errors"].append(
-                f"Deposit block at row {block['row']}"
-                + ": unexpected error — the server log has the details"
+                f"Deposit block at row {block['row']}: "
+                + safe_message(e, "QB report import")
             )
 
     for btype, count in sorted(skipped_types.items()):
@@ -610,17 +605,17 @@ def import_check_report(db: Session, csv_text: str) -> dict:
             hdr = block["header"]
             chk_date = _parse_date(_cell(hdr, cols, "Date"))
             if chk_date is None:
-                raise ValueError("check row has no parseable date")
+                raise DataProblem("check row has no parseable date")
             bank_name = _cell(hdr, cols, "Account")
             bank = _find_account(db, bank_name)
             if not bank:
-                raise ValueError(f"bank account '{bank_name}' not found")
+                raise DataProblem(f"bank account '{bank_name}' not found")
             payee = _cell(hdr, cols, "Name")
             num = _cell(hdr, cols, "Num")
             memo = _cell(hdr, cols, "Memo")
             total = _q(abs(_amount(_cell(hdr, cols, "Original Amount"))))
             if total <= 0:
-                raise ValueError("check total is zero")
+                raise DataProblem("check total is zero")
 
             # Sign-aware splits: Paid Amount is negative for a normal
             # expense line and POSITIVE for a contra line — e.g. a payroll
@@ -639,14 +634,14 @@ def import_check_report(db: Session, csv_text: str) -> dict:
                 acct_name = _cell(drow, cols, "Account")
                 acct = _find_account(db, acct_name)
                 if not acct:
-                    raise ValueError(
+                    raise DataProblem(
                         f"account '{acct_name}' not found - import your "
                         "chart of accounts (IIF lists) first"
                     )
                 splits.append((acct, signed, _cell(drow, cols, "Memo")))
             split_sum = sum(a for _, a, _ in splits)
             if abs(split_sum - total) > Decimal("0.01"):
-                raise ValueError(
+                raise DataProblem(
                     f"splits ({split_sum}) do not equal the check total ({total})"
                 )
 
@@ -699,16 +694,13 @@ def import_check_report(db: Session, csv_text: str) -> dict:
             )
             sp.commit()
             result["checks"] += 1
-        except (ValueError, LookupError, InvalidOperation) as e:
-            # data problems carry our own wording — keep it for the user
+        except Exception as e:
+            # A DataProblem carries its own sentence; Python's own errors
+            # are bugs — logged with the traceback, answered generically.
             sp.rollback()
-            result["errors"].append(f"Check block at row {block['row']}: {e}")
-        except Exception:
-            sp.rollback()
-            logger.exception("QB report import row failed")
             result["errors"].append(
-                f"Check block at row {block['row']}"
-                + ": unexpected error — the server log has the details"
+                f"Check block at row {block['row']}: "
+                + safe_message(e, "QB report import")
             )
 
     for btype, count in sorted(skipped_types.items()):

--- a/app/services/safe_errors.py
+++ b/app/services/safe_errors.py
@@ -4,9 +4,19 @@ A route or importer that catches a bare Exception must not put the
 exception's own text in a response: SQLAlchemy errors carry the whole
 statement and every bound parameter (a live payment token, in the case
 macbase1 caught on the 2.9.4 gate), driver errors carry hostnames, and
-tracebacks carry paths. The rule here: data problems in our own words
-pass through; a database constraint is reduced to the constraint; anything
-else is logged with its traceback and answered with one fixed sentence.
+tracebacks carry paths. The rule here: a data problem described in our own
+words passes through; a database constraint is reduced to the constraint;
+anything else is logged with its traceback and answered with one fixed
+sentence.
+
+"In our own words" used to mean "is a ValueError", and that was a convention
+nobody could check: Python's own ValueErrors ("invalid literal for int()
+with base 10: 'abc'") passed under the same door, and a scanner reading the
+code sees only that a caught exception's text reaches a response — which is
+exactly what it should object to. So the marker is now explicit. An
+exception that was raised with a sentence for the user carries it as
+`user_text`, set at the point it was raised; `safe_message` hands that on
+and nothing else. `DataProblem` is the ordinary way to raise one.
 """
 
 import logging
@@ -18,12 +28,35 @@ logger = logging.getLogger(__name__)
 
 GENERIC = "unexpected error — the server log has the details"
 
-# Exceptions whose message is ours: the importers and services raise
-# ValueError with a sentence for the user ("Missing customer NAME"). Not
-# LookupError / ArithmeticError — those are what Python raises when the
-# code is wrong (KeyError, IndexError, ZeroDivisionError), and a bug must
-# be logged, not handed to the user as "'ACCNT'" (macbase1, 2.9.4 gate).
-DATA_ERRORS = (ValueError,)
+
+class DataProblem(ValueError):
+    """A problem with the data, in a sentence written for the person who
+    sent it: "Missing customer NAME on TRNS line", "Journal entry not
+    balanced". Raise it wherever the text is meant to be read by a user.
+
+    It is a ValueError so existing `except ValueError` handling is
+    unchanged. What it adds is `user_text`, the one thing `safe_message`
+    will pass on. A bare ValueError — Python's own wording from int(),
+    strptime(), a library — is treated as a bug: logged, answered
+    generically. Not LookupError / ArithmeticError either: KeyError,
+    IndexError and ZeroDivisionError are what Python raises when the code
+    is wrong, and a bug must be logged, not handed to the user as
+    "'ACCNT'" (macbase1, 2.9.4 gate).
+    """
+
+    def __init__(self, user_text: str):
+        super().__init__(user_text)
+        self.user_text = user_text
+
+
+def user_text_of(exc: BaseException) -> str | None:
+    """The sentence `exc` was raised with for the user, or None.
+
+    Any exception may carry one — `MissingControlAccount` does, because
+    its message tells the operator which account to restore — so this
+    reads the attribute rather than checking the class."""
+    text = getattr(exc, "user_text", None)
+    return text if isinstance(text, str) and text else None
 
 
 def safe_message(exc: BaseException, context: str = "operation") -> str:
@@ -36,15 +69,21 @@ def safe_message(exc: BaseException, context: str = "operation") -> str:
         orig = str(getattr(exc, "orig", "") or "").strip().splitlines()
         logger.warning("%s: database constraint", context, exc_info=True)
         return "Database constraint: " + (orig[0] if orig else "see the server log")
-    if isinstance(exc, StatementError) and not isinstance(exc, DATA_ERRORS):
+    if isinstance(exc, StatementError):
         logger.exception("%s: database error", context)
         return "Database error — the server log has the details"
     if isinstance(exc, InvalidOperation):
         # decimal's own text is "[<class 'decimal.ConversionSyntax'>]"
         logger.info("%s: a number could not be read", context)
         return "a number could not be read"
-    if isinstance(exc, DATA_ERRORS):
-        logger.info("%s: %s", context, exc)
-        return str(exc)
+    text = user_text_of(exc)
+    if text is not None:
+        logger.info("%s: %s", context, text)
+        return text
+    if isinstance(exc, ValueError):
+        # Python's or a library's wording, not ours. The row is still
+        # reported, and the log says what the value was.
+        logger.warning("%s: %s", context, exc, exc_info=True)
+        return GENERIC
     logger.exception("%s: unexpected error", context)
     return GENERIC

--- a/app/static/js/banking.js
+++ b/app/static/js/banking.js
@@ -751,7 +751,7 @@ const BankingPage = {
                     <tbody>${rows}</tbody>
                 </table></div>
                 <div class="form-actions" style="margin-top:12px;">
-                    <button class="btn btn-primary" onclick="BankingPage.confirmOFXImport(${feedId}, ${accountId})">Import ${data.transactions.length} Transactions</button>
+                    <button class="btn btn-primary" onclick="BankingPage.confirmOFXImport(${feedId}, ${accountId}, this)">Import ${data.transactions.length} Transactions</button>
                 </div>`;
         } catch (err) {
             $('#ofx-preview').innerHTML = `<div style="color:var(--danger); font-size:11px;">${escapeHtml(err.message)}</div>`;
@@ -760,9 +760,13 @@ const BankingPage = {
         }
     },
 
-    async confirmOFXImport(feedId, accountId) {
-        // Same guard on the import itself: one click, one import.
-        const importBtn = document.activeElement && document.activeElement.tagName === 'BUTTON' ? document.activeElement : null;
+    async confirmOFXImport(feedId, accountId, importBtn) {
+        // Same guard on the import itself: one click, one import. The
+        // button comes in from its own onclick (`this`) — the first cut
+        // found it through document.activeElement, and WebKit does not
+        // focus a button on click, so on macOS the guard never engaged
+        // (@macbase1, 2.13.0 gate, with a real click in a real WKWebView).
+        const label = importBtn ? importBtn.textContent : '';
         if (importBtn) { importBtn.disabled = true; importBtn.textContent = 'Importing…'; }
         try {
             const file = $('#ofx-file').files[0];
@@ -778,6 +782,11 @@ const BankingPage = {
             toast(`Imported ${data.imported} (${data.skipped} duplicates skipped, ${data.matched || 0} matched to the books)`);
             closeModal();
             App.navigate(`#/banking/${accountId}`);
-        } catch (err) { toast(err.message, 'error'); }
+        } catch (err) {
+            toast(err.message, 'error');
+        } finally {
+            // A failed import hands the button back, on every engine.
+            if (importBtn) { importBtn.disabled = false; importBtn.textContent = label; }
+        }
     },
 };

--- a/app/static/js/banking.js
+++ b/app/static/js/banking.js
@@ -699,7 +699,7 @@ const BankingPage = {
         openModal('Import Bank File', `
             <form onsubmit="BankingPage.previewOFX(event, ${feedId}, ${accountId})">
                 <div class="form-group">
-                    <label>Select an OFX/QFX file, or a CSV export (Chase checking, Chase credit, PayPal)</label>
+                    <label>Select an OFX/QFX file, or a CSV export (Bank of America, Chase checking, Chase credit, PayPal)</label>
                     <input type="file" name="file" accept=".ofx,.qfx,.csv" required id="ofx-file">
                 </div>
                 <div class="form-actions">
@@ -721,6 +721,13 @@ const BankingPage = {
         const isCsv = BankingPage._isCsvFile(file);
         const formData = new FormData();
         formData.append('file', file);
+        // The pane stayed empty for the whole round trip and the button
+        // stayed live, so a second click put a second parse in flight
+        // (2.13.0 gate, owner + skytech). Say something first, and take
+        // the button away until the answer is back.
+        const submit = e.target.querySelector('button[type="submit"]');
+        if (submit) submit.disabled = true;
+        $('#ofx-preview').innerHTML = '<p class="form-hint">Reading the file — this can take a moment for a year of statement lines.</p>';
         try {
             const endpoint = isCsv ? '/api/bank-import/preview-csv' : '/api/bank-import/preview';
             const resp = await fetch(endpoint, { method: 'POST', body: formData });
@@ -748,10 +755,15 @@ const BankingPage = {
                 </div>`;
         } catch (err) {
             $('#ofx-preview').innerHTML = `<div style="color:var(--danger); font-size:11px;">${escapeHtml(err.message)}</div>`;
+        } finally {
+            if (submit) submit.disabled = false;
         }
     },
 
     async confirmOFXImport(feedId, accountId) {
+        // Same guard on the import itself: one click, one import.
+        const importBtn = document.activeElement && document.activeElement.tagName === 'BUTTON' ? document.activeElement : null;
+        if (importBtn) { importBtn.disabled = true; importBtn.textContent = 'Importing…'; }
         try {
             const file = $('#ofx-file').files[0];
             const isCsv = BankingPage._isCsvFile(file);

--- a/app/static/whats-new.json
+++ b/app/static/whats-new.json
@@ -1,4 +1,12 @@
 {
+  "2.13.0": {
+    "title": "Bank of America, in a file the bank produced",
+    "items": [
+      "Import Bank of America checking and savings detail CSV exports into the bank feed review queue — contributed by Lazyjimpressions, and verified against exports the bank actually produced",
+      "On Windows, the server no longer waits a scheduler tick on about half of all requests",
+      "A Windows machine without the WebView2 runtime is told what it can do, and offered the app in its web browser instead"
+    ]
+  },
   "2.12.1": {
     "title": "See an email template before you save it",
     "items": [

--- a/app/static/whats-new.json
+++ b/app/static/whats-new.json
@@ -3,7 +3,7 @@
     "title": "Bank of America, in a file the bank produced",
     "items": [
       "Import Bank of America checking and savings detail CSV exports into the bank feed review queue — contributed by Lazyjimpressions, and verified against exports the bank actually produced",
-      "On Windows, the server no longer waits a scheduler tick on about half of all requests",
+      "The bank-import dialog shows that it is reading your file, and will not start a second import if you click twice",
       "A Windows machine without the WebView2 runtime is told what it can do, and offered the app in its web browser instead"
     ]
   },

--- a/desktop_launcher.py
+++ b/desktop_launcher.py
@@ -1432,10 +1432,32 @@ def raise_timer_resolution(period_ms: int = 1):
 
     Returns a function that undoes it (timeEndPeriod must be matched).
     The log line names the resolution before and after, so a gate can
-    confirm the request took effect rather than assume it. The cost is
-    a little power while serving; the request ends with the process.
+    confirm the request took effect rather than assume it.
+
+    OFF unless SLOWBOOKS_TIMER_RESOLUTION_MS is set. On the 2.13.0 gate
+    skytech put a Windows 11 box back at the true 15.625 ms default and
+    measured the UNFIXED build: median 1.8 ms, zero samples in the tick
+    band. The 2.9.3 symptom does not reproduce there, and a 1 ms timer
+    in a background process is a power cost — so it is not imposed on
+    every install for a benefit nobody has measured. Set the variable to
+    1 and the log line says whether the request took; that is the
+    instrument for anyone who does see the tick.
     """
     if sys.platform != "win32":
+        return lambda: None
+    requested = os.environ.get("SLOWBOOKS_TIMER_RESOLUTION_MS", "").strip()
+    if not requested:
+        print(
+            "timer resolution: left at the system default "
+            "(set SLOWBOOKS_TIMER_RESOLUTION_MS=1 to request 1 ms)"
+        )
+        return lambda: None
+    try:
+        period_ms = max(1, int(requested))
+    except ValueError:
+        print(
+            f"timer resolution: SLOWBOOKS_TIMER_RESOLUTION_MS={requested!r} is not a number"
+        )
         return lambda: None
     try:
         import ctypes

--- a/desktop_launcher.py
+++ b/desktop_launcher.py
@@ -1001,6 +1001,111 @@ def _webview2_installed() -> bool:
     return False
 
 
+WEBVIEW2_URL = "https://developer.microsoft.com/microsoft-edge/webview2/"
+WINDOWS_INSTALLER = "SlowBooksPro-Setup-x64.exe"
+
+
+def _no_webview2_message() -> str:
+    """What to tell someone whose machine has no WebView2 runtime.
+
+    Issue #149: the portable zip carries no bootstrapper (the installer
+    does), so this is the first thing a user of it sees on a fresh
+    Windows image. The old text ended "python desktop_launcher.py
+    --no-window" — an instruction the installed build cannot follow,
+    because it has no Python and no such file. Sixth appearance of that
+    class. The frozen build is told the two things it CAN do.
+    """
+    if FROZEN:
+        return (
+            "SlowBooks Pro needs the Microsoft Edge WebView2 runtime to show "
+            "its window, and this computer does not have it.\n"
+            "\n"
+            "Two ways to fix that:\n"
+            f"  1. Install the runtime from Microsoft: {WEBVIEW2_URL}\n"
+            f"  2. Or install SlowBooks Pro with its installer, {WINDOWS_INSTALLER}, "
+            "which sets the runtime up for you.\n"
+        )
+    return (
+        "The Microsoft WebView2 runtime is not installed, so the app window "
+        "cannot open properly.\n"
+        f"Install it from: {WEBVIEW2_URL}\n"
+        "You can also start without a native window:\n"
+        "    python desktop_launcher.py --no-window"
+    )
+
+
+def _ask_yes_no(message: str, title: str = "SlowBooks Pro 2026") -> bool:
+    """A native Yes/No box (Windows only; False anywhere it cannot ask)."""
+    if sys.platform != "win32":
+        return False
+    try:
+        import ctypes
+
+        MB_YESNO, MB_ICONWARNING, IDYES = 0x4, 0x30, 6
+        return (
+            ctypes.windll.user32.MessageBoxW(
+                0, message, title, MB_YESNO | MB_ICONWARNING
+            )
+            == IDYES
+        )
+    except Exception:
+        return False
+
+
+def _hold_until_dismissed(message: str, title: str = "SlowBooks Pro 2026") -> None:
+    """Block on a native OK box (Windows); elsewhere, wait for Ctrl+C."""
+    if sys.platform == "win32":
+        try:
+            import ctypes
+
+            MB_ICONINFORMATION = 0x40
+            ctypes.windll.user32.MessageBoxW(0, message, title, MB_ICONINFORMATION)
+            return
+        except Exception:
+            pass
+    try:
+        while True:
+            time.sleep(3600)
+    except KeyboardInterrupt:
+        pass
+
+
+def _run_without_webview2(port: int, log_fh=None) -> int:
+    """The window cannot open. Say why in terms the reader can act on and,
+    on Windows, offer the one thing that works without the runtime: the
+    app in the system browser, held open by a box the user closes to
+    stop it. Verified by unit test with a fake registry; the end-to-end
+    on a machine with the runtime genuinely absent needs a scratch VM
+    (issue #149) and is recorded as uncovered, not as passed."""
+    msg = _no_webview2_message()
+    print(msg)
+    if not _ask_yes_no(msg + "\nOpen SlowBooks Pro in your web browser instead?"):
+        _show_error_box(msg)
+        return 1
+    return run_in_browser(port, log_fh)
+
+
+def run_in_browser(port: int, log_fh=None) -> int:
+    """Serve on loopback and open the system browser on it."""
+    import webbrowser
+
+    proc = _start_default_company(port, output=log_fh)
+    if proc is None:
+        return 1
+    url = f"http://127.0.0.1:{port}"
+    print(f"SlowBooks Pro is running at {url}")
+    webbrowser.open(url)
+    try:
+        _hold_until_dismissed(
+            f"SlowBooks Pro is open in your web browser at {url}\n"
+            "\n"
+            "Keep this box open while you work. Click OK to stop SlowBooks Pro."
+        )
+    finally:
+        stop_server(proc)
+    return 0
+
+
 def _show_error_box(message: str) -> None:
     """Best-effort native popup for fatal errors -- used in --hidden mode,
     where there's no visible console to print to. No-op on unsupported
@@ -1097,17 +1202,7 @@ def run_window(port: int, log_fh=None) -> int:
         return 1
 
     if not _webview2_installed():
-        msg = (
-            "The Microsoft WebView2 runtime is not installed, so the app\n"
-            "window cannot open properly.\n"
-            "Install it from:\n"
-            "    https://developer.microsoft.com/microsoft-edge/webview2/\n"
-            "You can also start without a native window:\n"
-            "    python desktop_launcher.py --no-window"
-        )
-        print(msg)
-        _show_error_box(msg)
-        return 1
+        return _run_without_webview2(port, log_fh)
 
     # pywebview CANCELS downloads by default -- without this, saving a PDF,
     # a CSV export, or a backup from inside the app silently does nothing.
@@ -1207,7 +1302,11 @@ def _lan_addresses() -> list[str]:
     return seen
 
 
-def run_headless(port: int, bind_host: str = "127.0.0.1") -> int:
+def _start_default_company(
+    port: int, bind_host: str = "127.0.0.1", output=None
+) -> subprocess.Popen | None:
+    """Open the last-used company (or the first, or a new one) and start
+    the server for it. None, with the reason printed, if that fails."""
     from app.services import company_service
 
     filename = company_service.get_last_opened()
@@ -1220,14 +1319,22 @@ def run_headless(port: int, bind_host: str = "127.0.0.1") -> int:
             result = company_service.manifest_create_company("My Company")
             if not result["success"]:
                 print(f"ERROR: {result['error']}")
-                return 1
+                return None
             filename = result["file"]
 
     print(f"Opening company file: {filename}")
     try:
-        proc = launch_company(filename, port, bind_host=bind_host, persist=False)
+        return launch_company(
+            filename, port, bind_host=bind_host, persist=False, output=output
+        )
     except (ValueError, RuntimeError, subprocess.CalledProcessError) as exc:
         print(f"ERROR: {exc}")
+        return None
+
+
+def run_headless(port: int, bind_host: str = "127.0.0.1") -> int:
+    proc = _start_default_company(port, bind_host)
+    if proc is None:
         return 1
 
     if bind_host == "127.0.0.1":
@@ -1279,6 +1386,108 @@ def _watch_parent(parent_pid: int, poll_seconds: float = 2.0) -> None:
     threading.Thread(target=_poll, daemon=True, name="parent-watch").start()
 
 
+def _win32_dlls():
+    """The three Windows DLLs the timer code needs; a seam for tests."""
+    import ctypes
+
+    return ctypes.windll.winmm, ctypes.windll.kernel32, ctypes.windll.ntdll
+
+
+def _timer_resolution_ms(ntdll) -> float | None:
+    """The current system timer resolution, from NtQueryTimerResolution
+    (100-ns units), or None if it cannot be read."""
+    import ctypes
+
+    # ULONG is 32 bits on Windows; c_uint32 says so on every platform
+    lo, hi, cur = ctypes.c_uint32(), ctypes.c_uint32(), ctypes.c_uint32()
+    try:
+        if (
+            ntdll.NtQueryTimerResolution(
+                ctypes.byref(lo), ctypes.byref(hi), ctypes.byref(cur)
+            )
+            != 0
+        ):
+            return None
+    except Exception:
+        return None
+    return cur.value / 10_000
+
+
+def raise_timer_resolution(period_ms: int = 1):
+    """Windows: serve with a 1 ms timer instead of the 15.625 ms default.
+
+    Issue #107 (skytech, 2.9.3 gate): about half of all requests on Windows
+    waited exactly one scheduler tick — a trivial /health cost the same as
+    a full invoice write, and the histogram had a second peak on 15.625 ms.
+    A request bounces between the event loop and a worker thread (every
+    sync route, every SQLite call that releases the GIL), and each hand-off
+    is a timed wait that Windows rounds up to the tick. timeBeginPeriod(1)
+    is the documented fix and is what browsers do while active.
+
+    Two things the docs say that matter here. Since Windows 10 2004 the
+    request is per-process, so it has to be made in THIS process — the
+    server child — not the launcher. And Windows 11 ignores the request
+    from a process with no visible window unless it opts out with
+    SetProcessInformation, which is exactly what a --_serve child is.
+
+    Returns a function that undoes it (timeEndPeriod must be matched).
+    The log line names the resolution before and after, so a gate can
+    confirm the request took effect rather than assume it. The cost is
+    a little power while serving; the request ends with the process.
+    """
+    if sys.platform != "win32":
+        return lambda: None
+    try:
+        import ctypes
+
+        winmm, kernel32, ntdll = _win32_dlls()
+    except Exception:
+        return lambda: None
+
+    before = _timer_resolution_ms(ntdll)
+    try:
+        # PROCESS_POWER_THROTTLING_STATE { Version=1, ControlMask, StateMask }
+        # ControlMask selects IGNORE_TIMER_RESOLUTION (0x4); StateMask 0
+        # turns that throttling OFF — "always honor timer resolution
+        # requests", per the SetProcessInformation reference. Fails
+        # harmlessly (returns 0) on Windows 10, which has no such throttle.
+        class _PowerThrottling(ctypes.Structure):
+            _fields_ = [
+                ("Version", ctypes.c_uint32),
+                ("ControlMask", ctypes.c_uint32),
+                ("StateMask", ctypes.c_uint32),
+            ]
+
+        state = _PowerThrottling(1, 0x4, 0)
+        kernel32.SetProcessInformation(
+            kernel32.GetCurrentProcess(),
+            4,  # ProcessPowerThrottling
+            ctypes.byref(state),
+            ctypes.sizeof(state),
+        )
+    except Exception:
+        pass
+
+    try:
+        if winmm.timeBeginPeriod(period_ms) != 0:  # TIMERR_NOCANDO
+            print(f"timer resolution: request for {period_ms} ms refused")
+            return lambda: None
+    except Exception:
+        return lambda: None
+
+    after = _timer_resolution_ms(ntdll)
+    fmt = lambda v: "unknown" if v is None else f"{v:.3f} ms"  # noqa: E731
+    print(f"timer resolution: was {fmt(before)}, now {fmt(after)}")
+
+    def undo():
+        try:
+            winmm.timeEndPeriod(period_ms)
+        except Exception:
+            pass
+
+    return undo
+
+
 def _serve() -> int:
     """Internal: run the uvicorn server in this process. The frozen build
     has no child interpreter for `-m uvicorn`, so start_server() re-execs
@@ -1302,7 +1511,11 @@ def _serve() -> int:
 
     port = int(os.environ.get("APP_PORT", "3001"))
     host = os.environ.get("APP_HOST", "127.0.0.1")
-    uvicorn.run(app.main.app, host=host, port=port, use_colors=False)
+    restore_timer = raise_timer_resolution()
+    try:
+        uvicorn.run(app.main.app, host=host, port=port, use_colors=False)
+    finally:
+        restore_timer()
     return 0
 
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -57,7 +57,7 @@ The register is the ledger account (v2.10, issue #114). Full guide: [docs/bankin
 - **Make Deposits** — Move funds from Undeposited Funds to a bank account. Select pending payments, choose target account, create deposit
 - **Credit Card Charges** — DR Expense, CR the card you pick (default 2100). Voidable
 - **Check Printing** — Generate check PDFs in standard 3-per-page format (stub/stub/check) with payee, amount in words, memo, and signature line
-- **Bank feeds and file imports (SimpleFIN, OFX/QFX, Chase/PayPal CSV)** — a review queue: each statement line is auto-matched to the posting the ledger already has (same amount and side within five days, check number narrows, ambiguity waits), or added with a category, or excluded. Bank rules suggest categories and never post
+- **Bank feeds and file imports (SimpleFIN, OFX/QFX, Bank of America/Chase/PayPal CSV)** — a review queue: each statement line is auto-matched to the posting the ledger already has (same amount and side within five days, check number narrows, ambiguity waits), or added with a category, or excluded. Bank rules suggest categories and never post
 - **Bank Reconciliation** — over the ledger's lines: beginning balance from the prior statement, tick cleared lines (matched statement lines arrive cleared), difference must be $0, completing locks the lines
 
 ## Reports & Tax

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
 # ============================================================================
 # Slowbooks Pro 2026 — pytest configuration
 #
-# Each test gets a fresh in-memory SQLite database via the db_engine fixture.
-# The `client` fixture wires the app's get_db dependency to that same engine
-# so API calls and direct db_session queries hit the same tables.
+# One in-memory SQLite database for the whole run, built once; each test
+# runs inside a transaction on it that is rolled back at the end (issue
+# #128). The `client` fixture wires the app's get_db dependency to that same
+# connection so API calls and direct db_session queries hit the same tables.
 # Rate limiting is disabled by default so per-test counters don't collide.
 # ============================================================================
 
@@ -87,8 +88,8 @@ def pytest_runtest_call(item):
 
 from starlette.requests import HTTPConnection  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
-from sqlalchemy import create_engine  # noqa: E402
-from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy import create_engine, event  # noqa: E402
+from sqlalchemy.orm import close_all_sessions, sessionmaker  # noqa: E402
 from sqlalchemy.pool import StaticPool  # noqa: E402
 
 # Import all model modules so Base.metadata sees every table before create_all.
@@ -138,12 +139,7 @@ from app.seed.chart_of_accounts import CHART_OF_ACCOUNTS  # noqa: E402
 from app.main import app  # noqa: E402
 
 # ---------------------------------------------------------------------------
-# Per-test in-memory engine — every test gets a clean slate
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
-# ONE session factory for the whole suite, rebound to each test's engine.
+# ONE session factory for the whole suite.
 #
 # Issue #124: the suite used to build a fresh sessionmaker per test — two of
 # them, in fact — and call register_audit_hooks() on each. That is ~4,060
@@ -153,9 +149,7 @@ from app.main import app  # noqa: E402
 # the suite at a random point on a memory-constrained Windows box.
 #
 # A sessionmaker can be re-pointed with .configure(bind=...), so one factory
-# serves every test and the listener is attached exactly once. Per-test
-# isolation is unchanged: the ENGINE is still new for each test, so each gets
-# its own empty in-memory database.
+# serves every test and the listener is attached exactly once.
 #
 # The old comment here warned that id-reuse across short-lived factories made
 # `event.contains` unreliable. With one long-lived factory that hazard is gone
@@ -164,36 +158,136 @@ from app.main import app  # noqa: E402
 _SUITE_SESSION_FACTORY = sessionmaker(autocommit=False, autoflush=False)
 
 
-def _shared_factory(engine):
+def _shared_factory(bind):
     from app.services.audit import register_audit_hooks
 
-    _SUITE_SESSION_FACTORY.configure(bind=engine)
+    # create_savepoint: every Session on this connection — the test's, the
+    # client's, one the app opens itself — runs in its own SAVEPOINT, so
+    # session.commit() releases the savepoint and never touches the outer
+    # transaction that the db_engine fixture rolls back.
+    _SUITE_SESSION_FACTORY.configure(
+        bind=bind, join_transaction_mode="create_savepoint"
+    )
     register_audit_hooks(_SUITE_SESSION_FACTORY)  # idempotent via its sentinel
     return _SUITE_SESSION_FACTORY
 
 
-@pytest.fixture
-def db_engine():
-    """Per-test in-memory SQLite engine with full schema."""
+def _test_engine(url="sqlite:///:memory:"):
     engine = create_engine(
-        "sqlite:///:memory:",
+        url,
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
+
+    # pysqlite's legacy transaction handling never emits BEGIN for a
+    # SAVEPOINT, so a savepoint released before any BEGIN "functions on its
+    # own" and a rollback of the enclosing transaction leaves it in place —
+    # the exact failure that would make a test pass while leaking rows into
+    # the next one. SQLAlchemy's documented fix: take BEGIN away from the
+    # driver and emit it ourselves.
+    @event.listens_for(engine, "connect")
+    def _no_implicit_begin(dbapi_connection, _record):
+        dbapi_connection.isolation_level = None
+        # A file-backed database at memory speed: nothing here needs to
+        # survive a crash, and the file exists only so the database does
+        # (see _suite_engine).
+        cur = dbapi_connection.cursor()
+        cur.execute("PRAGMA journal_mode=MEMORY")
+        cur.execute("PRAGMA synchronous=OFF")
+        cur.execute("PRAGMA temp_store=MEMORY")
+        cur.close()
+
+    @event.listens_for(engine, "begin")
+    def _explicit_begin(conn):
+        conn.exec_driver_sql("BEGIN")
+
     Base.metadata.create_all(bind=engine)
-    # Point the app module at this engine so SessionLocal-based code (audit
-    # hooks, etc.) also lands in the same DB.
-    db_module.engine = engine
-    db_module.SessionLocal = _shared_factory(engine)
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# Issue #128: one engine and one schema for the whole run.
+#
+# Every test used to build its own engine and create_all() into it. Live
+# objects grew all run long (795k -> 1.36M, mostly DDL event dispatch and
+# column types that never freed), and the cost was linear in the size of the
+# suite. Now the schema exists once; a test gets a connection with an open
+# transaction, everything it does nests inside that as savepoints, and the
+# transaction is rolled back at the end. Isolation is by rollback, not by
+# rebuilding the world — and rowids restart with it, so `id == 1` still holds.
+#
+# The proof that no test sees another's data is a shuffled-order run, not
+# this comment: see the 2.13.0 gate record.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def _suite_engine(tmp_path_factory):
+    # A file rather than :memory:, for one reason: restoring a backup calls
+    # db_module.engine.dispose() so the app re-reads the overwritten file.
+    # On a :memory: database, closing the connection IS deleting the
+    # database — one restore test and every test after it would find an
+    # empty schema. On a file, dispose just reconnects.
+    path = tmp_path_factory.mktemp("suite") / "suite.db"
+    engine = _test_engine("sqlite:///" + path.as_posix())
     yield engine
     engine.dispose()
 
 
+# Tables that are empty at the start of every test. A test that commits
+# outside its transaction (after a dispose, say) shows up here at the NEXT
+# test's setup, named, rather than as a mystery failure three files later.
+_SENTINEL_TABLES = ("accounts", "customers", "vendors", "transactions", "users")
+_previous_test = {"nodeid": "(none)"}
+
+
+def _assert_pristine(connection, nodeid):
+    from sqlalchemy import text
+
+    for table in _SENTINEL_TABLES:
+        n = connection.execute(text(f"SELECT count(*) FROM {table}")).scalar()
+        if n:
+            pytest.fail(
+                f"{table} has {n} row(s) at the start of {nodeid}: a previous "
+                f"test ({_previous_test['nodeid']}) committed outside its "
+                "transaction, so its rows leaked into this one"
+            )
+
+
+@pytest.fixture
+def db_engine(_suite_engine, request):
+    """The suite's engine, with this test's transaction open on it. Rolled
+    back — every row the test wrote, whether it committed or not — at exit."""
+    connection = _suite_engine.connect()
+    outer = connection.begin()
+    _assert_pristine(connection, request.node.nodeid)
+    # Point the app module at this engine so SessionLocal-based code (the
+    # startup helpers, api_token_service, encryption) also lands in the
+    # same transaction.
+    db_module.engine = _suite_engine
+    db_module.SessionLocal = _shared_factory(connection)
+    try:
+        yield _suite_engine
+    finally:
+        _previous_test["nodeid"] = request.node.nodeid
+        close_all_sessions()
+        # A test that disposed the engine already lost this connection;
+        # what it wrote after that is the sentinel's job to catch.
+        try:
+            outer.rollback()
+        except Exception:
+            pass
+        try:
+            connection.close()
+        except Exception:
+            pass
+
+
 @pytest.fixture
 def TestSession(db_engine):
-    """The suite's session factory, bound to this test's engine. The `client`
-    fixture wires get_db to this."""
-    return _shared_factory(db_engine)
+    """The suite's session factory, bound to this test's transaction. The
+    `client` fixture wires get_db to this."""
+    return _SUITE_SESSION_FACTORY
 
 
 @pytest.fixture
@@ -306,17 +400,27 @@ def client(db_engine, TestSession):
 
 
 @pytest.fixture
-def lifespan_client(db_engine, TestSession):
+def lifespan_client():
     """An authenticated client with the app's startup events actually run.
 
     Use this only for a test that asserts on startup behaviour; `client` skips
-    the lifespan on purpose (issue #124)."""
-    _wire_app(TestSession)
-    with TestClient(app) as c:
-        r = c.post("/api/auth/setup", json={"password": "test-password-123"})
-        assert r.status_code == 200, f"Auth setup failed: {r.text}"
-        yield c
-    app.dependency_overrides.clear()
+    the lifespan on purpose (issue #124). Startup opens engine-level
+    transactions (the migration guard, create_all), which cannot nest inside
+    a test's open transaction — so this one gets a private engine of its own,
+    the way every test used to."""
+    engine = _test_engine()
+    db_module.engine = engine
+    db_module.SessionLocal = _shared_factory(engine)
+    _wire_app(_SUITE_SESSION_FACTORY)
+    try:
+        with TestClient(app) as c:
+            r = c.post("/api/auth/setup", json={"password": "test-password-123"})
+            assert r.status_code == 200, f"Auth setup failed: {r.text}"
+            yield c
+    finally:
+        app.dependency_overrides.clear()
+        close_all_sessions()
+        engine.dispose()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -283,6 +283,28 @@ def db_engine(_suite_engine, request):
             pass
 
 
+@pytest.fixture(autouse=True)
+def _release_closed_event_loops():
+    """anyio 4.12 keeps a registry of per-run variables keyed weakly by
+    event loop — and one of the values is the run's root Task, which holds
+    the loop strongly. A value that references its own weak key can never
+    be collected, so every event loop the test client spins up (one per
+    request, without a context manager) stayed alive after it was closed:
+    loop, task, thread limiter, worker sets, contexts. Measured at ~2.3
+    loops per test and about a third of the suite's remaining growth.
+    Drop the entries for closed loops after each test. Private API, so a
+    version that changes it simply leaves the leak in place."""
+    yield
+    try:
+        from anyio.lowlevel import _run_vars
+    except Exception:
+        return
+    for loop in [
+        k for k in list(_run_vars) if getattr(k, "is_closed", lambda: False)()
+    ]:
+        _run_vars.pop(loop, None)
+
+
 @pytest.fixture
 def TestSession(db_engine):
     """The suite's session factory, bound to this test's transaction. The

--- a/tests/fixtures/bofa_detail_real_shape.csv
+++ b/tests/fixtures/bofa_detail_real_shape.csv
@@ -1,0 +1,10 @@
+Description,,Summary Amt.
+Beginning balance as of 01/01/2026,,"1,000.00"
+Total credits,,"1,250.00"
+Total debits,,"-250.00"
+Ending balance as of 01/31/2026,,"2,000.00"
+
+Date,Description,Amount,Running Bal.
+01/01/2026,Beginning balance as of 01/01/2026,,"1,000.00"
+01/20/2026,"SYNTHETIC PAYOR, LLC CREDIT","1,250.00","2,250.00"
+01/22/2026,SYNTHETIC DEBIT,-250.00,"2,000.00"

--- a/tests/test_bank_csv_import.py
+++ b/tests/test_bank_csv_import.py
@@ -2,6 +2,7 @@
 content-derived import_id dedup, and bank-rule parity with OFX import."""
 
 from decimal import Decimal
+from pathlib import Path
 
 from app.models.accounts import Account, AccountType
 from app.models.bank_rules import BankRule
@@ -43,19 +44,9 @@ PAYPAL_NEW_CSV = (
     "grace@example.com,Grace Hopper,,,0.00,0.00,INV-9,\n"
 )
 
-BOFA_DETAIL_CSV = (
-    "Description,,Summary Amt.\n"
-    'Beginning balance as of 01/01/2026,,"1,000.00"\n'
-    'Total credits,,"1,239.90"\n'
-    'Total debits,,"(250.00)"\n'
-    'Ending balance as of 01/31/2026,,"1,989.90"\n'
-    "\n"
-    "Date,Description,Amount,Running Bal.\n"
-    '01/01/2026,Beginning balance as of 01/01/2026,,"1,000.00"\n'
-    '01/20/2026,Interest Earned,4.90,"1,004.90"\n'
-    '01/22/2026,Online Banking transfer to CHK 1234,(250.00),"754.90"\n'
-    '01/25/2026,BKOFAMERICA MOBILE DEPOSIT,"1,235.00","1,989.90"\n'
-)
+BOFA_DETAIL_FIXTURE = Path(__file__).parent / "fixtures/bofa_detail_real_shape.csv"
+BOFA_DETAIL_CSV_BYTES = BOFA_DETAIL_FIXTURE.read_bytes()
+BOFA_DETAIL_CSV = BOFA_DETAIL_CSV_BYTES.decode("ascii")
 
 
 def _mk_bank_account(db_session):
@@ -127,14 +118,18 @@ def test_parse_paypal_new_format():
 
 
 def test_parse_bofa_detail_after_summary_preamble():
+    # The fixture preserves the line endings emitted by both real exports.
+    assert b"\r\n" in BOFA_DETAIL_CSV_BYTES
+    assert b"\n" not in BOFA_DETAIL_CSV_BYTES.replace(b"\r\n", b"")
+
     result = parse_csv(BOFA_DETAIL_CSV)
     assert result["format"] == "bofa_detail"
     assert result["error"] is None
     txns = result["transactions"]
-    assert len(txns) == 3
-    assert txns[0]["amount"] == Decimal("4.90")
+    assert len(txns) == 2
+    assert txns[0]["payee"] == "SYNTHETIC PAYOR, LLC CREDIT"
+    assert txns[0]["amount"] == Decimal("1250.00")
     assert txns[1]["amount"] == Decimal("-250.00")
-    assert txns[-1]["amount"] == Decimal("1235.00")
 
 
 # ── Import + dedup ───────────────────────────────────────────────────────
@@ -168,7 +163,7 @@ def test_bofa_reimport_skips_everything(db_session):
     ba = _mk_bank_account(db_session)
     first = import_csv_transactions(db_session, ba.id, BOFA_DETAIL_CSV)
     assert first["format"] == "bofa_detail"
-    assert first["imported"] == 3
+    assert first["imported"] == 2
     assert first["matched"] == 0
 
     rows = (
@@ -176,12 +171,12 @@ def test_bofa_reimport_skips_everything(db_session):
         .filter(BankTransaction.bank_account_id == ba.id)
         .all()
     )
-    assert len(rows) == 3
+    assert len(rows) == 2
     assert all(row.import_source == "csv_bofa_detail" for row in rows)
 
     second = import_csv_transactions(db_session, ba.id, BOFA_DETAIL_CSV)
     assert second["imported"] == 0
-    assert second["skipped"] == 3
+    assert second["skipped"] == 2
 
 
 def test_overlapping_export_skips_only_known_rows(db_session):

--- a/tests/test_bank_csv_import.py
+++ b/tests/test_bank_csv_import.py
@@ -249,3 +249,125 @@ def test_unknown_format_reports_error(db_session):
     result = import_csv_transactions(db_session, ba.id, "Foo,Bar\n1,2\n")
     assert result["imported"] == 0
     assert result["errors"]
+
+
+# ── Bank of America: shapes the contributor's tests did not reach ────────
+#
+# The BofA parser arrived with the preamble case covered (PR #130). These
+# are the cases around it: the same export without a preamble, the metadata
+# row that carries an amount, the scan bound, and — the one that matters —
+# what the ledger does when one of these rows is added from the queue.
+
+BOFA_NO_PREAMBLE_CSV = (
+    "Date,Description,Amount,Running Bal.\n"
+    '01/20/2026,Interest Earned,4.90,"1,004.90"\n'
+    '01/22/2026,Online Banking transfer to CHK 1234,-250.00,"754.90"\n'
+)
+
+BOFA_METADATA_WITH_AMOUNT_CSV = (
+    "Date,Description,Amount,Running Bal.\n"
+    '01/01/2026,Beginning balance as of 01/01/2026,1000.00,"1,000.00"\n'
+    '01/20/2026,Interest Earned,4.90,"1,004.90"\n'
+    '01/31/2026,Ending balance as of 01/31/2026,1004.90,"1,004.90"\n'
+)
+
+
+def test_bofa_export_without_the_summary_preamble():
+    """BofA emits this export both ways. The header-scan must not require
+    a preamble to be there."""
+    result = parse_csv(BOFA_NO_PREAMBLE_CSV)
+    assert result["format"] == "bofa_detail"
+    assert [t["amount"] for t in result["transactions"]] == [
+        Decimal("4.90"),
+        Decimal("-250.00"),
+    ]
+
+
+def test_bofa_minus_sign_and_parentheses_are_the_same_debit():
+    """The summary block uses (250.00) and the detail rows use -250.00.
+    Both are money leaving the account."""
+    paren = parse_csv(
+        "Date,Description,Amount,Running Bal.\n"
+        '01/22/2026,Transfer out,(250.00),"754.90"\n'
+    )["transactions"]
+    minus = parse_csv(BOFA_NO_PREAMBLE_CSV)["transactions"]
+    assert paren[0]["amount"] == minus[1]["amount"] == Decimal("-250.00")
+
+
+def test_bofa_balance_rows_are_dropped_even_when_they_carry_an_amount():
+    """A beginning-balance row is the statement's opening figure, not a
+    deposit. BofA normally leaves its Amount blank, which the blank guard
+    catches; if it ever fills it in, importing it would overstate the
+    account by the whole opening balance and the register would show a
+    deposit nobody made."""
+    txns = parse_csv(BOFA_METADATA_WITH_AMOUNT_CSV)["transactions"]
+    assert [t["description"] for t in txns] == ["Interest Earned"]
+
+
+def test_header_scan_is_bounded_so_a_data_row_cannot_be_taken_for_a_header():
+    """The scan exists for BofA's ~8-line preamble. Past the bound the file
+    is data, and a data row that happens to spell a signature's column
+    names would truncate the import at that row."""
+    from app.services.bank_csv_import import PREAMBLE_SCAN_LINES
+
+    padding = "junk,junk2\n" * (PREAMBLE_SCAN_LINES + 5)
+    result = parse_csv(padding + "Date,Description,Amount,Running Bal.\n")
+    assert result["format"] == "unknown"
+
+    near = "junk,junk2\n" * (PREAMBLE_SCAN_LINES - 2)
+    assert parse_csv(near + "Date,Description,Amount,Running Bal.\n")["format"] == (
+        "bofa_detail"
+    )
+
+
+def test_bofa_row_added_from_the_queue_posts_the_right_way_round(
+    client, db_session, seed_accounts
+):
+    """The sign contract, end to end, through the review queue.
+
+    Everything above tests the parser in isolation. This is the test that
+    would have caught a sign inversion: a positive BofA row must DEBIT the
+    bank account (money in) and a negative one must CREDIT it. #119 is why
+    a parser test is not enough — the question is always what reached the
+    ledger."""
+    from app.models.transactions import TransactionLine
+
+    checking = seed_accounts["1000"]
+    feed = client.post(
+        "/api/banking/accounts",
+        json={"name": "BofA checking", "account_id": checking.id},
+    ).json()
+
+    out = import_csv_transactions(db_session, feed["id"], BOFA_NO_PREAMBLE_CSV)
+    assert out["imported"] == 2 and out["format"] == "bofa_detail"
+
+    rows = client.get(f"/api/banking/transactions?bank_account_id={feed['id']}").json()
+    by_amount = {Decimal(str(r["amount"])): r for r in rows}
+
+    def add(row, category):
+        r = client.post(
+            f"/api/banking/transactions/{row['id']}/add",
+            json={"category_account_id": category.id},
+        )
+        assert r.status_code in (200, 201), r.text
+        return r.json()
+
+    # +4.90 interest earned: money in, so the bank account is debited.
+    add(by_amount[Decimal("4.90")], seed_accounts["4000"])
+    # -250.00 transfer out: money out, so the bank account is credited.
+    add(by_amount[Decimal("-250.00")], seed_accounts["6000"])
+
+    lines = (
+        db_session.query(TransactionLine)
+        .filter(TransactionLine.account_id == checking.id)
+        .all()
+    )
+    debits = sum(line.debit or 0 for line in lines)
+    credits = sum(line.credit or 0 for line in lines)
+    assert debits == Decimal("4.90")
+    assert credits == Decimal("250.00")
+
+    reg = client.get(f"/api/banking/check-register?account_id={checking.id}").json()
+    assert reg["entries"][-1]["balance"] == "-245.10" or Decimal(
+        str(reg["entries"][-1]["balance"])
+    ) == Decimal("-245.10")

--- a/tests/test_bank_csv_import.py
+++ b/tests/test_bank_csv_import.py
@@ -43,6 +43,20 @@ PAYPAL_NEW_CSV = (
     "grace@example.com,Grace Hopper,,,0.00,0.00,INV-9,\n"
 )
 
+BOFA_DETAIL_CSV = (
+    "Description,,Summary Amt.\n"
+    'Beginning balance as of 01/01/2026,,"1,000.00"\n'
+    'Total credits,,"1,239.90"\n'
+    'Total debits,,"(250.00)"\n'
+    'Ending balance as of 01/31/2026,,"1,989.90"\n'
+    "\n"
+    "Date,Description,Amount,Running Bal.\n"
+    '01/01/2026,Beginning balance as of 01/01/2026,,"1,000.00"\n'
+    '01/20/2026,Interest Earned,4.90,"1,004.90"\n'
+    '01/22/2026,Online Banking transfer to CHK 1234,(250.00),"754.90"\n'
+    '01/25/2026,BKOFAMERICA MOBILE DEPOSIT,"1,235.00","1,989.90"\n'
+)
+
 
 def _mk_bank_account(db_session):
     ba = BankAccount(name="Test Checking", bank_name="Chase")
@@ -75,6 +89,10 @@ def test_detect_formats():
         == "chase_credit"
     )
     assert detect_format({"Date", "Time", "Name", "Type", "Status"}) == "paypal"
+    assert (
+        detect_format({"Date", "Description", "Amount", "Running Bal."})
+        == "bofa_detail"
+    )
     assert detect_format({"Nothing", "Useful"}) == "unknown"
 
 
@@ -108,6 +126,17 @@ def test_parse_paypal_new_format():
     assert txns[0]["payee"] == "Grace Hopper"
 
 
+def test_parse_bofa_detail_after_summary_preamble():
+    result = parse_csv(BOFA_DETAIL_CSV)
+    assert result["format"] == "bofa_detail"
+    assert result["error"] is None
+    txns = result["transactions"]
+    assert len(txns) == 3
+    assert txns[0]["amount"] == Decimal("4.90")
+    assert txns[1]["amount"] == Decimal("-250.00")
+    assert txns[-1]["amount"] == Decimal("1235.00")
+
+
 # ── Import + dedup ───────────────────────────────────────────────────────
 
 
@@ -133,6 +162,26 @@ def test_reimport_same_file_skips_everything(db_session):
     second = import_csv_transactions(db_session, ba.id, CHASE_CHECKING_CSV)
     assert second["imported"] == 0
     assert second["skipped"] == 4
+
+
+def test_bofa_reimport_skips_everything(db_session):
+    ba = _mk_bank_account(db_session)
+    first = import_csv_transactions(db_session, ba.id, BOFA_DETAIL_CSV)
+    assert first["format"] == "bofa_detail"
+    assert first["imported"] == 3
+    assert first["matched"] == 0
+
+    rows = (
+        db_session.query(BankTransaction)
+        .filter(BankTransaction.bank_account_id == ba.id)
+        .all()
+    )
+    assert len(rows) == 3
+    assert all(row.import_source == "csv_bofa_detail" for row in rows)
+
+    second = import_csv_transactions(db_session, ba.id, BOFA_DETAIL_CSV)
+    assert second["imported"] == 0
+    assert second["skipped"] == 3
 
 
 def test_overlapping_export_skips_only_known_rows(db_session):

--- a/tests/test_bank_import_dialog.py
+++ b/tests/test_bank_import_dialog.py
@@ -10,7 +10,9 @@ things are present and in the right order."""
 import re
 from pathlib import Path
 
-JS = (Path(__file__).resolve().parents[1] / "app/static/js/banking.js").read_text()
+JS = (Path(__file__).resolve().parents[1] / "app/static/js/banking.js").read_text(
+    encoding="utf-8"
+)
 
 
 def _handler(name):

--- a/tests/test_bank_import_dialog.py
+++ b/tests/test_bank_import_dialog.py
@@ -42,6 +42,21 @@ def test_preview_says_something_before_the_fetch_and_takes_the_button_away():
     )
 
 
-def test_the_import_button_is_one_click_one_import():
+def test_the_import_button_is_one_click_one_import_on_every_engine():
+    """The first cut found the button through document.activeElement, and
+    WebKit does not focus a button on click — the guard was inert on macOS
+    (@macbase1, with a real click). The button comes in from its own
+    onclick now, and a failed import hands it back."""
+    assert re.search(
+        r'onclick="BankingPage\.confirmOFXImport\(\$\{feedId\}, \$\{accountId\}, this\)"',
+        JS,
+    )
     body = _handler("confirmOFXImport")
+    assert (
+        "= document.activeElement" not in body
+    )  # the comment may say the word; the code may not use it
     assert body.index("importBtn.disabled = true") < body.index("await fetch(")
+    assert (
+        "finally" in body
+        and "importBtn.disabled = false" in body.split("finally", 1)[1]
+    )

--- a/tests/test_bank_import_dialog.py
+++ b/tests/test_bank_import_dialog.py
@@ -1,0 +1,47 @@
+"""2.13.0 gate, owner + skytech: the import preview pane stayed empty for the
+whole round trip and the button stayed live, so a second click put a second
+parse in flight. And the dialog's own label — the one place a user is
+choosing a file — did not name Bank of America in the release named for it.
+
+String-level, deliberately: the handler is a template literal in a page
+module with no test harness, and what is being pinned is that the three
+things are present and in the right order."""
+
+import re
+from pathlib import Path
+
+JS = (Path(__file__).resolve().parents[1] / "app/static/js/banking.js").read_text()
+
+
+def _handler(name):
+    m = re.search(rf"async {name}\(.*?\n    }},\n", JS, re.S)
+    assert m, name
+    return m.group(0)
+
+
+def test_the_file_picker_names_every_format_the_parser_detects():
+    label = re.search(
+        r"<label>Select an OFX/QFX file, or a CSV export \((.*?)\)</label>", JS
+    )
+    assert label, "import dialog label not found"
+    named = label.group(1)
+    for bank in ("Bank of America", "Chase checking", "Chase credit", "PayPal"):
+        assert bank in named, (bank, named)
+
+
+def test_preview_says_something_before_the_fetch_and_takes_the_button_away():
+    body = _handler("previewOFX")
+    placeholder = body.index("Reading the file")
+    disable = body.index("submit.disabled = true")
+    fetch = body.index("await fetch(")
+    assert (
+        disable < fetch and placeholder < fetch
+    ), "feedback must come before the round trip"
+    assert (
+        "finally" in body and "submit.disabled = false" in body.split("finally", 1)[1]
+    )
+
+
+def test_the_import_button_is_one_click_one_import():
+    body = _handler("confirmOFXImport")
+    assert body.index("importBtn.disabled = true") < body.index("await fetch(")

--- a/tests/test_launcher_without_webview2.py
+++ b/tests/test_launcher_without_webview2.py
@@ -97,7 +97,9 @@ def test_installed_build_is_not_told_to_run_python(monkeypatch):
 
 def test_the_installer_the_message_names_is_the_one_the_build_produces(monkeypatch):
     """Read the other half out of the packaging source, not from memory."""
-    iss = (Path(dl.ROOT) / "packaging" / "windows" / "SlowBooksPro.iss").read_text()
+    iss = (Path(dl.ROOT) / "packaging" / "windows" / "SlowBooksPro.iss").read_text(
+        encoding="utf-8"
+    )
     m = re.search(r"^OutputBaseFilename=(\S+)", iss, re.M)
     assert m, "OutputBaseFilename not found in the Inno Setup script"
     assert dl.WINDOWS_INSTALLER == m.group(1) + ".exe"

--- a/tests/test_launcher_without_webview2.py
+++ b/tests/test_launcher_without_webview2.py
@@ -1,0 +1,197 @@
+"""Issue #149: the portable Windows zip ships no WebView2 bootstrapper, so on
+a machine without the runtime the launcher is the only thing standing between
+the user and pywebview's silent fall-back to the IE control.
+
+The check itself existed. What was wrong was what it SAID: the installed
+build was told to run `python desktop_launcher.py --no-window`, an
+instruction it cannot follow — no Python, no such file. Sixth appearance of
+the class this month. These tests pin the detection with a fake registry,
+pin that each message names only things its reader can do, and execute the
+offered path (serve + browser + stop) rather than assert it exists.
+"""
+
+import re
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+import desktop_launcher as dl
+
+GUID = "{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"
+
+
+class _FakeWinreg:
+    """Just enough of winreg for _webview2_installed: OpenKey + QueryValueEx."""
+
+    HKEY_LOCAL_MACHINE = "HKLM"
+    HKEY_CURRENT_USER = "HKCU"
+
+    def __init__(self, values):
+        self.values = values  # {(root, path): pv}
+
+    def OpenKey(self, root, path):
+        if (root, path) not in self.values:
+            raise OSError(2, "not found")
+        key = (root, path)
+
+        class _Key:
+            def __enter__(self_inner):
+                return key
+
+            def __exit__(self_inner, *a):
+                return False
+
+        return _Key()
+
+    def QueryValueEx(self, key, name):
+        assert name == "pv"
+        return self.values[key], 1
+
+
+def _with_registry(monkeypatch, values):
+    monkeypatch.setattr(dl.sys, "platform", "win32")
+    monkeypatch.setitem(sys.modules, "winreg", _FakeWinreg(values))
+
+
+def test_detects_the_evergreen_runtime_under_any_of_the_three_keys(monkeypatch):
+    hklm64 = ("HKLM", rf"SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{GUID}")
+    hklm = ("HKLM", rf"SOFTWARE\Microsoft\EdgeUpdate\Clients\{GUID}")
+    hkcu = ("HKCU", rf"Software\Microsoft\EdgeUpdate\Clients\{GUID}")
+    for key in (hklm64, hklm, hkcu):
+        _with_registry(monkeypatch, {key: "120.0.2210.91"})
+        assert dl._webview2_installed() is True, key
+
+
+def test_absent_or_placeholder_version_means_not_installed(monkeypatch):
+    _with_registry(monkeypatch, {})
+    assert dl._webview2_installed() is False
+    # Microsoft's own docs: an uninstalled runtime can leave pv = 0.0.0.0
+    _with_registry(
+        monkeypatch,
+        {("HKLM", rf"SOFTWARE\Microsoft\EdgeUpdate\Clients\{GUID}"): "0.0.0.0"},
+    )
+    assert dl._webview2_installed() is False
+
+
+def test_not_windows_is_always_installed(monkeypatch):
+    monkeypatch.setattr(dl.sys, "platform", "darwin")
+    assert dl._webview2_installed() is True
+
+
+# ---------------------------------------------------------------------------
+# The message: each reader is told only what they can do.
+# ---------------------------------------------------------------------------
+
+
+def test_installed_build_is_not_told_to_run_python(monkeypatch):
+    monkeypatch.setattr(dl, "FROZEN", True)
+    msg = dl._no_webview2_message()
+    assert "python" not in msg.lower()
+    assert "desktop_launcher" not in msg
+    assert dl.WEBVIEW2_URL in msg
+    assert dl.WINDOWS_INSTALLER in msg
+
+
+def test_the_installer_the_message_names_is_the_one_the_build_produces(monkeypatch):
+    """Read the other half out of the packaging source, not from memory."""
+    iss = (Path(dl.ROOT) / "packaging" / "windows" / "SlowBooksPro.iss").read_text()
+    m = re.search(r"^OutputBaseFilename=(\S+)", iss, re.M)
+    assert m, "OutputBaseFilename not found in the Inno Setup script"
+    assert dl.WINDOWS_INSTALLER == m.group(1) + ".exe"
+
+
+def test_checkout_message_names_a_flag_the_launcher_accepts(monkeypatch):
+    """The checkout IS told the Python command — and the flag it names must
+    be one --help lists, not one somebody remembered."""
+    monkeypatch.setattr(dl, "FROZEN", False)
+    msg = dl._no_webview2_message()
+    m = re.search(r"python desktop_launcher\.py (--\S+)", msg)
+    assert m, msg
+    out = subprocess.run(
+        [sys.executable, str(Path(dl.ROOT) / "desktop_launcher.py"), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env={**__import__("os").environ, "SLOWBOOKS_DATA_DIR": str(Path(dl.ROOT))},
+    )
+    assert m.group(1) in out.stdout, out.stdout[-400:]
+
+
+# ---------------------------------------------------------------------------
+# The offered path is executed, not asserted to exist.
+# ---------------------------------------------------------------------------
+
+
+class _Proc:
+    def __init__(self):
+        self.stopped = False
+
+    def poll(self):
+        return None
+
+
+@pytest.fixture
+def browser_run(monkeypatch, tmp_path):
+    """Stub the server start and the two native boxes; record what ran."""
+    calls = {"launch": [], "opened": [], "held": [], "stopped": []}
+    proc = _Proc()
+    from app.services import company_service
+
+    monkeypatch.setattr(company_service, "get_last_opened", lambda: "books.db")
+    monkeypatch.setattr(
+        dl,
+        "launch_company",
+        lambda filename, port, output=None, bind_host="127.0.0.1", persist=True: (
+            calls["launch"].append((filename, port, bind_host, persist)),
+            proc,
+        )[1],
+    )
+    monkeypatch.setattr(dl, "stop_server", lambda p: calls["stopped"].append(p))
+    monkeypatch.setattr(
+        dl, "_hold_until_dismissed", lambda m, title="": calls["held"].append(m)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "webbrowser",
+        types.SimpleNamespace(open=lambda url: calls["opened"].append(url)),
+    )
+    return calls, proc
+
+
+def test_yes_serves_on_loopback_opens_the_browser_and_stops_on_dismiss(
+    monkeypatch, browser_run
+):
+    calls, proc = browser_run
+    _with_registry(monkeypatch, {})  # no runtime
+    monkeypatch.setattr(dl, "_ask_yes_no", lambda msg, title="": True)
+    monkeypatch.setattr(
+        dl, "_show_error_box", lambda m: pytest.fail("no error box on Yes")
+    )
+    monkeypatch.setitem(sys.modules, "webview", types.SimpleNamespace())
+
+    assert dl.run_window(3001) == 0
+    assert calls["launch"] == [("books.db", 3001, "127.0.0.1", False)]
+    assert calls["opened"] == ["http://127.0.0.1:3001"]
+    assert calls["held"] and "http://127.0.0.1:3001" in calls["held"][0]
+    assert calls["stopped"] == [proc]  # the box closing stops the server
+
+
+def test_no_shows_the_message_and_starts_nothing(monkeypatch, browser_run):
+    calls, _ = browser_run
+    _with_registry(monkeypatch, {})
+    monkeypatch.setattr(dl, "_ask_yes_no", lambda msg, title="": False)
+    shown = []
+    monkeypatch.setattr(dl, "_show_error_box", lambda m: shown.append(m))
+    monkeypatch.setitem(sys.modules, "webview", types.SimpleNamespace())
+
+    assert dl.run_window(3001) == 1
+    assert calls["launch"] == [] and calls["opened"] == []
+    assert shown and dl.WEBVIEW2_URL in shown[0]
+
+
+def test_the_question_only_gets_asked_on_windows(monkeypatch):
+    monkeypatch.setattr(dl.sys, "platform", "linux")
+    assert dl._ask_yes_no("anything") is False

--- a/tests/test_no_exception_text_in_responses.py
+++ b/tests/test_no_exception_text_in_responses.py
@@ -148,7 +148,7 @@ def test_iif_row_errors_carry_the_constraint_not_the_statement(
 def test_safe_message_shapes(caplog):
     from sqlalchemy.exc import IntegrityError
 
-    from app.services.safe_errors import GENERIC, safe_message
+    from app.services.safe_errors import GENERIC, DataProblem, safe_message
 
     class _Orig(Exception):
         pass
@@ -167,10 +167,20 @@ def test_safe_message_shapes(caplog):
         == "Database constraint: NOT NULL constraint failed: invoices.invoice_number"
     )
     assert "tok-secret" not in msg and "INSERT" not in msg
+    # A sentence written for the user passes; Python's own wording does
+    # not, because "is a ValueError" was never a property anyone could
+    # check — a scanner sees a caught exception's text reaching a response.
     assert (
-        safe_message(ValueError("Row 3: amount is not a number"), "test")
+        safe_message(DataProblem("Row 3: amount is not a number"), "test")
         == "Row 3: amount is not a number"
     )
+    with caplog.at_level("WARNING"):
+        try:
+            int("abc")
+        except ValueError as exc:
+            msg = safe_message(exc, "test")
+    assert msg == GENERIC
+    assert "invalid literal" in caplog.text  # logged, with the value
     with caplog.at_level("ERROR"):
         try:
             raise RuntimeError(SECRET)
@@ -228,3 +238,111 @@ def test_python_errors_are_bugs_not_user_messages(caplog):
         Decimal("abc")
     except InvalidOperation as exc:
         assert safe_message(exc, "test") == "a number could not be read"
+
+
+# ---------------------------------------------------------------------------
+# CodeQL alerts 39, 45, 46, 47 again, 2.13.0. The four sites were already
+# answering through safe_message, and the scanner was still right: for a
+# ValueError it returned str(exc), and nothing distinguished "Missing
+# customer NAME" from "invalid literal for int() with base 10: 'abc'". The
+# marker is explicit now — user_text, set where the sentence is written.
+# ---------------------------------------------------------------------------
+
+
+def test_a_missing_control_account_tells_the_operator_what_to_restore(caplog):
+    """LookupError is a bug — except this one, which was written for the
+    operator and used to be swallowed into 'unexpected error'."""
+    from app.services.control_accounts import MissingControlAccount
+    from app.services.safe_errors import safe_message
+
+    try:
+        raise MissingControlAccount("1100", "Accounts Receivable", "every invoice")
+    except LookupError as exc:
+        msg = safe_message(exc, "test")
+    assert msg.startswith("The account this posting needs is missing")
+    assert "1100 Accounts Receivable" in msg and "Restore it" in msg
+
+
+def test_qb_report_rows_keep_our_sentence_and_hide_pythons(
+    client, seed_accounts, monkeypatch, caplog
+):
+    from app.services import inventory_hooks
+    from app.services.safe_errors import DataProblem
+
+    # a seam the row loop calls directly (the Invoice constructor sits
+    # inside a SQLAlchemy lambda, which mangles what it raises)
+    def _data_problem(*a, **kw):
+        raise DataProblem("bank account 'Chase' not found")
+
+    monkeypatch.setattr(inventory_hooks, "post_sale_for_invoice", _data_problem)
+    r = client.post(
+        "/api/csv/import/qb-report",
+        files={"file": ("receipts.csv", FIXTURE.read_bytes(), "text/csv")},
+    )
+    assert r.status_code == 200, r.text
+    assert all("bank account 'Chase' not found" in e for e in r.json()["errors"])
+
+    def _key_error(*a, **kw):
+        return {}["ACCNT"]
+
+    monkeypatch.setattr(inventory_hooks, "post_sale_for_invoice", _key_error)
+    with caplog.at_level("ERROR"):
+        r = client.post(
+            "/api/csv/import/qb-report",
+            files={"file": ("receipts.csv", FIXTURE.read_bytes(), "text/csv")},
+        )
+    errors = r.json()["errors"]
+    assert errors and all("unexpected error" in e for e in errors), errors
+    assert "ACCNT" not in r.text and "KeyError" in caplog.text
+
+
+def test_time_entry_post_to_job_answers_with_our_sentence_only(
+    client, seed_accounts, monkeypatch, caplog
+):
+    emp = client.post(
+        "/api/employees",
+        json={
+            "first_name": "Ann",
+            "last_name": "Crew",
+            "pay_type": "hourly",
+            "pay_rate": 30,
+            "cost_rate": 40,
+        },
+    )
+    assert emp.status_code in (200, 201), emp.text
+    te = client.post(
+        "/api/time-entries",
+        json={
+            "employee_id": emp.json()["id"],
+            "date": "2026-07-11",
+            "hours_regular": 8,
+        },
+    )
+    assert te.status_code == 201, te.text
+    te_id = te.json()["id"]
+
+    # a draft entry with no job: the service's own sentence
+    r = client.post("/api/time-entries/post-to-job", json={"ids": [te_id]})
+    assert r.status_code == 200, r.text
+    row = r.json()["results"][0]
+    assert row["ok"] is False
+    assert row["error"] in {
+        "Time entry has no job",
+        "Only submitted or approved time entries post to a job",
+    }, row
+
+    # Python's wording from somewhere underneath: not ours, not served
+    from app.services import job_costing
+
+    def _strptime_failure(db, entry):
+        raise ValueError("time data '13/45/2026' does not match format '%m/%d/%Y'")
+
+    monkeypatch.setattr(job_costing, "post_time_entry_to_job", _strptime_failure)
+    with caplog.at_level("WARNING"):
+        r = client.post("/api/time-entries/post-to-job", json={"ids": [te_id]})
+    row = r.json()["results"][0]
+    assert (
+        row["ok"] is False
+        and row["error"] == "unexpected error — the server log has the details"
+    )
+    assert "13/45/2026" not in r.text and "13/45/2026" in caplog.text

--- a/tests/test_windows_timer_resolution.py
+++ b/tests/test_windows_timer_resolution.py
@@ -59,9 +59,13 @@ class _FakeNtdll:
         return 0
 
 
-def _fake_windows(monkeypatch, refuse=False):
+def _fake_windows(monkeypatch, refuse=False, env="1"):
     calls = _Calls()
     monkeypatch.setattr(dl.sys, "platform", "win32")
+    if env is None:
+        monkeypatch.delenv("SLOWBOOKS_TIMER_RESOLUTION_MS", raising=False)
+    else:
+        monkeypatch.setenv("SLOWBOOKS_TIMER_RESOLUTION_MS", env)
     monkeypatch.setattr(
         dl,
         "_win32_dlls",
@@ -126,3 +130,22 @@ def test_serve_restores_the_timer_when_uvicorn_returns(monkeypatch):
     except RuntimeError:
         pass
     assert order == ["raise", "run", "undo"]
+
+
+def test_off_by_default_and_the_log_says_how_to_turn_it_on(monkeypatch, capsys):
+    """2.13.0 gate: the 15.625 ms symptom did not reproduce on a box put
+    back at the default, so the 1 ms timer is not imposed on every install.
+    The log line still names the switch, so the instrument is findable."""
+    calls = _fake_windows(monkeypatch, env=None)
+    dl.raise_timer_resolution()()
+    assert calls.log == []
+    out = capsys.readouterr().out
+    assert (
+        "left at the system default" in out and "SLOWBOOKS_TIMER_RESOLUTION_MS=1" in out
+    )
+
+
+def test_a_non_number_is_named_not_swallowed(monkeypatch, capsys):
+    calls = _fake_windows(monkeypatch, env="fast")
+    dl.raise_timer_resolution()()
+    assert calls.log == [] and "'fast' is not a number" in capsys.readouterr().out

--- a/tests/test_windows_timer_resolution.py
+++ b/tests/test_windows_timer_resolution.py
@@ -1,0 +1,128 @@
+"""Issue #107: on Windows about half of all requests waited one 15.625 ms
+scheduler tick. The server child asks for a 1 ms timer while it serves, and
+tells Windows 11 not to ignore that request from a windowless process.
+
+There is no Windows here, so the calls are pinned against fakes: which DLL
+entry points, with which arguments, in which order, and that the request is
+matched by timeEndPeriod when the server stops. Whether the median actually
+moves is measured on the gate, on real hardware, from the log line this
+prints — not asserted here.
+"""
+
+import ctypes
+
+import desktop_launcher as dl
+
+
+class _Calls:
+    def __init__(self):
+        self.log = []
+
+
+class _FakeWinmm:
+    def __init__(self, calls, refuse=False):
+        self.calls, self.refuse = calls, refuse
+
+    def timeBeginPeriod(self, ms):
+        self.calls.log.append(("timeBeginPeriod", ms))
+        return 97 if self.refuse else 0  # TIMERR_NOCANDO / TIMERR_NOERROR
+
+    def timeEndPeriod(self, ms):
+        self.calls.log.append(("timeEndPeriod", ms))
+        return 0
+
+
+class _FakeKernel32:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def GetCurrentProcess(self):
+        return -1
+
+    def SetProcessInformation(self, handle, klass, ptr, size):
+        state = ctypes.cast(ptr, ctypes.POINTER(ctypes.c_uint32 * 3)).contents
+        self.calls.log.append(
+            ("SetProcessInformation", handle, klass, tuple(state), size)
+        )
+        return 1
+
+
+class _FakeNtdll:
+    """Resolution reads 15.625 ms until timeBeginPeriod ran, then 1 ms."""
+
+    def __init__(self, calls):
+        self.calls = calls
+
+    def NtQueryTimerResolution(self, lo, hi, cur):
+        raised = any(c[0] == "timeBeginPeriod" for c in self.calls.log)
+        cur._obj.value = 10_000 if raised else 156_250
+        return 0
+
+
+def _fake_windows(monkeypatch, refuse=False):
+    calls = _Calls()
+    monkeypatch.setattr(dl.sys, "platform", "win32")
+    monkeypatch.setattr(
+        dl,
+        "_win32_dlls",
+        lambda: (_FakeWinmm(calls, refuse), _FakeKernel32(calls), _FakeNtdll(calls)),
+    )
+    return calls
+
+
+def test_requests_one_ms_and_opts_out_of_windows_11_throttling(monkeypatch, capsys):
+    calls = _fake_windows(monkeypatch)
+    undo = dl.raise_timer_resolution()
+    names = [c[0] for c in calls.log]
+    # the opt-out comes first, so the request that follows is honoured
+    assert names == ["SetProcessInformation", "timeBeginPeriod"]
+    _, handle, klass, state, size = calls.log[0]
+    assert handle == -1 and klass == 4  # ProcessPowerThrottling
+    # Version 1; ControlMask selects IGNORE_TIMER_RESOLUTION (0x4);
+    # StateMask 0 turns that throttle OFF = "always honor timer requests"
+    assert state == (1, 0x4, 0) and size == 12
+    assert calls.log[1] == ("timeBeginPeriod", 1)
+    out = capsys.readouterr().out
+    assert "timer resolution: was 15.625 ms, now 1.000 ms" in out
+    undo()
+    assert calls.log[-1] == ("timeEndPeriod", 1)  # matched, as the docs require
+
+
+def test_a_refused_request_is_reported_and_never_ended(monkeypatch, capsys):
+    calls = _fake_windows(monkeypatch, refuse=True)
+    undo = dl.raise_timer_resolution()
+    assert "refused" in capsys.readouterr().out
+    undo()
+    assert ("timeEndPeriod", 1) not in calls.log
+
+
+def test_nothing_happens_off_windows(monkeypatch):
+    monkeypatch.setattr(dl.sys, "platform", "linux")
+    called = []
+    monkeypatch.setattr(dl, "_win32_dlls", lambda: called.append(1))
+    dl.raise_timer_resolution()()
+    assert called == []
+
+
+def test_serve_restores_the_timer_when_uvicorn_returns(monkeypatch):
+    """The undo runs in a finally — a crash out of uvicorn.run still ends
+    the period, which is what "matched call" means in practice."""
+    import types
+
+    order = []
+    monkeypatch.setattr(
+        dl,
+        "raise_timer_resolution",
+        lambda: order.append("raise") or (lambda: order.append("undo")),
+    )
+    monkeypatch.setattr(dl, "_watch_parent", lambda pid: None)
+    fake_uvicorn = types.SimpleNamespace(
+        run=lambda *a, **kw: order.append("run")
+        or (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    monkeypatch.setitem(__import__("sys").modules, "uvicorn", fake_uvicorn)
+    try:
+        dl._serve()
+    except RuntimeError:
+        pass
+    assert order == ["raise", "run", "undo"]


### PR DESCRIPTION
## v2.13.0 — Bank of America, in a file the bank produced

**Five items, one gated branch.** The headline is the contributor's, and his commits sit at the front.

### 1. Bank of America detail CSV — @Lazyjimpressions (PR VonHoltenCodes/SlowBooks-Pro-2026#130, un-parked)

Parked on 2026-09-11 for one reason: no file a bank had produced. He opened two real exports, reported what they contain, and then committed a fixture derived from them with a `.gitattributes` rule pinning its byte shape. Every unknown the park recorded is answered by that file: minus-sign debits, a blank `Amount` on the balance row, the six-row preamble, CRLF, a quoted comma in a description, a thousands separator. The one gap left — a check-number column neither export has — is carried as a missing field, not a wrong number. His two commits (`fa3f5a7`, `dcd3a3f`) lead the branch; the three fixes from the parked branch follow.

### 2. CodeQL 39, 45, 46, 47 — `py/stack-trace-exposure`, open since August

All four sites already answered through `safe_message`, and the scanner was still right: for a `ValueError` it returned `str(exc)`, and nothing in the code told *"Missing customer NAME"* apart from *"invalid literal for int() with base 10: 'abc'"*. "In our own words" meant "is a ValueError" — a convention, not a property anyone could check.

The marker is explicit now. `DataProblem(ValueError)` carries `user_text`, set where the sentence is written; `safe_message` passes that on and nothing else. A bare `ValueError` is logged with its value and answered generically. `MissingControlAccount` carries its sentence too — a `LookupError` written for the operator that an import used to swallow into "unexpected error". The QB report importer had its own copy of the rule and got it wrong both ways (`'ACCNT'` and `[<class 'decimal.ConversionSyntax'>]` both reached row messages).

**Measured, not assumed:** the query run locally with the CodeQL CLI reports **no** stack-trace-exposure sinks on this tree; the previous tree reported five (the four open alerts plus the one Keith had dismissed on the time-entries route, now fixed the same way).

### 3. VonHoltenCodes/SlowBooks-Pro-2026#149 — the portable zip and the WebView2 runtime

Filed as "there is no check". There was one. What was wrong was what it **said**: the installed build was told to run `python desktop_launcher.py --no-window` — no Python, no such file — the sixth appearance of the class the last two releases were about. The frozen build is now told the two things it can do (install the runtime; use the installer, which sets it up) and on Windows is offered the one path that works without the runtime: the app in the system browser, held open by a box the user closes to stop it.

Tests execute that path against stubs, read the installer's name out of the Inno Setup script, and check the flag the checkout message names is one `--help` lists. **Still uncovered:** the end-to-end on a machine with the runtime genuinely absent needs a scratch VM. Recorded, not claimed.

### 4. VonHoltenCodes/SlowBooks-Pro-Testing#53 — the 15.625 ms tick on Windows: the instrument ships, off

The server child can call `timeBeginPeriod(1)` while it serves — per-process since Windows 10 2004, so it has to be *this* process — after opting out of the Windows 11 throttle that ignores the request from a windowless process (`SetProcessInformation`, `ProcessPowerThrottling`, `ControlMask=IGNORE_TIMER_RESOLUTION`, `StateMask=0`). It prints `timer resolution: was X ms, now Y ms` to the launcher log.

**Gated, and what the gate found (@skytech, Windows lane):** the box was already at 1 ms (SignalRGB, Razer). With those stopped and the timer verified back at 15.625 ms, the code proves out exactly — `was 15.625 ms, now 1.000 ms`. **And the unfixed 2.12.1 build, at the true default, showed a median of 1.8 ms and zero samples in the tick band.** The 2.9.3 symptom does not reproduce on the hardware that reported it.

So the request is **off unless `SLOWBOOKS_TIMER_RESOLUTION_MS` is set** (`0a078c2`). A permanent 1 ms timer in a background process is a power cost, and it is not imposed on every install for a benefit nobody has measured. The switch and the log line are the instrument for anyone who does see the tick. VonHoltenCodes/SlowBooks-Pro-Testing#53 stays open on that basis rather than closing on a number no box can produce.

### 4b. Two findings from the owner's walkthrough (`0a078c2`)

The bank-import preview pane stayed empty for the whole round trip and the button stayed live, so a second click put a second parse in flight — on a 382-byte file. It says *Reading the file…* first, takes the button away until the answer is back, and the import button does the same. And the file picker's own label listed Chase and PayPal and not Bank of America: the one place a user is choosing a file described a different product than the one shipped.

### 4c. The Import button, handed in rather than found by focus (`addcd2c`)

The one-click guard on **Import N Transactions** found its button through `document.activeElement`. @macbase1 drove the real dialog in a real WKWebView with a real click: WebKit does not focus a button on click, so on macOS the guard never engaged — while the same source read as a pass on Windows. A fix that works on one engine and not the other. The button now arrives from its own `onclick` (`this`), identical on both engines, and a `finally` hands it back after a failed import.

### 5. VonHoltenCodes/SlowBooks-Pro-Testing#52 — one engine and one schema for the whole run

Every test used to build its own engine and `create_all()` into it. Now the schema exists once; each test runs in a transaction on it, every Session joins with `create_savepoint`, and the transaction is rolled back at the end. Two things the first cut got wrong were found by running it: restoring a backup disposes the engine, which on a `:memory:` database *is* deleting the database (it is a file now), and a leak sentinel asserts five tables empty at the start of every test so a commit outside a transaction fails the next test **by name**.

Same machine, same commit, RSS sampled every 5 s from outside the process:

| | old harness | new harness |
|---|---|---|
| RSS at 0 / 25 / 50 / 75 / 100 % of the run | 167 → 344 → 521 → 647 → 731 MB | 209 → 289 → 381 → 474 → 586 MB |
| peak RSS | 795 MB | 606 MB |
| wall | 6:43 | 4:00 |
| passed | 2,199 | 2,199 |

**Shuffled-order run** (`pytest-randomly`, seed `20260912`): 2,199 passed, 2 skipped, 0 failed — no test sees another's data.

**Found on the way, fixed:** anyio 4.12's per-run registry (`anyio.lowlevel._run_vars`) is a `WeakKeyDictionary` keyed by event loop whose value holds the run's root `Task`, which holds the loop — a value that references its own weak key, so the key can never be collected. Every request the test client makes (one loop each, without a context manager) left a closed loop, task, limiter and worker sets behind forever: ~2.3 loops per test, 2,832 by test 1,400. The conftest drops the entries for closed loops after each test; zero retained loops after.

**Not met, said plainly:** the issue's definition of done asks for a flat curve. It is not flat. RSS still climbs about 170 KB per test from a source I have not named — not per-test DDL (gone), not the event loops (gone), not pytest's output capture (a `-s -p no:logging` run climbs the same). Object counts point at plain containers and SQLAlchemy compiler structures. So this **refs VonHoltenCodes/SlowBooks-Pro-Testing#52 rather than closing it**: the harness the issue asked for is in, measured, and proven for isolation; the memory question stays open with the numbers attached.

---

**No schema change.** An existing company file opens with no upgrade step.

Closes VonHoltenCodes/SlowBooks-Pro-2026#149. Refs VonHoltenCodes/SlowBooks-Pro-Testing#53 (instrument ships, off; symptom does not reproduce) and VonHoltenCodes/SlowBooks-Pro-Testing#52 (harness landed; flat-curve criterion not met). Closes VonHoltenCodes/SlowBooks-Pro-2026#130 by carrying its commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DaDm82ccTQi7awPEQrrW3
