### PR TITLE
Fix: QBO OAuth callback always 401s before token exchange (SameSite=Strict cookie dropped on Intuit's redirect)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -647,6 +647,17 @@ _AUTH_EXEMPT_EXACT = {
     "/analytics",  # redirect to SPA hash route
     "/favicon.ico",
     "/api/stripe/webhook",  # legacy alias — Stripe auth via signature
+    # Intuit's OAuth redirect lands the browser back here directly from
+    # accounts.intuit.com — a cross-site top-level navigation, so a
+    # SameSite=Strict session cookie is never attached (browsers withhold
+    # Strict cookies on any cross-site request, no exceptions). Session-
+    # gating this route made every QBO connection attempt dead-end on
+    # {"detail": "Not authenticated"} before qbo_service.handle_callback
+    # ever ran. Safe to exempt: the flow already carries its own CSRF
+    # protection independent of the session — get_auth_url() stores a
+    # random `state` token server-side and handle_callback() rejects any
+    # callback whose `state` doesn't match (see app/services/qbo_service.py).
+    "/api/qbo/callback",
 }
 # Provider payment routes that are public by design:
 #   - webhook: the provider's signature is the authentication

--- a/tests/test_sensitive_route_auth_contract.py
+++ b/tests/test_sensitive_route_auth_contract.py
@@ -35,6 +35,13 @@ _PUBLIC_JUSTIFIED = [
         re.compile(r"^/api/payments/[^/]+/create-checkout-session$"),
         "payment_token capability + rate limit",
     ),
+    (
+        re.compile(r"^/api/qbo/callback$"),
+        "Intuit's OAuth redirect is a cross-site top-level navigation, so a "
+        "SameSite=Strict session cookie is never attached; the route "
+        "carries its own CSRF check instead (handle_callback() rejects any "
+        "`state` that doesn't match the value get_auth_url() stored)",
+    ),
 ]
 
 


### PR DESCRIPTION
﻿See #152 for root cause and repro steps. One-line fix: exempt /api/qbo/callback from the session-auth middleware â€” it already has its own CSRF check via the stored `state` token (qbo_service.py:96-103), same shape as the existing Stripe webhook exemption. Updated the auth-contract test's justified-public allowlist to match. Full auth-contract suite (485 cases) + test_wiring.py pass locally.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)

