### PR TITLE
audit: the walker takes its password from the environment, never a default

### DIFF
--- a/scripts/audit/vocab_walk.py
+++ b/scripts/audit/vocab_walk.py
@@ -11,7 +11,8 @@ still carry a business word in nonprofit mode. A string that reads the
 same in both modes and exists verbatim in the source tree is a code leak;
 one that only exists in the data is a name somebody typed.
 
-    python3 scripts/audit/vocab_walk.py --base http://127.0.0.1:3777 --password neonpulse
+    SLOWBOOKS_QA_PASSWORD=<the scratch company's admin password> \\
+        python3 scripts/audit/vocab_walk.py --base http://127.0.0.1:3777
 
 Read-only by construction: GET routes, the 404 path of parameterised GET
 routes, the two preview endpoints, and PUT /api/settings for company_type
@@ -21,6 +22,7 @@ routes, the two preview endpoints, and PUT /api/settings for company_type
 from __future__ import annotations
 
 import argparse
+import os
 import html
 import http.cookiejar
 import json
@@ -326,12 +328,19 @@ def source_backed(literal: str, files: list[Path]) -> str | None:
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--base", required=True)
-    ap.add_argument("--password", default="neonpulse")
+    ap.add_argument(
+        "--password",
+        default=os.environ.get("SLOWBOOKS_QA_PASSWORD"),
+        help="the scratch company's admin password; prefer SLOWBOOKS_QA_PASSWORD "
+        "in the environment so it never lands in a shell history or a commit",
+    )
     ap.add_argument(
         "--out", type=Path, default=ROOT / "scripts/audit/vocab_walk_report.json"
     )
     args = ap.parse_args()
 
+    if not args.password:
+        ap.error("no password: pass --password or set SLOWBOOKS_QA_PASSWORD")
     c = Client(args.base)
     status, body = c.json("POST", "/api/auth/login", {"password": args.password})
     assert status == 200, f"login: {status} {body}"


### PR DESCRIPTION
Closes the GitGuardian finding on PR #153 (incident 37219235, `scripts/audit/vocab_walk.py`, commit `81606a7`): the example command in the docstring and the `--password` default carried a real password.

`--password` has no default now; `SLOWBOOKS_QA_PASSWORD` in the environment is the documented way to supply it, and the script refuses with a plain message when neither is given. Nothing under `app/` changes; the walker is not in the shipped bundle.

The string stays in git history and in the v2.13.1 tag; history is not rewritten on a public repository with released tags. The owner reviewed the exposure: the QA scratch-company passwords are non-consequential and nothing is being rotated. This PR is hygiene — a default password in a public script is wrong whatever the password is worth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DaDm82ccTQi7awPEQrrW3
